### PR TITLE
feat: add label_by_condition utility for group-level condition labeling

### DIFF
--- a/docs/analysis_modules.md
+++ b/docs/analysis_modules.md
@@ -1455,3 +1455,57 @@ labeled_data = filter_and_label_by_condition(products, conditions).execute()
 | 5          | electronics | 200   | Premium Electronics |
 | 6          | toys        | 35    | Toys                |
 | 7          | shoes       | 60    | Shoes               |
+
+### Label by Condition
+
+<div class="clear" markdown>
+
+The **Label by Condition** module provides functionality to label groups (customers, transactions, stores, etc.) based
+on whether they contain items that meet specified conditions. This module is designed for group-level analysis where you
+want to classify entire entities rather than individual records. Unlike the Filter and Label by Condition function which
+filters and labels individual rows of data, this module aggregates data by groups and applies labels at the group level.
+
+The Label by Condition module allows you to:
+
+- Label groups in a table based on whether items in the group meet a specified condition
+- Support both binary labeling (contains/not_contains) and extended labeling (contains/mixed/not_contains)
+- Customize label names and return column names for flexible analysis
+- Analyze group-level patterns for customer segmentation, product categorization, and promotional analysis
+
+This functionality is particularly useful for:
+
+- Tagging transactions as containing a product, product category, or promotion
+- Tagging customers as having bought a product, product category, or promotion, or store_id
+- Segmenting customers as new, repeating or lapsed
+
+</div>
+
+Example:
+
+```python
+import pandas as pd
+import ibis
+from pyretailscience.utils.label import label_by_condition
+
+# Sample transaction data
+df = pd.DataFrame({
+    "customer_id": [1, 1, 1, 2, 2, 3, 3],
+    "product_category": ["toys", "books", "toys", "books", "clothes", "clothes", "clothes"],
+})
+
+transactions = ibis.memtable(df)
+
+# Binary labeling: Label customers who bought any toys
+toy_customers = label_by_condition(
+    table=transactions,
+    label_col="customer_id",
+    condition=transactions["product_category"] == "toys",
+    labeling_strategy="binary"
+).execute()
+```
+
+| customer_id | label_name   |
+|:------------|-------------:|
+| 1           | contains     |
+| 2           | not_contains |
+| 3           | not_contains |

--- a/docs/api/utils/label.md
+++ b/docs/api/utils/label.md
@@ -1,0 +1,3 @@
+# Label Utils
+
+::: pyretailscience.utils.label

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
           - Date Utils: api/utils/date.md
           - Columns Utils: api/utils/columns.md
           - Filter & Label Utils: api/utils/filter_and_label.md
+          - Label Utils: api/utils/label.md
 
 theme:
   name: material

--- a/pyretailscience/utils/label.py
+++ b/pyretailscience/utils/label.py
@@ -1,0 +1,78 @@
+"""Label Utilities - Labeling by Condition.
+
+This module provides utilities to label groups in an Ibis table based on whether
+any items in the group meet a specified condition. It supports both binary labeling
+(contains/not_contains) and extended labeling (contains/mixed/not_contains).
+
+Example use cases:
+- Tag transactions as containing a product, product category, or promotion
+- Tag customers as containing a product, product category, or promotion, or store_id
+- Tag a transaction as containing promo items, no promo items, or both on/off promo items
+"""
+
+from typing import Literal
+
+import ibis
+from ibis import _
+
+from pyretailscience.options import get_option
+
+
+def label_by_condition(
+    table: ibis.Table,
+    condition: ibis.expr.types.BooleanColumn,
+    label_col: str | None = None,
+    return_col: str = "label_name",
+    labeling_strategy: Literal["binary", "extended"] = "binary",
+    contains_label: str | ibis.expr.types.Value = "contains",
+    not_contains_label: str | ibis.expr.types.Value = "not_contains",
+    mixed_label: str | ibis.expr.types.Value = "mixed",
+) -> ibis.Table:
+    """Labels groups in a table based on whether items in the group meet a condition.
+
+    This function groups a table by the specified label column and determines whether
+    any items in each group meet the given condition. It supports two labeling strategies:
+    - "binary": Labels groups as either "contains" or "not_contains" based on whether
+      any item in the group meets the condition
+    - "extended": Labels groups as "contains" (all items meet condition), "mixed"
+      (some items meet condition), or "not_contains" (no items meet condition)
+
+    Args:
+        table (ibis.Table): An ibis table to process.
+        condition (ibis.expr.types.BooleanColumn): Boolean expression representing
+            the condition to evaluate.
+        label_col (str): Column name to group by for labeling. Defaults to the setting column.customer_id
+        return_col (str): Name of the column to add with the labels. Defaults to "label_name".
+        labeling_strategy (Literal["binary", "extended"]): Strategy for labeling groups.
+            Defaults to "binary".
+        contains_label (str | ibis.expr.types.Value): Label for groups that contain
+            items meeting the condition. Defaults to "contains".
+        not_contains_label (str | ibis.expr.types.Value): Label for groups that do not
+            contain items meeting the condition. Defaults to "not_contains".
+        mixed_label (str | ibis.expr.types.Value): Label for groups with mixed results
+            (only used with "extended" strategy). Defaults to "mixed".
+
+    Returns:
+        ibis.Table: An ibis table grouped by label_col with an added label column.
+    """
+    if label_col is None:
+        label_col = get_option("column.customer_id")
+
+    table = table.mutate(label_condition=condition.ifelse(1, 0)).group_by(label_col)
+
+    if labeling_strategy == "binary":
+        return table.aggregate(
+            {
+                return_col: (_.label_condition.max() == 1).ifelse(contains_label, not_contains_label),
+            },
+        )
+
+    return table.aggregate(
+        {
+            return_col: ibis.cases(
+                ((_.label_condition.max() == 1) & (_.label_condition.min() == 1), contains_label),
+                ((_.label_condition.max() == 1) & (_.label_condition.min() == 0), mixed_label),
+                else_=not_contains_label,
+            ),
+        },
+    )

--- a/tests/utils/test_label.py
+++ b/tests/utils/test_label.py
@@ -1,0 +1,174 @@
+"""Tests for the label module."""
+
+import ibis
+import pandas as pd
+import pytest
+
+from pyretailscience.utils.label import label_by_condition
+
+
+class TestLabelByCondition:
+    """Test class for label_by_condition function."""
+
+    def test_binary_strategy_basic(self):
+        """Test binary labeling strategy with basic data."""
+        df = pd.DataFrame(
+            {
+                "customer_id": [1, 1, 1, 2, 2, 3, 3],
+                "product_category": ["toys", "books", "toys", "books", "clothes", "clothes", "clothes"],
+            },
+        )
+        table = ibis.memtable(df)
+
+        result = label_by_condition(
+            table=table,
+            label_col="customer_id",
+            condition=table["product_category"] == "toys",
+            labeling_strategy="binary",
+        )
+
+        expected_df = pd.DataFrame(
+            {
+                "customer_id": [1, 2, 3],
+                "label_name": ["contains", "not_contains", "not_contains"],
+            },
+        )
+
+        result_df = result.execute().sort_values("customer_id").reset_index(drop=True)
+        expected_df = expected_df.sort_values("customer_id")
+
+        assert result_df.equals(expected_df)
+
+    def test_extended_strategy_all_scenarios(self):
+        """Test extended labeling strategy with all possible scenarios."""
+        df = pd.DataFrame(
+            {
+                "transaction_id": [1, 1, 1, 2, 2, 3, 3, 4],
+                "on_promotion": [True, True, True, True, False, False, False, True],
+            },
+        )
+        table = ibis.memtable(df)
+
+        result = label_by_condition(
+            table=table,
+            label_col="transaction_id",
+            condition=table["on_promotion"],
+            labeling_strategy="extended",
+        )
+
+        expected_df = pd.DataFrame(
+            {
+                "transaction_id": [1, 2, 3, 4],
+                "label_name": ["contains", "mixed", "not_contains", "contains"],
+            },
+        )
+
+        result_df = result.execute().sort_values("transaction_id").reset_index(drop=True)
+        expected_df = expected_df.sort_values("transaction_id").reset_index(drop=True)
+
+        assert result_df.equals(expected_df)
+
+    @pytest.mark.parametrize(
+        ("strategy", "expected_labels"),
+        [
+            ("binary", ["contains", "contains", "not_contains"]),
+            ("extended", ["contains", "mixed", "not_contains"]),
+        ],
+    )
+    def test_labeling_strategies_comparison(self, strategy, expected_labels):
+        """Test both labeling strategies with the same data."""
+        df = pd.DataFrame(
+            {
+                "group_id": [1, 1, 2, 2, 3, 3],
+                "has_condition": [True, True, True, False, False, False],
+            },
+        )
+        table = ibis.memtable(df)
+
+        result = label_by_condition(
+            table=table,
+            label_col="group_id",
+            condition=table["has_condition"],
+            labeling_strategy=strategy,
+        )
+
+        expected_df = pd.DataFrame(
+            {
+                "group_id": [1, 2, 3],
+                "label_name": expected_labels,
+            },
+        )
+
+        result_df = result.execute().sort_values("group_id").reset_index(drop=True)
+        expected_df = expected_df.sort_values("group_id").reset_index(drop=True)
+
+        assert result_df.equals(expected_df)
+
+    def test_custom_labels_and_column_names(self):
+        """Test custom label names and return column name."""
+        df = pd.DataFrame(
+            {
+                "store_id": [1, 1, 2, 2],
+                "high_value": [True, False, False, False],
+            },
+        )
+        table = ibis.memtable(df)
+
+        result = label_by_condition(
+            table=table,
+            label_col="store_id",
+            condition=table["high_value"],
+            return_col="value_segment",
+            labeling_strategy="extended",
+            contains_label="all_high_value",
+            not_contains_label="no_high_value",
+            mixed_label="some_high_value",
+        )
+
+        expected_df = pd.DataFrame(
+            {
+                "store_id": [1, 2],
+                "value_segment": ["some_high_value", "no_high_value"],
+            },
+        )
+
+        result_df = result.execute().sort_values("store_id").reset_index(drop=True)
+        expected_df = expected_df.sort_values("store_id").reset_index(drop=True)
+
+        assert result_df.equals(expected_df)
+
+    @pytest.mark.parametrize(
+        ("condition_values", "expected_label"),
+        [
+            ([True, True, True], "contains"),
+            ([False, False, False], "not_contains"),
+        ],
+    )
+    def test_single_group_uniform_conditions(self, condition_values, expected_label):
+        """Test single group where all items have the same condition value."""
+        df = pd.DataFrame(
+            {
+                "customer_id": [1, 1, 1],
+                "premium_product": condition_values,
+            },
+        )
+        table = ibis.memtable(df)
+
+        result = label_by_condition(
+            table=table,
+            label_col="customer_id",
+            condition=table["premium_product"],
+            labeling_strategy="extended",
+        )
+
+        expected_df = pd.DataFrame(
+            {
+                "customer_id": [1],
+                "label_name": [expected_label],
+            },
+        )
+
+        result_df = result.execute().sort_values("customer_id").reset_index(drop=True)
+        expected_df = expected_df.sort_values("customer_id").reset_index(drop=True)
+
+        assert result_df.equals(expected_df)


### PR DESCRIPTION
## Summary

- Add new `utils.label` module with `label_by_condition` function for group-level condition labeling
- Support both binary (contains/not_contains) and extended (contains/mixed/not_contains) labeling strategies
- Include comprehensive documentation and API reference
- Add complete test suite with multiple scenarios

## Key Features

- **Binary Strategy**: Labels groups as "contains" or "not_contains" based on whether any item meets the condition
- **Extended Strategy**: Labels groups as "contains" (all items), "mixed" (some items), or "not_contains" (no items)
- **Customizable**: Custom label names, return column names, and grouping columns
- **Retail Analytics**: Designed for customer segmentation, product categorization, and promotional analysis

## Files Added

- `pyretailscience/utils/label.py` - Core module with label_by_condition function
- `tests/utils/test_label.py` - Comprehensive test suite with 7 test methods
- `docs/api/utils/label.md` - API documentation
- Updated `docs/analysis_modules.md` with practical examples
- Updated `mkdocs.yml` navigation

🤖 Generated with [Claude Code](https://claude.ai/code)