### PR TITLE
feat: add configurable period column name to filter_and_label_by_periods

### DIFF
--- a/pyretailscience/utils/date.py
+++ b/pyretailscience/utils/date.py
@@ -61,6 +61,7 @@ def _validate_and_normalize_periods(
 def filter_and_label_by_periods(
     transactions: ibis.Table,
     period_ranges: dict[str, tuple[datetime, datetime] | tuple[str, str]],
+    period_col: str = "period_name",
 ) -> ibis.Table:
     """Filters transactions to specified time periods and adds period labels.
 
@@ -81,9 +82,10 @@ def filter_and_label_by_periods(
         transactions (ibis.Table): An ibis table with a transaction_date column.
         period_ranges (dict[str, tuple[datetime, datetime] | tuple[str, str]]): Dict where keys are period names and
             values are(start_date, end_date) tuples.
+        period_col (str): Name of the column to create for period labels. Defaults to "period_name".
 
     Returns:
-        An ibis table with filtered transactions and added period_name column.
+        An ibis table with filtered transactions and added period label column.
 
     Raises:
         ValueError: If any value in period_ranges is not a tuple of length 2.
@@ -108,7 +110,7 @@ def filter_and_label_by_periods(
         branches.append((period_condition, ibis.literal(period_name)))
 
     conditions = ibis.or_(*[condition[0] for condition in branches])
-    return transactions.filter(conditions).mutate(period_name=ibis.cases(*branches))
+    return transactions.filter(conditions).mutate(**{period_col: ibis.cases(*branches)})
 
 
 def find_overlapping_periods(

--- a/tests/utils/test_date.py
+++ b/tests/utils/test_date.py
@@ -268,6 +268,33 @@ class TestFilterAndLabelByPeriods:
             assert isinstance(result_df, pd.DataFrame)
             assert "my_date_col" in result_df.columns
 
+    def test_custom_period_column_name(self, sample_transactions_table):
+        """Test filter_and_label_by_periods with a custom period column name."""
+        # Define expected transaction counts
+        q1_count = 2
+        q2_count = 2
+
+        period_ranges = {
+            "Q1": ("2023-01-01", "2023-03-31"),
+            "Q2": ("2023-04-01", "2023-06-30"),
+        }
+
+        # Test with custom column name
+        result = filter_and_label_by_periods(sample_transactions_table, period_ranges, period_col="quarter")
+        result_df = result.execute()
+
+        # Verify the custom column exists
+        assert "quarter" in result_df.columns, "Custom period column 'quarter' should exist"
+        assert "period_name" not in result_df.columns, "Default 'period_name' column should not exist"
+
+        # Verify the values are correct
+        assert len(result_df) == q1_count + q2_count, f"Should return {q1_count + q2_count} transactions from Q1 and Q2"
+        q1_transactions = result_df[result_df["quarter"] == "Q1"]
+        q2_transactions = result_df[result_df["quarter"] == "Q2"]
+
+        assert len(q1_transactions) == q1_count, f"Should have {q1_count} transactions in Q1"
+        assert len(q2_transactions) == q2_count, f"Should have {q2_count} transactions in Q2"
+
 
 class TestFindOverlappingPeriods:
     """Test cases for the find_overlapping_periods function."""


### PR DESCRIPTION
## Summary
- Added `period_col` parameter to `filter_and_label_by_periods` function to allow users to specify a custom column name for period labels
- Parameter defaults to `"period_name"` to maintain backward compatibility
- Follows package naming conventions using the `_col` suffix (consistent with `value_col`, `group_col`, etc.)

## Changes
- Added `period_col` parameter to function signature in [date.py:64](pyretailscience/utils/date.py#L64)
- Updated function implementation to use dynamic column naming with dictionary unpacking in [date.py:113](pyretailscience/utils/date.py#L113)
- Updated docstring with new parameter documentation in [date.py:85](pyretailscience/utils/date.py#L85)
- Added comprehensive test case `test_custom_period_column_name` to verify functionality in [test_date.py:271-296](tests/utils/test_date.py#L271-L296)

🤖 Generated with [Claude Code](https://claude.com/claude-code)