### PR TITLE
fix: prevent the version warning in home page

### DIFF
--- a/docs/overrides/partials/outdated.html
+++ b/docs/overrides/partials/outdated.html
@@ -2,7 +2,7 @@
   {% if not page.is_homepage %}
   <div class="md-banner__inner md-typeset">
     <strong>You're viewing an older version of the PyRetailScience documentation.</strong>
-    <a href="{{ base_url }}/latest/">
+    <a href="{{ config.site_url }}/latest/">
       <strong>Click here to go to the latest stable version.</strong>
     </a>
   </div>

--- a/uv.lock
+++ b/uv.lock
@@ -1699,7 +1699,7 @@ wheels = [
 
 [[package]]
 name = "pyretailscience"
-version = "0.17.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the link in the outdated documentation banner to direct users to the latest stable version using the configured site URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->