### PR TITLE
feat: add bar chart support to add_regression_line and fix subplot compatibility

### DIFF
--- a/pyretailscience/plots/styles/graph_utils.py
+++ b/pyretailscience/plots/styles/graph_utils.py
@@ -406,7 +406,12 @@ def _extract_plot_data(ax: Axes) -> tuple[np.ndarray, np.ndarray]:
     if len(lines) > 0:
         x_data = lines[0].get_xdata()
         y_data = lines[0].get_ydata()
-    # If no lines, check for scatter plots (or other collections)
+    # Check for bar charts (patches)
+    elif hasattr(ax, "patches") and ax.patches:
+        # Extract data from bar patches
+        x_data = np.array([patch.get_x() + patch.get_width() / 2 for patch in ax.patches])
+        y_data = np.array([patch.get_height() for patch in ax.patches])
+    # If no lines or bars, check for scatter plots (or other collections)
     elif hasattr(ax, "collections") and ax.collections:
         # Extract data from the first collection (e.g., scatter plot)
         collection = ax.collections[0]
@@ -524,8 +529,7 @@ def add_regression_line(
     y_max = intercept + slope * max(x_numeric)
 
     # Plot the regression line
-    x_min, x_max = ax.get_xlim()
-    ax.plot([x_min, x_max], [y_min, y_max], color=color, linestyle=linestyle, **kwargs)
+    ax.plot([min(x_numeric), max(x_numeric)], [y_min, y_max], color=color, linestyle=linestyle, **kwargs)
 
     # Add equation and R² text if requested
     _add_equation_text(ax, slope, intercept, r_squared, color, text_position, show_equation, show_r2)

--- a/tests/plots/styles/test_graph_utils.py
+++ b/tests/plots/styles/test_graph_utils.py
@@ -284,6 +284,20 @@ class TestRegressionLine:
         # Check that a line was added
         assert len(ax.get_lines()) == self.EXPECTED_LINE_COUNT_AFTER_REGRESSION
 
+    def test_bar_plot(self):
+        """Test regression line with a bar chart."""
+        _, ax = plt.subplots()
+        x = np.array([1, 2, 3, 4, 5])
+        y = np.array([2, 4, 3, 5, 6])
+        ax.bar(x, y)
+
+        gu.add_regression_line(ax, color="orange", show_equation=True, show_r2=True)
+
+        # Check that a regression line was added (bar plots start with 0 lines)
+        assert len(ax.get_lines()) == 1
+        # Check that we still have the bar patches
+        assert len(ax.patches) == len(x)
+
     def test_single_data_point(self):
         """Test that regression line raises ValueError with a single data point."""
         _, ax = plt.subplots()


### PR DESCRIPTION
## Summary
- Fixed regression line x-coordinates to use actual data range instead of axis limits, resolving subplot compatibility issues
- Added support for bar charts in `add_regression_line` by extracting data from bar patches
- Added comprehensive test coverage for bar chart regression functionality

## Changes
- `pyretailscience/plots/styles/graph_utils.py`: Modified `_extract_plot_data` to handle bar charts and fixed regression line plotting
- `tests/plots/styles/test_graph_utils.py`: Added `test_bar_plot` to verify bar chart regression functionality

🤖 Generated with [Claude Code](https://claude.ai/code)