### PR TITLE
fix: prevent division by zero across analysis and plotting modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,4 @@ cython_debug/
 # Data files
 *.csv
 
-# Claude Sync files
-.claudeignore
-.claudesync
+.claude-review

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,10 @@
 - Run tests with coverage: `uv run pytest --cov=pyretailscience`
 - Lint code: `uv run ruff check .`
 - Format code: `uv run ruff format .`
+- Run Python scripts: `uv run python script.py`
 - Run notebook: `uv run jupyter nbconvert --to notebook --execute my_notebook.ipynb`
+
+**Note**: Always use `uv run` to execute Python commands to ensure the correct virtual environment and dependencies are used.
 
 ## Code Style Guidelines
 
@@ -39,6 +42,9 @@
   error messages
 - Use ternary operators for simple conditional assignments (e.g., `status = "active" if count > 0 else "inactive"`
   instead of multi-line if/else blocks)
+- Avoid using `Any` or `object` types in annotations; determine and use the correct specific type whenever possible
+- Use `TYPE_CHECKING` blocks for type-only imports to avoid runtime import overhead. Do not use `noqa: TC003` to
+  suppress these warnings; instead, properly move type-only imports into `if TYPE_CHECKING:` blocks
 
 ## Test Writing Guidelines
 
@@ -91,6 +97,10 @@
   assertions (True == True)
 - **Don't test implementation details**: Avoid asserting internal state values or data structures. Testing private
   method behavior/outputs is OK; testing how data is stored internally is not.
+- **Don't test configuration defaults**: Avoid tests that only verify default values match their definitions (e.g.,
+  `assert get_option("foo") == "bar"` when you just set `"foo": "bar"` in the defaults dictionary). These are
+  tautological and can only fail from typos noticed immediately. Instead, test that configured values are actually
+  *used* by package functionality through integration tests.
 - **Don't use generic test data**: Use domain-specific examples (retail customer data, not "A", "B", "C")
 - **Don't mismatch test names and assertions**: If test claims to verify sorting, actually assert sort order. If it
   claims validation, verify validation logic works.
@@ -106,21 +116,3 @@ Before committing test code, verify each test meets these criteria:
 5. **No substantial duplication**: Similar tests use parametrize or are combined
 6. **Uses realistic data**: Test data reflects retail domain (customer IDs, prices, stores, etc.)
 7. **Minimal mocking**: Only external dependencies are mocked, not internal package logic
-
-## GitHub PR Review Comments
-
-When asked to review a GitHub PR comment (e.g., a URL like
-`https://github.com/Data-Simply/pyretailscience/pull/414#issuecomment-3592454545`), extract the comment ID from the URL
-and fetch the comment content using the `gh` CLI:
-
-```bash
-gh api repos/Data-Simply/pyretailscience/issues/comments/<COMMENT_ID>
-```
-
-For example, given the URL `https://github.com/Data-Simply/pyretailscience/pull/414#issuecomment-3592454545`, run:
-
-```bash
-gh api repos/Data-Simply/pyretailscience/issues/comments/3592454545
-```
-
-This returns the comment body and metadata, which you can then use to review and respond to the feedback

--- a/pyretailscience/analysis/customer.py
+++ b/pyretailscience/analysis/customer.py
@@ -192,10 +192,8 @@ class PurchasesPerCustomer:
         }
 
         if comparison not in ops:
-            raise ValueError(
-                "Comparison must be one of 'less_than', 'less_than_equal_to', 'equal_to', 'not_equal_to',",
-                "'greater_than', 'greater_than_equal_to'",
-            )
+            msg = f"Comparison must be one of {', '.join(repr(k) for k in ops)}"
+            raise ValueError(msg)
 
         return len(self.cust_purchases_s[ops[comparison](self.cust_purchases_s, number_of_purchases)]) / len(
             self.cust_purchases_s,

--- a/pyretailscience/analysis/customer_decision_hierarchy.py
+++ b/pyretailscience/analysis/customer_decision_hierarchy.py
@@ -220,9 +220,13 @@ class CustomerDecisionHierarchy:
         d = np.count_nonzero(~bought_product_1 & ~bought_product_2)
 
         # Calculate Yule's Q coefficient
-        q = (a * d - b * c) / (a * d + b * c)
+        denominator = a * d + b * c
+        if denominator == 0:
+            # Both a*d and b*c are zero, making Q mathematically undefined (0/0).
+            # Return 0.0 (no association) because NaN would break scipy's linkage() downstream.
+            return 0.0
 
-        return q  # noqa: RET504
+        return (a * d - b * c) / denominator
 
     def _get_yules_q_distances(self) -> float:
         """Calculate the Yules Q distances between pairs of products.

--- a/pyretailscience/analysis/revenue_tree.py
+++ b/pyretailscience/analysis/revenue_tree.py
@@ -26,6 +26,7 @@ inform strategic decision-making.
 """
 
 import ibis
+import numpy as np
 import pandas as pd
 from matplotlib.axes import Axes
 
@@ -97,29 +98,29 @@ def calc_tree_kpis(
         )
 
         # Percentage change calculations
-        df[col + "_" + get_option("column.suffix.percent_difference")] = (
-            df[col + "_" + get_option("column.suffix.difference")]
-            / df[col + "_" + get_option("column.suffix.period_1")]
-        )
+        p1_col = df[col + "_" + get_option("column.suffix.period_1")]
+        df[col + "_" + get_option("column.suffix.percent_difference")] = df[
+            col + "_" + get_option("column.suffix.difference")
+        ] / p1_col.replace(0, np.nan)
 
     # Calculate price elasticity
     if cols.agg.unit_qty in df_cols:
-        df[cols.calc.price_elasticity] = (
-            (df[cols.agg.unit_qty_p2] - df[cols.agg.unit_qty_p1])
-            / ((df[cols.agg.unit_qty_p2] + df[cols.agg.unit_qty_p1]) / 2)
-        ) / (
-            (df[cols.calc.price_per_unit_p2] - df[cols.calc.price_per_unit_p1])
-            / ((df[cols.calc.price_per_unit_p2] + df[cols.calc.price_per_unit_p1]) / 2)
-        )
+        qty_avg = ((df[cols.agg.unit_qty_p2] + df[cols.agg.unit_qty_p1]) / 2).replace(0, np.nan)
+        qty_pct_change = (df[cols.agg.unit_qty_p2] - df[cols.agg.unit_qty_p1]) / qty_avg
+
+        price_avg = ((df[cols.calc.price_per_unit_p2] + df[cols.calc.price_per_unit_p1]) / 2).replace(0, np.nan)
+        price_pct_change = (df[cols.calc.price_per_unit_p2] - df[cols.calc.price_per_unit_p1]) / price_avg
+
+        df[cols.calc.price_elasticity] = qty_pct_change / price_pct_change.replace(0, np.nan)
 
     # Calculate frequency elasticity
-    df[cols.calc.frequency_elasticity] = (
-        (df[cols.calc.trans_per_cust_p2] - df[cols.calc.trans_per_cust_p1])
-        / ((df[cols.calc.trans_per_cust_p2] + df[cols.calc.trans_per_cust_p1]) / 2)
-    ) / (
-        (df[cols.calc.spend_per_cust_p2] - df[cols.calc.spend_per_cust_p1])
-        / ((df[cols.calc.spend_per_cust_p2] + df[cols.calc.spend_per_cust_p1]) / 2)
-    )
+    freq_avg = ((df[cols.calc.trans_per_cust_p2] + df[cols.calc.trans_per_cust_p1]) / 2).replace(0, np.nan)
+    freq_pct_change = (df[cols.calc.trans_per_cust_p2] - df[cols.calc.trans_per_cust_p1]) / freq_avg
+
+    spend_avg = ((df[cols.calc.spend_per_cust_p2] + df[cols.calc.spend_per_cust_p1]) / 2).replace(0, np.nan)
+    spend_pct_change = (df[cols.calc.spend_per_cust_p2] - df[cols.calc.spend_per_cust_p1]) / spend_avg
+
+    df[cols.calc.frequency_elasticity] = freq_pct_change / spend_pct_change.replace(0, np.nan)
 
     # Contribution calculations
     df[cols.agg.customer_id_contrib] = (
@@ -168,10 +169,10 @@ def calc_tree_kpis(
             cols.calc.units_per_trans,
             cols.calc.price_per_unit,
         ]:
-            df[col + "_" + get_option("column.suffix.percent_difference")] = (
-                df[col + "_" + get_option("column.suffix.difference")]
-                / df[col + "_" + get_option("column.suffix.period_1")]
-            )
+            p1_col = df[col + "_" + get_option("column.suffix.period_1")]
+            df[col + "_" + get_option("column.suffix.percent_difference")] = df[
+                col + "_" + get_option("column.suffix.difference")
+            ] / p1_col.replace(0, np.nan)
 
         df[cols.calc.price_per_unit_contrib] = (
             (

--- a/tests/analysis/test_customer_decision_hierarchy.py
+++ b/tests/analysis/test_customer_decision_hierarchy.py
@@ -45,6 +45,27 @@ class TestCustomerDecisionHierarchy:
 
         assert rp.CustomerDecisionHierarchy._calculate_yules_q(bought_product_1, bought_product_2) == expected_q
 
+    @pytest.mark.parametrize(
+        ("bought_product_1", "bought_product_2"),
+        [
+            pytest.param(
+                np.array([True, True, True]),
+                np.array([True, True, True]),
+                id="all_customers_buy_both",
+            ),
+            pytest.param(
+                np.array([True, True, True]),
+                np.array([False, False, False]),
+                id="no_overlap_no_neither",
+            ),
+        ],
+    )
+    def test_calculate_yules_q_zero_denominator_returns_zero(self, bought_product_1, bought_product_2):
+        """Test that Yule's Q returns 0.0 when the denominator is zero."""
+        result = rp.CustomerDecisionHierarchy._calculate_yules_q(bought_product_1, bought_product_2)
+
+        assert result == 0.0
+
     def test_get_yules_q_distances(self):
         """Test that the function returns the correct Yules Q distances."""
         bought_product_1 = np.array([1, 0, 1, 0, 0, 1, 1, 0, 1], dtype=bool)

--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -1,11 +1,14 @@
 """Tests for the waterfall plot module."""
 
+import warnings
+
 import matplotlib.pyplot as plt
+import pandas as pd
 import pytest
 from matplotlib.colors import to_hex
 
 from pyretailscience.plots.styles.colors import COLORS
-from pyretailscience.plots.waterfall import plot
+from pyretailscience.plots.waterfall import format_data_labels, plot
 
 
 class TestWaterfallPlot:
@@ -107,3 +110,77 @@ class TestWaterfallPlot:
 
         with pytest.raises(ValueError):
             plot(amounts, labels, data_label_format="invalid_format")
+
+    @pytest.mark.parametrize("label_format", ["percentage", "both"])
+    def test_zero_total_change_does_not_raise(self, label_format):
+        """Test that offsetting amounts (zero total) do not raise ZeroDivisionError."""
+        amounts = [500.0, -300.0, -200.0]
+        labels = ["Revenue", "Cost of Goods", "Operating Expenses"]
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result_ax = plot(amounts, labels, data_label_format=label_format)
+
+        assert isinstance(result_ax, plt.Axes)
+        assert any("Total change is zero" in str(w.message) for w in caught)
+
+
+class TestFormatDataLabels:
+    """Tests for the format_data_labels function."""
+
+    @pytest.fixture
+    def sample_amounts(self):
+        """Return a sample Series of retail transaction amounts."""
+        return pd.Series([500.0, -300.0, 200.0])
+
+    def test_percentage_format_with_zero_total_returns_empty_strings(self):
+        """Test that percentage format returns empty strings when total change is zero."""
+        amounts = pd.Series([500.0, -300.0, -200.0])
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = format_data_labels(amounts, total_change=0, label_format="percentage", decimals=0)
+
+        assert result == ["", "", ""]
+        assert len(caught) == 1
+        assert "Total change is zero" in str(caught[0].message)
+
+    def test_both_format_with_zero_total_returns_absolute_values_only(self):
+        """Test that 'both' format returns only absolute values when total change is zero."""
+        amounts = pd.Series([500.0, -300.0, -200.0])
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = format_data_labels(amounts, total_change=0, label_format="both", decimals=0)
+
+        assert result == ["500", "-300", "-200"]
+        assert len(caught) == 1
+        assert "Total change is zero" in str(caught[0].message)
+
+    def test_absolute_format_unaffected_by_zero_total(self):
+        """Test that absolute format works normally regardless of total change."""
+        amounts = pd.Series([500.0, -300.0, -200.0])
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = format_data_labels(amounts, total_change=0, label_format="absolute", decimals=0)
+
+        assert result == ["500", "-300", "-200"]
+        # No warning should be emitted for absolute format
+        assert not any("Total change is zero" in str(w.message) for w in caught)
+
+    def test_percentage_format_with_nonzero_total(self, sample_amounts):
+        """Test that percentage format calculates correctly with a valid total."""
+        total = sample_amounts.sum()  # 400.0
+        result = format_data_labels(sample_amounts, total_change=total, label_format="percentage", decimals=0)
+
+        assert result[0] == "125%"
+        assert result[1] == "-75%"
+        assert result[2] == "50%"
+
+    def test_both_format_with_nonzero_total(self, sample_amounts):
+        """Test that 'both' format includes absolute value and percentage with a valid total."""
+        total = sample_amounts.sum()  # 400.0
+        result = format_data_labels(sample_amounts, total_change=total, label_format="both", decimals=0)
+
+        assert list(result) == ["500 (125%)", "-300 (-75%)", "200 (50%)"]


### PR DESCRIPTION
## Summary
- Replace raw division with safe alternatives (`np.nan`, `nullif(0)`, warnings) in `revenue_tree`, `customer_decision_hierarchy`, `index` plots, and `waterfall` plots to prevent `ZeroDivisionError` and `inf` values
- Improve error message formatting in `PurchasesPerCustomer` to dynamically list valid comparison options
- Add comprehensive tests covering all zero-denominator edge cases across affected modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)