### PR TITLE
fix: add missing permissions for deploy-docs reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ permissions:
   contents: write
   deployments: write
   packages: write
-  pages: write
-  id-token: write
 concurrency:
   group: "release"
   cancel-in-progress: false
@@ -215,4 +213,8 @@ jobs:
   deploy-docs:
     name: Deploy Documentation
     needs: pypi-publish
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     uses: ./.github/workflows/gh-page.yml


### PR DESCRIPTION
## Summary
- Add `pages:write` and `id-token:write` permissions to release.yml

These permissions are required by the `gh-page.yml` reusable workflow that is called from the `deploy-docs` job.

## Test plan
- [ ] Manually trigger the PyPi Package Deploy workflow after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)