### PR TITLE
Fix deterministic ordering in threshold segmentation

### DIFF
--- a/tests/segmentation/test_threshold.py
+++ b/tests/segmentation/test_threshold.py
@@ -152,6 +152,42 @@ class TestThresholdSegmentation:
             assert isinstance(result_df, pd.DataFrame), "Should execute successfully with custom column names"
             assert result_df.index.name == "buyer_id", "Should use custom customer_id column name as index"
 
+    def test_segmentation_with_tied_spend_values(self):
+        """Test that customers with identical spend values are segmented consistently using customer_id as tiebreaker."""
+        # Create dataset with multiple customers having identical spend values
+        df = pd.DataFrame(
+            {
+                cols.customer_id: [101, 102, 103, 104, 105, 106, 107, 108],
+                cols.unit_spend: [100, 100, 100, 200, 200, 300, 300, 300],
+            },
+        )
+
+        thresholds = [0.5, 1.0]
+        segments = ["Low", "High"]
+
+        seg = ThresholdSegmentation(
+            df=df,
+            thresholds=thresholds,
+            segments=segments,
+            zero_value_customers="exclude",
+        )
+        result = seg.df
+
+        # Expected behavior: customers ordered by (spend, customer_id)
+        # With 8 customers and threshold at 0.5:
+        # - Percentile ranks: 0.0, 0.143, 0.286, 0.429, 0.571, 0.714, 0.857, 1.0
+        # - First 4 customers (ranks ≤ 0.5) → "Low", last 4 (ranks > 0.5) → "High"
+        # - Ordering: (100, 101), (100, 102), (100, 103), (200, 104), (200, 105), (300, 106), (300, 107), (300, 108)
+        expected_df = pd.DataFrame(
+            {
+                cols.customer_id: [101, 102, 103, 104, 105, 106, 107, 108],
+                cols.unit_spend: [100, 100, 100, 200, 200, 300, 300, 300],
+                "segment_name": ["Low", "Low", "Low", "Low", "High", "High", "High", "High"],
+            },
+        ).set_index(cols.customer_id)
+
+        pd.testing.assert_frame_equal(result.sort_index(), expected_df)
+
 
 class TestThresholdSegmentationGroupCol:
     """Tests for ThresholdSegmentation group_col functionality."""


### PR DESCRIPTION
## Summary

- Fixed non-deterministic ordering in threshold segmentation window function by adding `customer_id` as secondary sort key
- Replaced `get_option()` calls with `ColumnHelper` for cleaner, more maintainable code
- Added test to verify consistent segmentation when customers have identical spend values

## Problem

The window function was ordering only by `value_col`, which caused non-deterministic behavior when multiple customers had identical values (e.g., three customers all with $100 spend). Different database engines or runs could order these tied customers differently, leading to inconsistent percentile assignments and different segment classifications.

## Solution

Updated the window function to use `order_by=[ibis.asc(df[value_col]), ibis.asc(df[cols.customer_id])]` instead of just `order_by=ibis.asc(df[value_col])`. This ensures that when values are tied, customers are always ordered consistently by their `customer_id`, making segment assignments deterministic and reproducible.

This fix applies to both:
- `ThresholdSegmentation` 
- `HMLSegmentation` (which inherits from `ThresholdSegmentation`)

## Test plan

- [x] All existing tests pass (12/12 tests in `tests/segmentation/test_threshold.py`)
- [x] Added new test `test_segmentation_with_tied_spend_values` that verifies consistent ordering with tied values
- [x] Pre-commit hooks pass (ruff, pytest, conventional commit check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)