### PR TITLE
fix: add tick label size to standard_tick_styles function

### DIFF
--- a/pyretailscience/style/graph_utils.py
+++ b/pyretailscience/style/graph_utils.py
@@ -248,8 +248,10 @@ def standard_tick_styles(ax: Axes) -> Axes:
     """
     for tick in ax.get_xticklabels():
         tick.set_fontproperties(GraphStyles.POPPINS_REG)
+        tick.set_fontsize(GraphStyles.DEFAULT_TICK_LABEL_FONT_SIZE)
     for tick in ax.get_yticklabels():
         tick.set_fontproperties(GraphStyles.POPPINS_REG)
+        tick.set_fontsize(GraphStyles.DEFAULT_TICK_LABEL_FONT_SIZE)
 
     return ax
 


### PR DESCRIPTION
Fixed issue where standard_tick_styles wasn't setting the font size for tick labels even though DEFAULT_TICK_LABEL_FONT_SIZE was defined in GraphStyles.

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved graph visuals by standardizing the tick label font sizes on both axes, ensuring a uniform and clear display across graphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->