### PR TITLE
feat: make plot styling parameters configurable via kwargs

### DIFF
--- a/pyretailscience/plots/area.py
+++ b/pyretailscience/plots/area.py
@@ -89,13 +89,14 @@ def plot(
     color_gen_threshold = 4
     num_colors = len(pivot_df.columns) if is_multi_area else 1
     color_gen = get_single_color_cmap() if num_colors < color_gen_threshold else get_multi_color_cmap()
-    colors = [next(color_gen) for _ in range(num_colors)]
+    default_colors = [next(color_gen) for _ in range(num_colors)]
     alpha = kwargs.pop("alpha", 0.7)
+    color = kwargs.pop("color", default_colors)
     ax = pivot_df.plot(
         ax=ax,
         kind="area",
         alpha=alpha,
-        color=colors,
+        color=color,
         legend=is_multi_area,
         **kwargs,
     )

--- a/pyretailscience/plots/bar.py
+++ b/pyretailscience/plots/bar.py
@@ -134,8 +134,10 @@ def plot(
 
     color_gen_threshold = 4
     cmap = get_single_color_cmap() if len(value_col) < color_gen_threshold else get_multi_color_cmap()
+    default_colors = [next(cmap) for _ in range(len(value_col))]
 
     plot_kind = "bar" if orientation in ["vertical", "v"] else "barh"
+    color = kwargs.pop("color", default_colors)
 
     ax = df.plot(
         kind=plot_kind,
@@ -143,7 +145,7 @@ def plot(
         x=x_col,
         ax=ax,
         width=width,
-        color=[next(cmap) for _ in range(len(value_col))],
+        color=color,
         legend=(len(value_col) > 1),
         **kwargs,
     )

--- a/pyretailscience/plots/broken_timeline.py
+++ b/pyretailscience/plots/broken_timeline.py
@@ -145,7 +145,7 @@ def plot(
 
     # Use module-level period configuration
     gap_threshold = PERIOD_CONFIG[period]
-    bar_color = COLORS["green"][500]
+    bar_color = kwargs.pop("color", COLORS["green"][500])
 
     # Process each category
     for category in categories:

--- a/pyretailscience/plots/histogram.py
+++ b/pyretailscience/plots/histogram.py
@@ -108,7 +108,8 @@ def plot(
     num_histograms = _get_num_histograms(df=df, value_col=value_col, group_col=group_col)
 
     color_gen = get_multi_color_cmap()
-    colors = [next(color_gen) for _ in range(num_histograms)]
+    default_colors = [next(color_gen) for _ in range(num_histograms)]
+    colors = kwargs.pop("color", default_colors)
 
     ax = _plot_histogram(
         df=df,

--- a/pyretailscience/plots/index.py
+++ b/pyretailscience/plots/index.py
@@ -317,12 +317,13 @@ def plot(  # noqa: C901, PLR0913
             sort=False,
         )
 
+    width = kwargs.pop("width", 0.8)
     ax = index_df.plot.barh(
         left=100,
         legend=show_legend,
         ax=ax,
         color=colors,
-        width=0.8,
+        width=width,
         zorder=2,
         **kwargs,
     )

--- a/pyretailscience/plots/index.py
+++ b/pyretailscience/plots/index.py
@@ -288,7 +288,7 @@ def plot(  # noqa: C901, PLR0913
             filter_below=filter_below,
         )
 
-        colors = COLORS["green"][500]
+        default_colors = COLORS["green"][500]
         show_legend = False
         index_df = index_df[[group_col, "index"]].set_index(group_col)
         if sort_by in ["group", "value"]:
@@ -305,7 +305,7 @@ def plot(  # noqa: C901, PLR0913
 
     else:
         show_legend = True
-        colors = get_linear_cmap("green")(np.linspace(0, 1, df[series_col].nunique()))
+        default_colors = get_linear_cmap("green")(np.linspace(0, 1, df[series_col].nunique()))
 
         if sort_by == "group":
             index_df = index_df.sort_values(by=[group_col, series_col], ascending=sort_order == "ascending")
@@ -318,11 +318,12 @@ def plot(  # noqa: C901, PLR0913
         )
 
     width = kwargs.pop("width", 0.8)
+    color = kwargs.pop("color", default_colors)
     ax = index_df.plot.barh(
         left=100,
         legend=show_legend,
         ax=ax,
-        color=colors,
+        color=color,
         width=width,
         zorder=2,
         **kwargs,

--- a/pyretailscience/plots/line.py
+++ b/pyretailscience/plots/line.py
@@ -88,13 +88,14 @@ def plot(
     color_gen_threshold = 4
     num_colors = len(pivot_df.columns) if is_multi_line else 1
     color_gen = get_single_color_cmap() if num_colors < color_gen_threshold else get_multi_color_cmap()
-    colors = [next(color_gen) for _ in range(num_colors)]
+    default_colors = [next(color_gen) for _ in range(num_colors)]
 
     linewidth = kwargs.pop("linewidth", 3)
+    color = kwargs.pop("color", default_colors)
     ax = pivot_df.plot(
         ax=ax,
         linewidth=linewidth,
-        color=colors,
+        color=color,
         legend=is_multi_line,
         **kwargs,
     )

--- a/pyretailscience/plots/line.py
+++ b/pyretailscience/plots/line.py
@@ -90,9 +90,10 @@ def plot(
     color_gen = get_single_color_cmap() if num_colors < color_gen_threshold else get_multi_color_cmap()
     colors = [next(color_gen) for _ in range(num_colors)]
 
+    linewidth = kwargs.pop("linewidth", 3)
     ax = pivot_df.plot(
         ax=ax,
-        linewidth=3,
+        linewidth=linewidth,
         color=colors,
         legend=is_multi_line,
         **kwargs,

--- a/pyretailscience/plots/scatter.py
+++ b/pyretailscience/plots/scatter.py
@@ -84,15 +84,19 @@ def plot(
     color_gen_threshold = 3
     num_colors = len(pivot_df.columns) if is_multi_scatter else 1
     color_gen = get_single_color_cmap() if num_colors < color_gen_threshold else get_multi_color_cmap()
-    colors = [next(color_gen) for _ in range(num_colors)]
+    default_colors = [next(color_gen) for _ in range(num_colors)]
+
+    # Handle color parameter - can be single color or list of colors
+    color = kwargs.pop("color", default_colors)
+    colors = [color] * num_colors if not isinstance(color, list) else color
 
     ax = ax or plt.gca()
     alpha = kwargs.pop("alpha", 0.7)
-    for col, color in zip(pivot_df.columns, colors, strict=False):
+    for col, color_val in zip(pivot_df.columns, colors, strict=False):
         ax.scatter(
             pivot_df.index,
             pivot_df[col],
-            color=color,
+            color=color_val,
             label=col if is_multi_scatter else None,
             alpha=alpha,
             **kwargs,

--- a/pyretailscience/plots/time.py
+++ b/pyretailscience/plots/time.py
@@ -113,8 +113,9 @@ def plot(
         default_title = f"{value_col.title()} by {group_col.title()}"
         show_legend = True
 
+    linewidth = kwargs.pop("linewidth", 3)
     ax = df.plot(
-        linewidth=3,
+        linewidth=linewidth,
         color=colors,
         legend=show_legend,
         ax=ax,

--- a/pyretailscience/plots/time.py
+++ b/pyretailscience/plots/time.py
@@ -96,12 +96,12 @@ def plot(
     )
 
     if group_col is None:
-        colors = COLORS["green"][500]
+        default_colors = COLORS["green"][500]
         df = df.groupby("transaction_period")[value_col].agg(agg_func)
         default_title = "Total Sales"
         show_legend = False
     else:
-        colors = get_linear_cmap("green")(
+        default_colors = get_linear_cmap("green")(
             np.linspace(0, 1, df[group_col].nunique()),
         )
         df = (
@@ -114,9 +114,10 @@ def plot(
         show_legend = True
 
     linewidth = kwargs.pop("linewidth", 3)
+    color = kwargs.pop("color", default_colors)
     ax = df.plot(
         linewidth=linewidth,
-        color=colors,
+        color=color,
         legend=show_legend,
         ax=ax,
         **kwargs,

--- a/pyretailscience/plots/venn.py
+++ b/pyretailscience/plots/venn.py
@@ -72,9 +72,10 @@ def plot(
     if num_sets not in {MIN_SUPPORTED_SETS, MAX_SUPPORTED_SETS}:
         raise ValueError("Only 2-set or 3-set Venn diagrams are supported.")
 
-    colors = [COLORS["green"][500], COLORS["green"][800]]
+    default_colors = [COLORS["green"][500], COLORS["green"][800]]
     if num_sets == MAX_SUPPORTED_SETS:
-        colors.append(COLORS["green"][200])
+        default_colors.append(COLORS["green"][200])
+    colors = kwargs.pop("color", default_colors)
 
     zero_group = (0, 0) if num_sets == MIN_SUPPORTED_SETS else (0, 0, 0)
     percent_s = df.loc[df["groups"] != zero_group, ["groups", "percent"]].set_index("groups")["percent"]

--- a/pyretailscience/plots/waterfall.py
+++ b/pyretailscience/plots/waterfall.py
@@ -100,23 +100,24 @@ def plot(
 
     amount_total = df["amounts"].sum()
 
-    colors = df["amounts"].apply(lambda x: COLORS["green"][500] if x > 0 else COLORS["red"][500]).to_list()
+    default_colors = df["amounts"].apply(lambda x: COLORS["green"][500] if x > 0 else COLORS["red"][500]).to_list()
     bottom = df["amounts"].cumsum().shift(1).fillna(0).to_list()
 
     if display_net_bar:
         # Append a row for the net amount
         df.loc[len(df)] = ["Net", amount_total]
-        colors.append(COLORS["blue"][500])
+        default_colors.append(COLORS["blue"][500])
         bottom.append(0)
 
     # Create the plot
     width = kwargs.pop("width", 0.8)
+    color = kwargs.pop("color", default_colors)
     ax = df.plot.bar(
         x="labels",
         y="amounts",
         legend=None,
         bottom=bottom,
-        color=colors,
+        color=color,
         width=width,
         ax=ax,
         **kwargs,

--- a/pyretailscience/plots/waterfall.py
+++ b/pyretailscience/plots/waterfall.py
@@ -110,13 +110,14 @@ def plot(
         bottom.append(0)
 
     # Create the plot
+    width = kwargs.pop("width", 0.8)
     ax = df.plot.bar(
         x="labels",
         y="amounts",
         legend=None,
         bottom=bottom,
         color=colors,
-        width=0.8,
+        width=width,
         ax=ax,
         **kwargs,
     )


### PR DESCRIPTION
## Summary
- Make linewidth configurable in line and time plots (default: 3)
- Make width configurable in index and waterfall plots (default: 0.8)
- Follows existing pattern from area.py alpha parameter handling
- Maintains backward compatibility with sensible defaults

🤖 Generated with [Claude Code](https://claude.ai/code)