### PR TITLE
feat: add composable grouping sets with cube() and rollup() helpers

### DIFF
--- a/pyretailscience/segmentation/segstats.py
+++ b/pyretailscience/segmentation/segstats.py
@@ -471,6 +471,15 @@ class SegTransactionStats:
             TypeError: If grouping_sets has invalid type
         """
         if grouping_sets is None:
+            # Warn if relying on implicit calc_total=True default (calc_total will be removed)
+            if calc_total is None and calc_rollup is None:
+                warnings.warn(
+                    "The calc_total parameter is deprecated and will be removed in a future version. "
+                    "To maintain the current behavior of including a grand total, use grouping_sets=[()] instead. "
+                    "See documentation for more flexible aggregation control with the grouping_sets parameter.",
+                    FutureWarning,
+                    stacklevel=3,
+                )
             return
 
         # Mutual exclusivity check


### PR DESCRIPTION
## Summary

Adds composable grouping sets functionality with `cube()` and `rollup()` helper functions, enabling SQL-style syntax like `GROUP BY CUBE(A, B), C` where fixed columns appear in every generated grouping set.

## Changes

### New Helper Functions
- **`cube(*columns)`**: Generates all 2^n combinations of specified columns
- **`rollup(*columns)`**: Generates hierarchical aggregation levels (n+1 grouping sets)
- Both functions return `list[tuple[str, ...]]` for direct use or composition

### Composable Syntax
Users can now mix CUBE/ROLLUP with fixed columns:
```python
from pyretailscience.segmentation import SegTransactionStats, cube

# Geographic CUBE analysis with consistent time dimension
stats = SegTransactionStats(
    data=df,
    segment_col=["store", "region", "date"],
    grouping_sets=[(cube("store", "region"), "date")]
)
# Generates: (store, region, date), (store, date), (region, date), (date,)
```

### Implementation Details
- Added `_flatten_item()` helper method using structural detection to distinguish:
  - Explicit grouping sets: `("region", "store")` 
  - Composable specifications: `(cube("region", "store"), "date")`
- Updated validation to only accept tuples (not lists) for API consistency
- Updated `_generate_grouping_sets()` to delegate to helper functions and flatten composable specs
- Automatic deduplication of generated grouping sets

### API Consistency Updates
- Changed validation to only accept tuples in `grouping_sets` lists (breaking change from previous implementation)
- Updated 4 existing tests to match new tuple-only validation
- Removed 1 test that validated list support (no longer supported)

## Testing

- ✅ All 85 tests passing
- Added 12 new comprehensive tests for composable grouping sets:
  - Helper function behavior tests
  - Composable syntax tests
  - Validation tests
  - Integration test with real data
- Updated 4 tests from previous implementation to match new tuple-only API
- Code formatted and linted

## Use Cases

**Time-consistent geographic analysis:**
```python
# Analyze store/region performance while keeping date fixed
grouping_sets=[(cube("store", "region"), "date")]
```

**Hierarchical time with fixed customer segment:**
```python
# Roll up year/quarter while maintaining segment dimension
grouping_sets=[(rollup("year", "quarter"), "customer_segment")]
```

**Multiple composable specifications:**
```python
# Combine geographic CUBE with time ROLLUP, both by segment
grouping_sets=[
    (cube("region", "store"), "customer_segment"),
    (rollup("quarter"), "customer_segment")
]
```

## Documentation

- Added comprehensive docstrings to `cube()` and `rollup()` functions with examples
- Updated `_flatten_item()` docstring with structural detection explanation
- Updated module `__all__` exports to include new public functions

## Related Work

This builds on the grouping sets refactor completed in earlier PRs:
- Unified grouping sets execution architecture
- ROLLUP mode (`grouping_sets="rollup"`)
- CUBE mode (`grouping_sets="cube"`)
- Custom grouping sets (list of explicit tuples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)