### PR TITLE
fix: update the uv sync command

### DIFF
--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Pre-commit in uv environment
         run: uv run pip install pre-commit
       - name: Install Dependencies
-        run: uv sync -G docs
+        run: uv sync --group docs
       - name: Setup Git User
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           pip install build
           pip install uv==0.5.30
       - name: Install Dependencies
-        run: uv sync -G dev
+        run: uv sync --group dev
       - name: Bump Version
         id: set_version
         run: |
@@ -155,7 +155,7 @@ jobs:
           pip install --upgrade pip
           pip install uv==0.5.30
       - name: Install Dependencies
-        run: uv sync -G docs
+        run: uv sync --group docs
       - name: Setup Git User
         run: |
           git config --global user.name "github-actions[bot]"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow commands for installing dependencies to use the long-form `--group` option instead of the shorthand `-G` in GitHub Actions. No functional changes to workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->