### PR TITLE
remove macros from mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,6 @@ plugins:
   - mkdocstrings
   - autorefs
   - mkdocs-jupyter
-  - macros
 
 markdown_extensions:
   - attr_list


### PR DESCRIPTION
fix: remove macros from mkdocs.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the macros plugin from the documentation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->