### PR TITLE
fix:remove cookie banner and solve sitemap issue

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -1,4 +1,8 @@
-{% extends "main.html" %} {% block tabs %} {{ super() }} {% include "partials/outdated.html" %}
+{% extends "main.html" %}
+{% block tabs %}
+{{ super() }}
+{% include "partials/outdated.html" %}
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -233,5 +237,10 @@
     </section>
   </body>
 </html>
-{% endblock %} {% block content %}{% endblock %} {% block footer %} {{ super()
-}} {% endblock %}
+{% endblock %}
+
+{% block content %}{% endblock %}
+
+{% block footer %}
+{{ super() }}
+{% endblock %}

--- a/docs/overrides/partials/outdated.html
+++ b/docs/overrides/partials/outdated.html
@@ -1,10 +1,8 @@
 <div class="md-banner md-banner--warning">
-  {% if not page.is_homepage %}
   <div class="md-banner__inner md-typeset">
     <strong>You're viewing an older version of the PyRetailScience documentation.</strong>
     <a href="https://pyretailscience.datasimply.co/latest/">
       <strong>Click here to go to the latest stable version.</strong>
     </a>
   </div>
-  {% endif %}
 </div>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -7,4 +7,4 @@ Disallow: /examples
 User-agent: *
 Allow: /
 
-Sitemap: https://pyretailscience.datasimply.co/sitemap.xml
+Sitemap: https://pyretailscience.datasimply.co/latest/sitemap.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ plugins:
   - mike:
       version_selector: true
       canonical_version: latest
+      alias_type: copy
 
 markdown_extensions:
   - attr_list
@@ -112,16 +113,6 @@ extra:
   analytics:
     provider: google
     property: G-7S7YSNJ82W
-  consent:
-    actions:
-      - accept
-      - manage
-    title: Cookie consent
-    description: >-
-      We use cookies to recognize your repeated visits and preferences, as well
-      as to measure the effectiveness of our documentation and whether users
-      find what they're searching for. With your consent, you're helping us to
-      make our documentation better.
   scope: "/"
   social:
     - icon: fontawesome/brands/github
@@ -133,5 +124,4 @@ extra:
   generator: true
 
 copyright: |
-  &copy; 2025 <a href="https://datasimply.co"  target="_blank" rel="noopener">Murray Vanwyk</a> -
-  <a href="#__consent">Change cookie settings</a>
+  &copy; 2025 <a href="https://datasimply.co"  target="_blank" rel="noopener">Murray Vanwyk</a>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - The outdated version warning banner is now displayed on all documentation pages, including the homepage.
  - Cookie consent information and related links have been removed from the documentation footer.
  - Minor improvements to template formatting for better readability; no changes to content or logic.
  - Updated sitemap URL in robots.txt to point to the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->