### PR TITLE
feat(segmentation): add SQL ROLLUP mode for grouping sets

### DIFF
--- a/pyretailscience/segmentation/segstats.py
+++ b/pyretailscience/segmentation/segstats.py
@@ -93,6 +93,7 @@ class SegTransactionStats:
                 Defaults to "segment_name".
             calc_total (bool | None, optional): Whether to include the total row. Defaults to True if grouping_sets is
                 None. Cannot be used with grouping_sets parameter.
+                Note: This parameter is planned for deprecation. Use grouping_sets parameter for new code.
             extra_aggs (dict[str, tuple[str, str]], optional): Additional aggregations to perform.
                 The keys in the dictionary will be the column names for the aggregation results.
                 The values are tuples with (column_name, aggregation_function), where:
@@ -105,9 +106,11 @@ class SegTransactionStats:
                 - Prefix rollups: progressively aggregating left-to-right (e.g., [A, B, Total], [A, Total, Total]).
                 - Suffix rollups: progressively aggregating right-to-left (e.g., [Total, B, C], [Total, Total, C]).
                 A grand total row is also included when calc_total is True.
+                Note: This differs from grouping_sets='rollup' which generates only prefix rollups (SQL standard).
                 Performance: adds O(n) extra aggregation passes where n is the number of segment
                 columns. For large hierarchies, consider disabling rollups or reducing columns.
                 Cannot be used with grouping_sets parameter.
+                Note: This parameter is planned for deprecation. Use grouping_sets parameter for new code.
             rollup_value (Any | list[Any], optional): The value to use for rollup totals. Can be a single value
                 applied to all columns or a list of values matching the length of segment_col, with each value
                 cast to match the corresponding column type. Defaults to "Total".


### PR DESCRIPTION
## Summary

Implements SQL-style ROLLUP mode for the `SegTransactionStats` class, enabling hierarchical aggregation from right to left. This is the first step in adding full GROUPING SETS support to PyRetailScience.

## Changes

### New Features
- ✅ Add `grouping_sets` parameter supporting `"rollup"` mode
- ✅ Change `calc_total` and `calc_rollup` to accept `bool | None` for cleaner API
- ✅ Mutual exclusivity validation between new and legacy parameters

### Implementation Details
- Add `_validate_grouping_sets_params()` static method for parameter validation
- Add `_validate_extra_aggs()` static method (reduces `__init__` cyclomatic complexity)
- Update `_generate_grouping_sets()` to handle ROLLUP mode generation
- Update `_calc_seg_stats()` signature to accept `grouping_sets` parameter
- Comprehensive docstrings with examples and migration guidance

### Testing
- ✅ 10 new comprehensive tests for ROLLUP mode
- ✅ All 39 existing tests pass (backward compatibility maintained)
- ✅ Tests cover: hierarchical generation, validation, edge cases, and integration

### Code Quality
- ✅ All linting checks pass
- ✅ Cyclomatic complexity reduced by extracting validation helper
- ✅ 100% backward compatible

## Example Usage

**New ROLLUP mode:**
```python
stats = SegTransactionStats(
    data=df,
    segment_col=["region", "store", "product"],
    grouping_sets="rollup",
)
```

Generates hierarchical aggregations (SQL ROLLUP):
- `[region, store, product]` - full detail
- `[region, store]` - regional store totals
- `[region]` - regional totals
- `[]` - grand total

**Legacy mode (still works):**
```python
stats = SegTransactionStats(
    data=df,
    segment_col=["region", "store"],
    calc_total=True,
    calc_rollup=False,
)
```

## Key Difference from Legacy `calc_rollup=True`

The new `grouping_sets="rollup"` is cleaner and matches **SQL ROLLUP behavior exactly** (hierarchical prefix rollups only):
- **`grouping_sets="rollup"`**: `[A,B,C], [A,B], [A], []` (prefix only)
- **`calc_rollup=True`**: `[A,B,C], [A,B], [A], [B,C], [C], []` (prefix AND suffix rollups)

The legacy `calc_rollup=True` behavior generated both prefix and suffix rollups, which doesn't match standard SQL ROLLUP. The new parameter provides cleaner, more predictable behavior.

## Test Results

```
49 passed, 1 warning in 4.16s
All linting checks passed
```

## Next Steps

This implementation sets the foundation for:
- CUBE mode (all combinations)
- Custom grouping sets (arbitrary combinations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)