### PR TITLE
feat: add configurable label column name to filter_and_label_by_condition

### DIFF
--- a/pyretailscience/utils/filter_and_label.py
+++ b/pyretailscience/utils/filter_and_label.py
@@ -17,6 +17,7 @@ import ibis
 def filter_and_label_by_condition(
     table: ibis.Table,
     conditions: dict[str, ibis.expr.types.BooleanColumn],
+    label_col: str = "label",
 ) -> ibis.Table:
     """Filters a table based on specified conditions and adds labels.
 
@@ -40,6 +41,7 @@ def filter_and_label_by_condition(
         table (ibis.Table): An ibis table to filter.
         conditions (dict[str, ibis.expr.types.BooleanColumn]): Dict where keys are labels and
             values are ibis boolean expressions representing filter conditions.
+        label_col (str): Name of the label column to add. Defaults to "label".
 
     Returns:
         ibis.Table: An ibis table with filtered rows and an added label column.
@@ -47,4 +49,4 @@ def filter_and_label_by_condition(
     branches = [(condition, ibis.literal(label)) for label, condition in conditions.items()]
     combined_condition = ibis.or_(*[condition for condition, _ in branches])
 
-    return table.filter(combined_condition).mutate(label=ibis.cases(*branches))
+    return table.filter(combined_condition).mutate(**{label_col: ibis.cases(*branches)})

--- a/tests/utils/test_filter_and_label.py
+++ b/tests/utils/test_filter_and_label.py
@@ -7,7 +7,7 @@ from pyretailscience.utils.filter_and_label import filter_and_label_by_condition
 
 
 def test_filter_and_label_by_condition():
-    """Test cases for filtering and labeling by condition."""
+    """Test cases for filtering and labeling by condition with default label column."""
     df = pd.DataFrame(
         {
             "product_id": [1, 2, 3, 4],
@@ -32,11 +32,40 @@ def test_filter_and_label_by_condition():
         },
     )
 
-    assert (
-        result.execute()
-        .sort_values("product_id")
-        .reset_index(drop=True)
-        .equals(
-            expected_df.sort_values("product_id").reset_index(drop=True),
-        )
+    pd.testing.assert_frame_equal(
+        result.execute().sort_values("product_id").reset_index(drop=True),
+        expected_df.sort_values("product_id").reset_index(drop=True),
+    )
+
+
+def test_filter_and_label_by_condition_custom_column():
+    """Test filtering and labeling with a custom label column name."""
+    df = pd.DataFrame(
+        {
+            "product_id": [1, 2, 3, 4],
+            "category": ["toys", "shoes", "toys", "books"],
+        },
+    )
+    table = ibis.memtable(df)
+
+    result = filter_and_label_by_condition(
+        table,
+        {
+            "toys": table["category"] == "toys",
+            "shoes": table["category"] == "shoes",
+        },
+        label_col="product_type",
+    )
+
+    expected_df = pd.DataFrame(
+        {
+            "product_id": [1, 2, 3],
+            "category": ["toys", "shoes", "toys"],
+            "product_type": ["toys", "shoes", "toys"],
+        },
+    )
+
+    pd.testing.assert_frame_equal(
+        result.execute().sort_values("product_id").reset_index(drop=True),
+        expected_df.sort_values("product_id").reset_index(drop=True),
     )


### PR DESCRIPTION
## Summary

- Added `label_col` parameter to `filter_and_label_by_condition` function to allow custom label column names
- Defaults to "label" for backward compatibility
- Updated tests to verify both default and custom column name behavior
- Improved test assertions to use `pd.testing.assert_frame_equal` for better error messages

## Changes

- Modified [filter_and_label.py](pyretailscience/utils/filter_and_label.py#L20) to accept `label_col` parameter
- Updated function implementation to use dynamic column naming with `mutate(**{label_col: ...})`
- Added test case for custom column name in [test_filter_and_label.py](tests/utils/test_filter_and_label.py#L41)
- Updated existing test docstring and assertion method

🤖 Generated with [Claude Code](https://claude.com/claude-code)