### PR TITLE
feat: allow legend kwarg override in bar plot

### DIFF
--- a/pyretailscience/plots/bar.py
+++ b/pyretailscience/plots/bar.py
@@ -138,6 +138,7 @@ def plot(
 
     plot_kind = "bar" if orientation in ["vertical", "v"] else "barh"
     color = kwargs.pop("color", default_colors)
+    legend = kwargs.pop("legend", (len(value_col) > 1))
 
     ax = df.plot(
         kind=plot_kind,
@@ -146,7 +147,7 @@ def plot(
         ax=ax,
         width=width,
         color=color,
-        legend=(len(value_col) > 1),
+        legend=legend,
         **kwargs,
     )
 


### PR DESCRIPTION
## Summary

- Added ability for users to override the legend parameter via kwargs in `bar.plot()`
- The legend now defaults to `(len(value_col) > 1)` but can be explicitly set via kwargs by passing `legend=True` or `legend=False`
- Maintains backward compatibility with existing behavior

## Changes

- `pyretailscience/plots/bar.py:141` - Extract legend parameter from kwargs with default value
- `pyretailscience/plots/bar.py:150` - Use the extracted legend variable in df.plot() call
