### PR TITLE
fix: remove the truncated_svd paramater from cdh

### DIFF
--- a/tests/analysis/test_customer_decision_hierarchy.py
+++ b/tests/analysis/test_customer_decision_hierarchy.py
@@ -59,10 +59,9 @@ class TestCustomerDecisionHierarchy:
             {cols.customer_id: [1, 2, 3], cols.transaction_id: [1, 2, 3], "product_name": ["A", "B", "C"]},
         )
         exclude_same_transaction_products = True
-        random_state = 42
 
         with pytest.raises(ValueError):
-            rp.CustomerDecisionHierarchy(df, exclude_same_transaction_products, random_state)
+            rp.CustomerDecisionHierarchy(df, "invalid_product_col", exclude_same_transaction_products)
 
     def test_init_exclude_same_transaction_products_true(self):
         """Test that the function returns the correct pairs dataframe when exclude_same_transaction_products is True."""

--- a/tests/integration/bigquery/test_customer_decision_hierarchy.py
+++ b/tests/integration/bigquery/test_customer_decision_hierarchy.py
@@ -8,8 +8,6 @@ from pyretailscience.analysis.customer_decision_hierarchy import CustomerDecisio
 @pytest.mark.parametrize(
     ("method", "exclude_same_transaction"),
     [
-        ("truncated_svd", False),
-        ("truncated_svd", None),
         ("yules_q", False),
         ("yules_q", None),
     ],

--- a/uv.lock
+++ b/uv.lock
@@ -1993,7 +1993,7 @@ wheels = [
 
 [[package]]
 name = "pyretailscience"
-version = "0.36.0"
+version = "0.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified distance configuration to only support Yule’s Q; removed the truncated SVD option and the related variance parameter.
  - Updated the constructor signature to require a product column and adjusted parameter order.

- Tests
  - Updated unit tests to match the new constructor signature and validation behavior.
  - Adjusted integration tests to remove truncated SVD scenarios; now parameterized only for Yule’s Q across supported combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->