### PR TITLE
test: replace gu mock-introspection with behavioural assertions

### DIFF
--- a/tests/plots/test_area.py
+++ b/tests/plots/test_area.py
@@ -1,7 +1,5 @@
 """Tests for the plots.area module."""
 
-from itertools import cycle
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -9,7 +7,6 @@ import pytest
 from matplotlib.axes import Axes
 
 from openretailscience.plots import area
-from openretailscience.plots.styles import graph_utils as gu
 
 
 @pytest.fixture(autouse=True)
@@ -34,26 +31,6 @@ def sample_dataframe():
     return pd.DataFrame(data)
 
 
-@pytest.fixture
-def _mock_color_generators(mocker):
-    """Mock the color generators for single and multi color maps."""
-    single_color_gen = cycle(["#FF0000"])  # Mocked single-color generator (e.g., red)
-    multi_color_gen = cycle(["#FF0000", "#00FF00", "#0000FF"])  # Mocked multi-color generator (red, green, blue)
-
-    mocker.patch("openretailscience.plots.styles.colors.get_single_color_cmap", return_value=single_color_gen)
-    mocker.patch("openretailscience.plots.styles.colors.get_multi_color_cmap", return_value=multi_color_gen)
-
-
-@pytest.fixture
-def _mock_gu_functions(mocker):
-    mocker.patch(
-        "openretailscience.plots.styles.graph_utils.standard_graph_styles", side_effect=lambda ax, **kwargs: ax
-    )
-    mocker.patch("openretailscience.plots.styles.graph_utils.standard_tick_styles", side_effect=lambda ax: ax)
-    mocker.patch("openretailscience.plots.styles.graph_utils.add_source_text", side_effect=lambda ax, source_text: ax)
-
-
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_single_column(sample_dataframe):
     """Test the plot function with a single value column."""
     result_ax = area.plot(
@@ -69,7 +46,6 @@ def test_plot_single_column(sample_dataframe):
     assert len(result_ax.get_children()) > 0
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_group_col(sample_dataframe):
     """Test the plot function with a group column (stacked area chart)."""
     result_ax = area.plot(
@@ -86,7 +62,6 @@ def test_plot_with_group_col(sample_dataframe):
     assert len(result_ax.get_children()) > 0
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_multiple_columns(sample_dataframe):
     """Test the plot function with multiple columns as a stacked area chart."""
     sample_dataframe["additional_spend"] = RNG.integers(1, 6, size=3 * PERIODS)
@@ -104,7 +79,6 @@ def test_plot_multiple_columns(sample_dataframe):
     assert len(result_ax.get_children()) > 0
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_multiple_columns_with_group_col(sample_dataframe):
     """Test the plot function when using multiple columns along with a group column."""
     sample_dataframe["additional_spend"] = RNG.integers(1, 6, size=3 * PERIODS)
@@ -120,9 +94,8 @@ def test_plot_multiple_columns_with_group_col(sample_dataframe):
         )
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_adds_source_text(sample_dataframe):
-    """Test the plot function adds source text to the plot."""
+    """The area plot renders source_text as a figure-level text element."""
     source_text = "Source: Test Data"
 
     result_ax = area.plot(
@@ -135,10 +108,10 @@ def test_plot_adds_source_text(sample_dataframe):
         source_text=source_text,
     )
 
-    gu.add_source_text.assert_called_once_with(ax=result_ax, source_text=source_text)
+    rendered = [t.get_text() for t in result_ax.figure.texts]
+    assert source_text in rendered
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_single_column_series(sample_dataframe):
     """Test the plot function with a single value as a Pandas Series."""
     result_ax = area.plot(

--- a/tests/plots/test_bar.py
+++ b/tests/plots/test_bar.py
@@ -1,15 +1,13 @@
 """Tests for the bar plot module."""
 
-from itertools import cycle
-
 import pandas as pd
 import pytest
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.patches import Rectangle
 
+from openretailscience.options import PlotStyleHelper
 from openretailscience.plots import bar
-from openretailscience.plots.styles import graph_utils as gu
 
 
 @pytest.fixture(autouse=True)
@@ -36,27 +34,6 @@ def sample_series():
     return pd.Series([1000, 1500, 2000, 2500], index=["A", "B", "C", "D"])
 
 
-@pytest.fixture
-def _mock_color_generators(mocker):
-    """Mock the color generators for single and multi color maps."""
-    single_color_gen = cycle(["#FF0000"])  # Mocked single-color generator (e.g., red)
-    multi_color_gen = cycle(["#FF0000", "#00FF00", "#0000FF"])  # Mocked multi-color generator
-    mocker.patch("openretailscience.plots.styles.colors.get_single_color_cmap", return_value=single_color_gen)
-    mocker.patch("openretailscience.plots.styles.colors.get_multi_color_cmap", return_value=multi_color_gen)
-
-
-@pytest.fixture
-def _mock_gu_functions(mocker):
-    """Mock the standard graph utilities functions."""
-    mocker.patch(
-        "openretailscience.plots.styles.graph_utils.standard_graph_styles", side_effect=lambda ax, **kwargs: ax
-    )
-    mocker.patch("openretailscience.plots.styles.graph_utils.standard_tick_styles", side_effect=lambda ax: ax)
-    mocker.patch("openretailscience.plots.styles.graph_utils.add_source_text", side_effect=lambda ax, source_text: ax)
-    mocker.patch("openretailscience.plots.styles.graph_utils.apply_hatches", side_effect=lambda ax, num_segments: ax)
-
-
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_empty_dataframe():
     """Test bar plot with an empty DataFrame."""
     empty_df = pd.DataFrame(columns=["sales_q1", "sales_q2"])
@@ -70,7 +47,6 @@ def test_plot_with_empty_dataframe():
         )
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_single_bar(sample_dataframe):
     """Test the bar plot function with a single value column."""
     result_ax = bar.plot(
@@ -86,7 +62,6 @@ def test_plot_single_bar(sample_dataframe):
     assert len(result_ax.patches) == expected_num_patches
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_missing_x_col_in_dataframe(sample_dataframe):
     """Test bar plot when the provided x_col does not exist in the DataFrame."""
     with pytest.raises(KeyError, match="x_col 'missing_col' not found in DataFrame"):
@@ -98,7 +73,6 @@ def test_missing_x_col_in_dataframe(sample_dataframe):
         )
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_none_value_col(sample_dataframe):
     """Test bar plot with None for value_col (default 'Value' column)."""
     result_ax = bar.plot(
@@ -116,7 +90,6 @@ def test_plot_with_none_value_col(sample_dataframe):
     assert actual_heights == pytest.approx(expected_heights)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_nan_values():
     """Test bar plot with NaN values in the data."""
     nan_dataframe = pd.DataFrame(
@@ -145,7 +118,6 @@ def test_plot_with_nan_values():
     assert actual_heights == pytest.approx(expected_heights)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_horizontal_orientation(sample_dataframe):
     """Test bar plot with horizontal orientation."""
     result_ax = bar.plot(
@@ -164,7 +136,6 @@ def test_plot_horizontal_orientation(sample_dataframe):
     assert all(p.get_height() == expected_height for p in result_ax.patches)  # Default bar height in horizontal bars
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_vertical_orientation(sample_dataframe):
     """Test bar plot with vertical orientation."""
     result_ax = bar.plot(
@@ -183,7 +154,6 @@ def test_plot_vertical_orientation(sample_dataframe):
     assert all(p.get_width() == expected_width for p in result_ax.patches)  # Default bar width in vertical bars
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_custom_bar_width(sample_dataframe):
     """Test bar plot with a custom width for bars."""
     custom_width = 0.5
@@ -200,30 +170,26 @@ def test_plot_with_custom_bar_width(sample_dataframe):
     assert all(p.get_width() == custom_width for p in result_ax.patches if isinstance(p, Rectangle))
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_legend_outside(sample_dataframe):
-    """Test the bar plot function moves the legend outside the plot."""
+    """move_legend_outside=True anchors the legend at the configured outside position."""
     result_ax = bar.plot(
         df=sample_dataframe,
-        value_col="sales_q1",
+        value_col=["sales_q1", "sales_q2"],
         x_col="product",
         title="Test Bar Plot with Legend Outside",
         move_legend_outside=True,
     )
 
-    gu.standard_graph_styles.assert_called_once_with(
-        ax=result_ax,
-        title="Test Bar Plot with Legend Outside",
-        x_label=None,
-        y_label=None,
-        legend_title=None,
-        move_legend_outside=True,
-    )
+    legend = result_ax.get_legend()
+    assert legend is not None
+    anchor = legend.get_bbox_to_anchor().transformed(result_ax.transAxes.inverted())
+    expected_x, expected_y = PlotStyleHelper().legend_bbox_to_anchor
+    assert anchor.x0 == pytest.approx(expected_x)
+    assert anchor.y0 == pytest.approx(expected_y)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_hatch(sample_dataframe):
-    """Test the bar plot function with hatching."""
+    """use_hatch=True applies a hatch pattern to every bar patch."""
     result_ax = bar.plot(
         df=sample_dataframe,
         value_col="sales_q1",
@@ -232,10 +198,11 @@ def test_plot_with_hatch(sample_dataframe):
         title="Test Bar Plot with Hatch",
     )
 
-    gu.apply_hatches.assert_called_once_with(ax=result_ax, num_segments=1)
+    hatches = [p.get_hatch() for p in result_ax.patches]
+    assert len(hatches) > 0
+    assert all(h is not None for h in hatches)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_multiple_bars(sample_dataframe):
     """Test the bar plot function with multiple value columns."""
     result_ax = bar.plot(
@@ -255,7 +222,6 @@ def test_plot_multiple_bars(sample_dataframe):
     assert actual_heights == pytest.approx(expected_heights)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_sorting(sample_dataframe):
     """Test the bar plot function with sorting in ascending order."""
     result_ax = bar.plot(
@@ -278,7 +244,6 @@ def test_plot_with_sorting(sample_dataframe):
     assert bar_heights == sorted(bar_heights)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_data_labels(sample_dataframe):
     """Test the bar plot function with data labels in absolute format."""
     result_ax = bar.plot(
@@ -297,7 +262,6 @@ def test_plot_with_data_labels(sample_dataframe):
     assert actual_labels == expected_labels
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_percentage_by_bar_group_labels(sample_dataframe):
     """Test the bar plot function with data labels in 'percentage_by_bar_group' format and verify percentages."""
     # Plot the bars with percentage labels
@@ -325,7 +289,6 @@ def test_plot_with_percentage_by_bar_group_labels(sample_dataframe):
         assert float(label.strip("%")) == pytest.approx(expected_percentage, 0.01)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_percentage_by_series_labels(sample_dataframe):
     """Test the bar plot function with data labels in 'percentage_by_series' format and verify percentages."""
     result_ax = bar.plot(
@@ -354,9 +317,8 @@ def test_plot_with_percentage_by_series_labels(sample_dataframe):
         assert float(label.strip("%")) == pytest.approx(expected_percentage, 0.29)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_adds_source_text(sample_dataframe):
-    """Test the bar plot function adds source text to the plot."""
+    """The bar plot renders source_text as a figure-level text element."""
     source_text = "Source: Test Data"
     result_ax = bar.plot(
         df=sample_dataframe,
@@ -366,36 +328,28 @@ def test_plot_adds_source_text(sample_dataframe):
         source_text=source_text,
     )
 
-    gu.add_source_text.assert_called_once_with(ax=result_ax, source_text=source_text)
+    rendered = [t.get_text() for t in result_ax.figure.texts]
+    assert source_text in rendered
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
-def test_plot_calls_dataframe_plot(mocker, sample_dataframe):
-    """Test that pandas.DataFrame.plot is called with correct arguments."""
-    # Spy on DataFrame.plot
-    mock_df_plot = mocker.patch("pandas.DataFrame.plot")
+def test_default_bar_styling(sample_dataframe):
+    """Single value_col bar plot has the documented default width (0.8) and no legend."""
+    default_width = 0.8
 
-    # Call the bar plot function
-    bar.plot(
+    result_ax = bar.plot(
         df=sample_dataframe,
         value_col="sales_q1",
         x_col="product",
         title="Test Bar Plot",
     )
 
-    # Check the arguments passed to DataFrame.plot
-    mock_df_plot.assert_called_once_with(
-        kind="bar",
-        y=["sales_q1"],
-        x="product",
-        ax=mocker.ANY,
-        color=mocker.ANY,
-        legend=False,
-        width=0.8,
-    )
+    rectangles = [p for p in result_ax.patches if isinstance(p, Rectangle)]
+    assert len(rectangles) > 0
+    assert all(p.get_width() == default_width for p in rectangles)
+    assert result_ax.get_legend() is None
+    assert [label.get_text() for label in result_ax.get_xticklabels()] == sample_dataframe["product"].tolist()
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_invalid_orientation(sample_dataframe):
     """Test that an invalid orientation raises a ValueError."""
     with pytest.raises(ValueError, match=r"Invalid orientation: invalid_orientation. Expected one of .*"):
@@ -407,7 +361,6 @@ def test_invalid_orientation(sample_dataframe):
         )
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_invalid_sort_order(sample_dataframe):
     """Test that an invalid sort_order raises a ValueError."""
     with pytest.raises(ValueError, match=r"Invalid sort_order: invalid_sort_order. Expected one of .*"):
@@ -419,7 +372,6 @@ def test_invalid_sort_order(sample_dataframe):
         )
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_invalid_data_label_format(sample_dataframe):
     """Test that an invalid data_label_format raises a ValueError."""
     with pytest.raises(ValueError, match=r"Invalid data_label_format: invalid_format. Expected one of .*"):
@@ -431,7 +383,6 @@ def test_invalid_data_label_format(sample_dataframe):
         )
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_default_value_col_handling(sample_series):
     """Test that a default 'Value' column is created when no value_col is passed."""
     result_ax = bar.plot(
@@ -448,7 +399,6 @@ def test_default_value_col_handling(sample_series):
     assert legend_labels == ["Value"], f"Expected legend label to be 'Value', got {legend_labels}"
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_series(sample_series):
     """Test the bar plot function works with a pandas Series."""
     result_ax = bar.plot(
@@ -462,7 +412,6 @@ def test_plot_with_series(sample_series):
     assert len(result_ax.patches) == expected_num_patches
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_no_x_col_string_value_col(sample_dataframe):
     """Test bar plot when x_col is None and value_col is a string."""
     result_ax = bar.plot(
@@ -477,7 +426,6 @@ def test_plot_no_x_col_string_value_col(sample_dataframe):
     assert len(result_ax.patches) == expected_num_patches
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_no_x_col_list_value_col(sample_dataframe):
     """Test bar plot when x_col is None and value_col is a list."""
     result_ax = bar.plot(
@@ -492,7 +440,6 @@ def test_plot_no_x_col_list_value_col(sample_dataframe):
     assert len(result_ax.patches) == expected_num_patches
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_percentage_by_bar_group_with_negative_values():
     """Test percentage_by_bar_group with negative values, triggering warning."""
     df = pd.DataFrame(
@@ -511,7 +458,6 @@ def test_percentage_by_bar_group_with_negative_values():
         )
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_percentage_by_bar_group_with_zero_group_total():
     """Test percentage_by_bar_group with zero group totals and verify warning is emitted."""
     df = pd.DataFrame({"product": ["A", "B"], "sales": [0, 0]})

--- a/tests/plots/test_cohort.py
+++ b/tests/plots/test_cohort.py
@@ -7,7 +7,6 @@ import pytest
 from matplotlib.axes import Axes
 
 from openretailscience.plots import cohort
-from openretailscience.plots.styles import graph_utils as gu
 
 RNG = np.random.default_rng(42)
 
@@ -26,20 +25,6 @@ def sample_cohort_dataframe():
     return pd.DataFrame(data, columns=[f"Month {i + 1}" for i in range(6)], index=[f"Cohort {i + 1}" for i in range(6)])
 
 
-@pytest.fixture
-def _mock_gu_functions(mocker):
-    """Mocks graph utility functions to avoid modifying global styles."""
-    mocker.patch(
-        "openretailscience.plots.styles.graph_utils.standard_graph_styles", side_effect=lambda ax, **kwargs: ax
-    )
-    mocker.patch("openretailscience.plots.styles.graph_utils.standard_tick_styles", side_effect=lambda ax: ax)
-    mocker.patch(
-        "openretailscience.plots.styles.graph_utils.add_source_text",
-        side_effect=lambda ax, source_text: ax,
-    )
-
-
-@pytest.mark.usefixtures("_mock_gu_functions")
 def test_plot_cohort(sample_cohort_dataframe):
     """Test cohort plot with a standard DataFrame."""
     result_ax = cohort.plot(
@@ -54,9 +39,8 @@ def test_plot_cohort(sample_cohort_dataframe):
     assert len(result_ax.get_children()) > 0
 
 
-@pytest.mark.usefixtures("_mock_gu_functions")
 def test_plot_cohort_with_source_text(sample_cohort_dataframe):
-    """Test cohort plot with source text annotation."""
+    """The cohort plot renders source_text as a figure-level text element."""
     source_text = "Source: Test Data"
 
     result_ax = cohort.plot(
@@ -65,10 +49,10 @@ def test_plot_cohort_with_source_text(sample_cohort_dataframe):
         source_text=source_text,
     )
 
-    gu.add_source_text.assert_called_once_with(ax=result_ax, source_text=source_text)
+    rendered = [t.get_text() for t in result_ax.figure.texts]
+    assert source_text in rendered
 
 
-@pytest.mark.usefixtures("_mock_gu_functions")
 def test_plot_cohort_with_percentage(sample_cohort_dataframe):
     """Test cohort plot with percentage formatting enabled."""
     result_ax = cohort.plot(
@@ -81,7 +65,6 @@ def test_plot_cohort_with_percentage(sample_cohort_dataframe):
     assert len(result_ax.get_children()) > 0
 
 
-@pytest.mark.usefixtures("_mock_gu_functions")
 def test_plot_cohort_with_ax_none(sample_cohort_dataframe):
     """Test cohort plot when ax is None (should create a new figure)."""
     result_ax = cohort.plot(
@@ -95,7 +78,6 @@ def test_plot_cohort_with_ax_none(sample_cohort_dataframe):
     assert result_ax.figure is not None
 
 
-@pytest.mark.usefixtures("_mock_gu_functions")
 def test_plot_cohort_with_figsize(sample_cohort_dataframe):
     """Test cohort plot with a specified figsize."""
     width = 14

--- a/tests/plots/test_heatmap.py
+++ b/tests/plots/test_heatmap.py
@@ -7,7 +7,6 @@ import pytest
 from matplotlib.axes import Axes
 
 from openretailscience.plots import heatmap
-from openretailscience.plots.styles import graph_utils as gu
 
 RNG = np.random.default_rng(42)
 
@@ -30,16 +29,6 @@ def sample_heatmap_dataframe():
     )
 
 
-@pytest.fixture
-def _mock_gu_functions(mocker):
-    """Mocks graph utility functions to avoid modifying global styles."""
-    mocker.patch(
-        "openretailscience.plots.styles.graph_utils.standard_graph_styles", side_effect=lambda ax, **kwargs: ax
-    )
-    mocker.patch("openretailscience.plots.styles.graph_utils.standard_tick_styles", side_effect=lambda ax: ax)
-    mocker.patch("openretailscience.plots.styles.graph_utils.add_source_text", side_effect=lambda ax, source_text: ax)
-
-
 def test_plot_basic_heatmap(sample_heatmap_dataframe):
     """Test basic heatmap creation with required parameters."""
     result_ax = heatmap.plot(
@@ -56,9 +45,8 @@ def test_plot_basic_heatmap(sample_heatmap_dataframe):
     assert len(result_ax.texts) == sample_heatmap_dataframe.size
 
 
-@pytest.mark.usefixtures("_mock_gu_functions")
 def test_plot_with_source_text(sample_heatmap_dataframe):
-    """Test heatmap with source text annotation."""
+    """The heatmap renders source_text as a figure-level text element."""
     source_text = "Source: Test Data"
     result_ax = heatmap.plot(
         df=sample_heatmap_dataframe,
@@ -66,7 +54,8 @@ def test_plot_with_source_text(sample_heatmap_dataframe):
         source_text=source_text,
     )
 
-    gu.add_source_text.assert_called_once_with(ax=result_ax, source_text=source_text)
+    rendered = [t.get_text() for t in result_ax.figure.texts]
+    assert source_text in rendered
 
 
 def test_plot_with_figsize(sample_heatmap_dataframe):

--- a/tests/plots/test_histogram.py
+++ b/tests/plots/test_histogram.py
@@ -1,15 +1,13 @@
 """Tests for the histograms plot module."""
 
-from itertools import cycle
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
 from matplotlib.axes import Axes
 
+from openretailscience.options import PlotStyleHelper
 from openretailscience.plots import histogram
-from openretailscience.plots.styles import graph_utils as gu
 
 
 @pytest.fixture(autouse=True)
@@ -36,25 +34,6 @@ def sample_series():
     return pd.Series([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
 
-@pytest.fixture
-def _mock_color_generators(mocker):
-    """Mock the color generator for multi color maps."""
-    multi_color_gen = cycle(["#FF0000", "#00FF00", "#0000FF"])  # Mocked multi-color generator
-    mocker.patch("openretailscience.plots.styles.colors.get_multi_color_cmap", return_value=multi_color_gen)
-
-
-@pytest.fixture
-def _mock_gu_functions(mocker):
-    """Mock standard graph utilities functions."""
-    mocker.patch(
-        "openretailscience.plots.styles.graph_utils.standard_graph_styles", side_effect=lambda ax, **kwargs: ax
-    )
-    mocker.patch("openretailscience.plots.styles.graph_utils.standard_tick_styles", side_effect=lambda ax: ax)
-    mocker.patch("openretailscience.plots.styles.graph_utils.add_source_text", side_effect=lambda ax, source_text: ax)
-    mocker.patch("openretailscience.plots.styles.graph_utils.apply_hatches", side_effect=lambda ax, num_segments: ax)
-
-
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_single_histogram(sample_dataframe):
     """Test the plot function with a single histogram."""
     result_ax = histogram.plot(
@@ -67,7 +46,6 @@ def test_plot_single_histogram(sample_dataframe):
     assert len(result_ax.patches) > 0  # Ensure that some bars were plotted
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_grouped_histogram(sample_dataframe):
     """Test the plot function with grouped histograms."""
     result_ax = histogram.plot(
@@ -81,7 +59,6 @@ def test_plot_grouped_histogram(sample_dataframe):
     assert len(result_ax.patches) > 0  # Ensure that some bars were plotted
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_enforces_range_clipping(sample_dataframe):
     """Test that the plot function enforces range clipping through the Axes limits and print the min/max values."""
     range_lower = 2
@@ -105,7 +82,6 @@ def test_plot_enforces_range_clipping(sample_dataframe):
     assert all(range_lower <= val + np.finfo(np.float64).eps <= range_upper for val in clipped_values)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_range_fillna(sample_dataframe):
     """Test the plot function with range fillna."""
     range_lower = 3
@@ -129,7 +105,6 @@ def test_plot_with_range_fillna(sample_dataframe):
     assert all(range_lower <= val + np.finfo(np.float64).eps <= range_upper for val in clipped_values)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_range_lower_none(sample_dataframe):
     """Test the plot function with range_lower=None (no lower bound) and a specific upper bound."""
     range_upper = 8  # No lower bound
@@ -151,7 +126,6 @@ def test_plot_with_range_lower_none(sample_dataframe):
     assert all(val + np.finfo(np.float64).eps <= range_upper for val in clipped_values)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_range_upper_none(sample_dataframe):
     """Test the plot function with range_upper=None (no upper bound) and a specific lower bound."""
     range_lower = 3  # No upper bound
@@ -173,7 +147,6 @@ def test_plot_with_range_upper_none(sample_dataframe):
     assert all(range_lower <= val + np.finfo(np.float64).eps for val in clipped_values)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_fillna_outside_range(sample_dataframe):
     """Test the fillna method, ensuring values outside the range are replaced by NaN."""
     range_lower = 3
@@ -196,7 +169,6 @@ def test_plot_fillna_outside_range(sample_dataframe):
     assert all(range_lower <= val + np.finfo(np.float64).eps <= range_upper for val in clipped_values)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_single_histogram_series(sample_series):
     """Test the plot function with a pandas series."""
     result_ax = histogram.plot(
@@ -208,9 +180,8 @@ def test_plot_single_histogram_series(sample_series):
     assert len(result_ax.patches) > 0  # Ensure that some bars were plotted
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_histogram_with_hatch(sample_dataframe):
-    """Test the plot function with hatching."""
+    """use_hatch=True applies a hatch pattern to every histogram patch."""
     result_ax = histogram.plot(
         df=sample_dataframe,
         value_col="value_1",
@@ -218,10 +189,11 @@ def test_plot_histogram_with_hatch(sample_dataframe):
         use_hatch=True,
     )
 
-    gu.apply_hatches.assert_called_once_with(ax=result_ax, num_segments=1)
+    hatches = [p.get_hatch() for p in result_ax.patches]
+    assert len(hatches) > 0
+    assert all(h is not None for h in hatches)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_invalid_value_col_with_group_col(sample_dataframe):
     """Test the plot function raises an error when both `value_col` is a list and `group_col` is provided."""
     with pytest.raises(ValueError, match="`value_col` cannot be a list when `group_col` is provided"):
@@ -233,9 +205,8 @@ def test_plot_invalid_value_col_with_group_col(sample_dataframe):
         )
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_legend_outside(sample_dataframe):
-    """Test the plot function moves the legend outside the plot."""
+    """move_legend_outside=True anchors the legend at the configured outside position."""
     result_ax = histogram.plot(
         df=sample_dataframe,
         value_col="value_1",
@@ -244,19 +215,16 @@ def test_plot_legend_outside(sample_dataframe):
         move_legend_outside=True,
     )
 
-    gu.standard_graph_styles.assert_called_once_with(
-        ax=result_ax,
-        title="Test Legend Outside",
-        x_label=None,
-        y_label=None,
-        legend_title=None,
-        move_legend_outside=True,
-    )
+    legend = result_ax.get_legend()
+    assert legend is not None
+    anchor = legend.get_bbox_to_anchor().transformed(result_ax.transAxes.inverted())
+    expected_x, expected_y = PlotStyleHelper().legend_bbox_to_anchor
+    assert anchor.x0 == pytest.approx(expected_x)
+    assert anchor.y0 == pytest.approx(expected_y)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_adds_source_text(sample_dataframe):
-    """Test the plot function adds source text to the plot."""
+    """The histogram renders source_text as a figure-level text element."""
     source_text = "Source: Test Data"
     result_ax = histogram.plot(
         df=sample_dataframe,
@@ -265,10 +233,10 @@ def test_plot_adds_source_text(sample_dataframe):
         source_text=source_text,
     )
 
-    gu.add_source_text.assert_called_once_with(ax=result_ax, source_text=source_text)
+    rendered = [t.get_text() for t in result_ax.figure.texts]
+    assert source_text in rendered
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_multiple_histograms(sample_dataframe):
     """Test the plot function with multiple histograms."""
     result_ax = histogram.plot(
@@ -281,63 +249,23 @@ def test_plot_multiple_histograms(sample_dataframe):
     assert len(result_ax.patches) > 0  # Ensure that bars were plotted for both histograms
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
-def test_plot_single_histogram_calls_dataframe_plot(mocker, sample_dataframe):
-    """Test that pandas.DataFrame.plot is called with correct arguments when group_col is None."""
-    # Spy on DataFrame.plot
-    mock_df_plot = mocker.patch("pandas.DataFrame.plot")
-
-    # Prepare input
-    value_col = "value_1"
-    range_lower = 2
-    range_upper = 8
-
-    # Call the histogram plot function without a group column (single histogram)
-    histogram.plot(
+@pytest.mark.parametrize(
+    ("group_col", "expected_legend", "expected_alpha"),
+    [
+        (None, False, None),
+        ("group", True, 0.7),
+    ],
+)
+def test_histogram_legend_and_alpha_by_grouping(sample_dataframe, group_col, expected_legend, expected_alpha):
+    """Single histograms render without a legend/alpha; grouped histograms render with both."""
+    result_ax = histogram.plot(
         df=sample_dataframe,
-        value_col=value_col,
-        range_lower=range_lower,
-        range_upper=range_upper,
-        title="Test Single Histogram",
-    )
-
-    # Check the arguments passed to DataFrame.plot for single histogram
-    mock_df_plot.assert_called_once_with(
-        kind="hist",
-        ax=mocker.ANY,
-        legend=False,  # No grouping, so no need for a legend
-        color=mocker.ANY,
-        alpha=None,  # Since it's a single histogram
-    )
-
-
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
-def test_plot_grouped_histogram_calls_dataframe_plot(mocker, sample_dataframe):
-    """Test that pandas.DataFrame.plot is called with correct arguments when group_col is provided."""
-    # Spy on DataFrame.plot
-    mock_df_plot = mocker.patch("pandas.DataFrame.plot")
-
-    # Prepare input
-    value_col = "value_1"
-    group_col = "group"
-    range_lower = 2
-    range_upper = 8
-
-    # Call the histogram plot function with a group column (multiple histograms)
-    histogram.plot(
-        df=sample_dataframe,
-        value_col=value_col,
+        value_col="value_1",
         group_col=group_col,
-        range_lower=range_lower,
-        range_upper=range_upper,
-        title="Test Grouped Histogram",
+        title="Histogram grouping",
     )
 
-    # Check the arguments passed to DataFrame.plot for grouped histogram
-    mock_df_plot.assert_called_once_with(
-        kind="hist",
-        ax=mocker.ANY,
-        legend=True,  # Multiple histograms should have a legend
-        color=mocker.ANY,
-        alpha=0.7,  # Alpha is set to 0.7 for grouped histograms
-    )
+    assert (result_ax.get_legend() is not None) is expected_legend
+
+    patch_alphas = {p.get_alpha() for p in result_ax.patches}
+    assert patch_alphas == {expected_alpha}

--- a/tests/plots/test_line.py
+++ b/tests/plots/test_line.py
@@ -1,15 +1,13 @@
 """Tests for the plots.line module."""
 
-from itertools import cycle
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
 from matplotlib.axes import Axes
 
+from openretailscience.options import PlotStyleHelper
 from openretailscience.plots import line
-from openretailscience.plots.styles import graph_utils as gu
 
 
 @pytest.fixture(autouse=True)
@@ -57,26 +55,6 @@ def retail_sales_dataframe():
     return pd.DataFrame(data)
 
 
-@pytest.fixture
-def _mock_color_generators(mocker):
-    """Mock the color generators for single and multi color maps."""
-    single_color_gen = cycle(["#FF0000"])  # Mocked single-color generator (e.g., red)
-    multi_color_gen = cycle(["#FF0000", "#00FF00", "#0000FF"])  # Mocked multi-color generator (red, green, blue)
-
-    mocker.patch("openretailscience.plots.styles.colors.get_single_color_cmap", return_value=single_color_gen)
-    mocker.patch("openretailscience.plots.styles.colors.get_multi_color_cmap", return_value=multi_color_gen)
-
-
-@pytest.fixture
-def _mock_gu_functions(mocker):
-    mocker.patch(
-        "openretailscience.plots.styles.graph_utils.standard_graph_styles", side_effect=lambda ax, **kwargs: ax
-    )
-    mocker.patch("openretailscience.plots.styles.graph_utils.standard_tick_styles", side_effect=lambda ax: ax)
-    mocker.patch("openretailscience.plots.styles.graph_utils.add_source_text", side_effect=lambda ax, source_text: ax)
-
-
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_with_group_col(sample_dataframe):
     """Test the plot function with a group column."""
     result_ax = line.plot(
@@ -94,7 +72,6 @@ def test_plot_with_group_col(sample_dataframe):
     assert len(result_ax.get_lines()) == expected_num_lines, "Should have one line for each group"
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_without_group_col(sample_dataframe):
     """Test the plot function without a group column."""
     result_ax = line.plot(
@@ -111,143 +88,95 @@ def test_plot_without_group_col(sample_dataframe):
     assert len(result_ax.get_lines()) == expected_num_lines, "Should have only one line"
 
 
-@pytest.mark.parametrize(
-    ("move_legend_outside", "expected_title"),
-    [
-        (True, "Test Plot Legend Outside"),
-        (False, "Test Plot Legend Inside"),
-    ],
-)
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
-def test_plot_legend_positioning(sample_dataframe, move_legend_outside, expected_title):
-    """Test the plot function legend positioning (inside vs outside)."""
+@pytest.mark.parametrize("move_legend_outside", [True, False])
+def test_plot_legend_positioning(sample_dataframe, move_legend_outside):
+    """move_legend_outside controls whether the legend is anchored outside the axes."""
     result_ax = line.plot(
         df=sample_dataframe,
         value_col="y",
-        x_label="X Axis",
-        y_label="Y Axis",
-        title=expected_title,
+        title="Legend positioning",
         x_col="x",
         group_col="group",
         move_legend_outside=move_legend_outside,
     )
 
-    # Assert that standard_graph_styles was called with the correct move_legend_outside value
-    gu.standard_graph_styles.assert_called_once_with(
-        ax=result_ax,
-        title=expected_title,
-        x_label="X Axis",
-        y_label="Y Axis",
-        legend_title=None,
-        move_legend_outside=move_legend_outside,
-    )
+    legend = result_ax.get_legend()
+    assert legend is not None
+    anchor = legend.get_bbox_to_anchor().transformed(result_ax.transAxes.inverted())
+    if move_legend_outside:
+        expected_x, expected_y = PlotStyleHelper().legend_bbox_to_anchor
+        assert anchor.x0 == pytest.approx(expected_x)
+        assert anchor.y0 == pytest.approx(expected_y)
+    else:
+        # Inside: legend anchored to the axes bbox.
+        assert anchor.x0 == pytest.approx(0.0)
+        assert anchor.y0 == pytest.approx(0.0)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_adds_source_text(sample_dataframe):
-    """Test the plot function adds source text to the plot."""
+    """The line plot renders source_text as a figure-level text element."""
     source_text = "Source: Test Data"
 
     result_ax = line.plot(
         df=sample_dataframe,
         value_col="y",
-        x_label="X Axis",
-        y_label="Y Axis",
         title="Test Plot Source Text",
         x_col="x",
         source_text=source_text,
     )
 
-    gu.add_source_text.assert_called_once_with(ax=result_ax, source_text=source_text)
+    rendered = [t.get_text() for t in result_ax.figure.texts]
+    assert source_text in rendered
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
-def test_plot_with_legend_title(sample_dataframe):
-    """Test the plot function with a legend title."""
-    # Create the plot with a legend title
+@pytest.mark.parametrize("move_legend_outside", [True, False])
+def test_plot_with_legend_title(sample_dataframe, move_legend_outside):
+    """legend_title is rendered as the legend's title regardless of position."""
     legend_title = "Test Legend"
     result_ax = line.plot(
         df=sample_dataframe,
         value_col="y",
-        x_label="X Axis",
-        y_label="Y Axis",
         title="Test Plot with Legend Title",
         x_col="x",
         group_col="group",
         legend_title=legend_title,
+        move_legend_outside=move_legend_outside,
     )
 
-    # Assert that standard_graph_styles was called with the provided legend title
-    gu.standard_graph_styles.assert_called_once_with(
-        ax=result_ax,
-        title="Test Plot with Legend Title",
-        x_label="X Axis",
-        y_label="Y Axis",
-        legend_title=legend_title,
-        move_legend_outside=False,
-    )
-
-
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
-def test_plot_with_legend_title_and_move_outside(sample_dataframe):
-    """Test the plot function with both move_legend_outside=True and legend_title."""
-    # Create the plot with both options
-    legend_title = "Test Legend"
-    result_ax = line.plot(
-        df=sample_dataframe,
-        value_col="y",
-        x_label="X Axis",
-        y_label="Y Axis",
-        title="Test Plot Legend Outside with Title",
-        x_col="x",
-        group_col="group",
-        move_legend_outside=True,
-        legend_title=legend_title,
-    )
-
-    # Assert that standard_graph_styles was called with both options
-    gu.standard_graph_styles.assert_called_once_with(
-        ax=result_ax,
-        title="Test Plot Legend Outside with Title",
-        x_label="X Axis",
-        y_label="Y Axis",
-        legend_title=legend_title,
-        move_legend_outside=True,
-    )
+    legend = result_ax.get_legend()
+    assert legend is not None
+    assert legend.get_title().get_text() == legend_title
 
 
 @pytest.mark.parametrize(
-    ("group_col", "expected_legend", "plot_title"),
+    ("group_col", "expected_legend"),
     [
-        (None, False, "Test Single Line Plot"),
-        ("group", True, "Test Grouped Line Plot"),
+        (None, False),
+        ("group", True),
     ],
 )
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
-def test_line_plot_calls_dataframe_plot(mocker, sample_dataframe, group_col, expected_legend, plot_title):
-    """Test that pandas.DataFrame.plot is called with correct arguments for single vs grouped plots."""
-    # Mock DataFrame's plot method
-    mock_df_plot = mocker.patch("pandas.DataFrame.plot")
+def test_default_line_styling(sample_dataframe, group_col, expected_legend):
+    """Default lines render with the documented linewidth, alpha, and zorder; legend visibility tracks group_col."""
+    default_linewidth = 3
+    default_alpha = 1.0
+    default_zorder = 2
 
-    # Call the line plot function
-    line.plot(
+    result_ax = line.plot(
         df=sample_dataframe,
         value_col="y",
         group_col=group_col,
         x_col="x",
-        title=plot_title,
+        title="Default styling",
     )
 
-    # Check that DataFrame.plot was called with the correct arguments
-    # Since we added highlight functionality, we expect additional parameters
-    mock_df_plot.assert_called_once_with(
-        ax=mocker.ANY,
-        linewidth=3,
-        color=mocker.ANY,  # Dynamic color generation
-        alpha=1.0,  # New parameter added for highlight functionality
-        legend=expected_legend,
-        zorder=2,  # New parameter added for highlight functionality
-    )
+    plotted_lines = result_ax.get_lines()
+    assert len(plotted_lines) > 0
+    for plot_line in plotted_lines:
+        assert plot_line.get_linewidth() == default_linewidth
+        assert plot_line.get_alpha() == default_alpha
+        assert plot_line.get_zorder() == default_zorder
+
+    assert (result_ax.get_legend() is not None) is expected_legend
 
 
 @pytest.mark.parametrize(
@@ -271,7 +200,6 @@ def test_dataframe_error_conditions(sample_dataframe, value_col, group_col, expe
         )
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_fill_na_value_fills_missing_pivot_values(retail_sales_dataframe):
     """Test that fill_na_value fills NaN values for Store_North but not Store_South."""
     result_ax = line.plot(
@@ -303,7 +231,6 @@ def test_fill_na_value_fills_missing_pivot_values(retail_sales_dataframe):
     assert 0.0 not in south_data, "Store_South should not have any 0.0 values"
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_fill_na_value_none_preserves_nan_values(retail_sales_dataframe):
     """Test that when fill_na_value is None, NaN exists in Store_North but not Store_South."""
     result_ax = line.plot(

--- a/tests/plots/test_period_on_period.py
+++ b/tests/plots/test_period_on_period.py
@@ -1,14 +1,12 @@
 """Tests for the period_on_period overlapping_periods function."""
 
-from itertools import cycle
-
 import matplotlib.pyplot as plt
 import pandas as pd
 import pytest
 from matplotlib.axes import Axes
 
+from openretailscience.options import PlotStyleHelper
 from openretailscience.plots.period_on_period import plot
-from openretailscience.plots.styles import graph_utils as gu
 
 
 @pytest.fixture(autouse=True)
@@ -28,22 +26,6 @@ def sample_dataframe():
     return pd.DataFrame(data)
 
 
-@pytest.fixture
-def _mock_color_generators(mocker):
-    """Mock single color generator."""
-    mocker.patch("openretailscience.plots.styles.colors.get_single_color_cmap", return_value=cycle(["#FF0000"]))
-
-
-@pytest.fixture
-def _mock_gu_functions(mocker):
-    """Mock graph utility functions."""
-    mocker.patch(
-        "openretailscience.plots.styles.graph_utils.standard_graph_styles", side_effect=lambda ax, **kwargs: ax
-    )
-    mocker.patch("openretailscience.plots.styles.graph_utils.add_source_text", side_effect=lambda ax, source_text: ax)
-
-
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_overlapping_periods_basic(sample_dataframe):
     """Test basic overlapping periods plot."""
     periods = [("2023-01-01", "2023-01-05"), ("2023-01-06", "2023-01-10")]
@@ -59,9 +41,8 @@ def test_overlapping_periods_basic(sample_dataframe):
     assert len(ax.get_lines()) == expected_lines_count
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_overlapping_periods_with_labels_and_title(sample_dataframe):
-    """Test overlapping periods with axis labels and title."""
+    """The plot renders the supplied title and axis labels on the axes."""
     periods = [("2023-01-01", "2023-01-05"), ("2023-01-06", "2023-01-10")]
     title = "Overlapping Periods Test"
     ax = plot(
@@ -74,20 +55,13 @@ def test_overlapping_periods_with_labels_and_title(sample_dataframe):
         title=title,
     )
 
-    assert isinstance(ax, Axes)
-    gu.standard_graph_styles.assert_any_call(
-        ax=ax,
-        title=title,
-        x_label="Time",
-        y_label="Sales",
-        legend_title=None,
-        move_legend_outside=False,
-    )
+    assert ax.get_title() == title
+    assert ax.get_xlabel() == "Time"
+    assert ax.get_ylabel() == "Sales"
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_overlapping_periods_with_source_text(sample_dataframe):
-    """Test overlapping periods with source text added."""
+    """The plot renders source_text as a figure-level text element."""
     periods = [("2023-01-01", "2023-01-05"), ("2023-01-06", "2023-01-10")]
     source_text = "Source: Sales Data"
 
@@ -99,13 +73,12 @@ def test_overlapping_periods_with_source_text(sample_dataframe):
         source_text=source_text,
     )
 
-    gu.add_source_text.assert_called_once_with(ax=ax, source_text=source_text)
-    assert isinstance(ax, Axes)
+    rendered = [t.get_text() for t in ax.figure.texts]
+    assert source_text in rendered
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_overlapping_periods_with_legend_title_and_outside(sample_dataframe):
-    """Test overlapping periods with legend title and moved legend."""
+    """move_legend_outside=True anchors the legend outside, with the supplied title."""
     periods = [("2023-01-01", "2023-01-05"), ("2023-01-06", "2023-01-10")]
     legend_title = "Periods"
 
@@ -118,20 +91,17 @@ def test_overlapping_periods_with_legend_title_and_outside(sample_dataframe):
         legend_title=legend_title,
     )
 
-    gu.standard_graph_styles.assert_any_call(
-        ax=ax,
-        title=None,
-        x_label="date",
-        y_label="value",
-        legend_title=legend_title,
-        move_legend_outside=True,
-    )
-    assert isinstance(ax, Axes)
+    legend = ax.get_legend()
+    assert legend is not None
+    assert legend.get_title().get_text() == legend_title
+    anchor = legend.get_bbox_to_anchor().transformed(ax.transAxes.inverted())
+    expected_x, expected_y = PlotStyleHelper().legend_bbox_to_anchor
+    assert anchor.x0 == pytest.approx(expected_x)
+    assert anchor.y0 == pytest.approx(expected_y)
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_overlapping_periods_raises_on_empty_periods(sample_dataframe):
-    """Test overlapping periods with a ValueError is raised if an empty list of periods is passed."""
+    """Test overlapping periods raises a ValueError when an empty list is passed."""
     with pytest.raises(
         ValueError,
         match=r"The 'periods' list must contain at least two \(start, end\) tuples for comparison",

--- a/tests/plots/test_price.py
+++ b/tests/plots/test_price.py
@@ -137,29 +137,18 @@ def test_plot_invalid_bins_list_non_numeric(simple_price_dataframe):
         )
 
 
-def test_plot_with_unsorted_bins_list(mocker, simple_price_dataframe):
-    """Test price architecture plot passes sorted bins to pd.cut."""
-    # Mock pd.cut to capture the bins parameter and return realistic intervals
-    mock_cut = mocker.patch("pandas.cut")
-    # Create mock intervals that mimic pandas.cut behavior
-    intervals = [
-        pd.Interval(left=1, right=2, closed="right"),
-        pd.Interval(left=2, right=3, closed="right"),
-        pd.Interval(left=2, right=3, closed="right"),
-    ]
-    mock_cut.return_value = pd.Series(intervals, name="price_bin")
-
-    price.plot(
+def test_plot_with_unsorted_bins_list(simple_price_dataframe):
+    """Unsorted bin edges are sorted before binning so the y-tick labels read low → high."""
+    result_ax = price.plot(
         df=simple_price_dataframe,
         value_col="unit_price",
         group_col="retailer",
-        bins=[3, 1, 2],  # Unsorted bins
+        bins=[3, 1, 2],  # Unsorted on input.
     )
 
-    # Verify pd.cut was called with sorted bins
-    mock_cut.assert_called_once()
-    call_args = mock_cut.call_args
-    assert call_args[1]["bins"] == [1, 2, 3]  # Should be sorted
+    # If bins were not sorted, the resulting y-tick labels would be jumbled
+    # (e.g. "3.0 - 1.0"). Sorted bins produce ascending "1.0 - 2.0", "2.0 - 3.0".
+    assert [label.get_text() for label in result_ax.get_yticklabels()] == ["1.0 - 2.0", "2.0 - 3.0"]
 
 
 def test_plot_invalid_bins_type(simple_price_dataframe):
@@ -173,24 +162,14 @@ def test_plot_invalid_bins_type(simple_price_dataframe):
         )
 
 
-def test_plot_with_missing_values(mocker):
-    """Test price architecture plot handles missing values by dropping rows with NaN."""
+def test_plot_with_missing_values():
+    """Rows with NaN in value_col or group_col are dropped, leaving only valid retailers on the x-axis."""
     df = pd.DataFrame(
         {
-            "unit_price": [1, 2, None, 4, 5],
+            "unit_price": [1.0, 2.0, None, 4.0, 5.0],
             "retailer": ["Walmart", "Walmart", "Target", "Target", None],
         },
     )
-
-    # Mock pd.cut to capture the cleaned data that gets passed to it
-    mock_cut = mocker.patch("pandas.cut")
-    # Create mock intervals that mimic pandas.cut behavior
-    intervals = [
-        pd.Interval(left=1, right=2, closed="right"),
-        pd.Interval(left=1, right=2, closed="right"),
-        pd.Interval(left=2, right=4, closed="right"),
-    ]
-    mock_cut.return_value = pd.Series(intervals, name="price_bin")
 
     result_ax = price.plot(
         df=df,
@@ -199,25 +178,11 @@ def test_plot_with_missing_values(mocker):
         bins=3,
     )
 
-    # Verify pd.cut was called and extract the cleaned data
-    mock_cut.assert_called_once()
-    cleaned_data = mock_cut.call_args[0][0]  # First positional argument to pd.cut
-
-    # Verify that missing values were properly dropped
-    # Expected: rows with indices 0, 1, 3 (original data [1, 2, 4])
-    # Row 2 (unit_price=None) and row 4 (retailer=None) should be dropped
-    expected_values = [1.0, 2.0, 4.0]
-
-    assert cleaned_data.tolist() == expected_values, f"Expected {expected_values}, got {cleaned_data.tolist()}"
-
-    # Also verify the retailer data was cleaned correctly by checking the DataFrame index
-    # The cleaned DataFrame should have the correct corresponding retailer values
-    expected_bins = 3
-    # The function should have properly cleaned both columns together
-    assert len(cleaned_data) == expected_bins, f"Expected 3 clean rows, got {len(cleaned_data)}"
-
-    # Verify the function still works with cleaned data
-    assert isinstance(result_ax, Axes)
+    # After dropping NaN rows: Walmart has prices [1.0, 2.0], Target has [4.0]; the row
+    # with retailer=None is gone. Both retailers should appear on the x-axis; "None"
+    # must not.
+    rendered_retailers = {label.get_text() for label in result_ax.get_xticklabels()}
+    assert rendered_retailers == {"Walmart", "Target"}
 
 
 def test_plot_all_missing_values():
@@ -263,32 +228,26 @@ def test_plot_with_bins(simple_price_dataframe, bins):
     assert len(result_ax.get_yticks()) == expected_bins
 
 
-def test_plot_basic_functionality(sample_price_dataframe, mocker):
-    """Test basic price architecture plot functionality with labels and titles."""
-    # Mock standard_graph_styles to capture title and label parameters
-    mock_standard_styles = mocker.patch("openretailscience.plots.styles.graph_utils.standard_graph_styles")
-    mock_standard_styles.side_effect = lambda ax, **kwargs: ax
+def test_plot_basic_functionality(sample_price_dataframe):
+    """Title and axis labels are rendered, and the x-axis has one tick per retailer."""
+    title = "Price Distribution Analysis"
+    x_label = "Retailers"
+    y_label = "Price Bands"
 
     result_ax = price.plot(
         df=sample_price_dataframe,
         value_col="unit_price",
         group_col="retailer",
         bins=5,
-        title="Price Distribution Analysis",
-        x_label="Retailers",
-        y_label="Price Bands",
+        title=title,
+        x_label=x_label,
+        y_label=y_label,
     )
 
-    assert isinstance(result_ax, Axes)
+    assert result_ax.get_title() == title
+    assert result_ax.get_xlabel() == x_label
+    assert result_ax.get_ylabel() == y_label
 
-    # Verify that standard_graph_styles was called with correct parameters
-    mock_standard_styles.assert_called_once()
-    call_kwargs = mock_standard_styles.call_args[1]
-    assert call_kwargs["title"] == "Price Distribution Analysis"
-    assert call_kwargs["x_label"] == "Retailers"
-    assert call_kwargs["y_label"] == "Price Bands"
-
-    # Verify we have the expected number of retailers and bins
     expected_retailers = 4  # Walmart, Target, Amazon, Best Buy
     assert len(result_ax.get_xticks()) == expected_retailers
 
@@ -355,29 +314,20 @@ def test_plot_adds_source_text(simple_price_dataframe):
     assert source_text in rendered
 
 
-def test_plot_with_kwargs(simple_price_dataframe, mocker):
-    """Test that additional kwargs are passed to scatter plot."""
-    # Mock ax.scatter to capture kwargs
-    mock_scatter = mocker.patch("matplotlib.axes.Axes.scatter")
+def test_plot_with_kwargs(simple_price_dataframe):
+    """Additional kwargs (e.g. alpha) are forwarded to the underlying scatter collection."""
+    custom_alpha = 0.8
 
-    price.plot(
+    result_ax = price.plot(
         df=simple_price_dataframe,
         value_col="unit_price",
         group_col="retailer",
         bins=3,
-        alpha=0.8,
-        s=200,
-        marker="^",
+        alpha=custom_alpha,
     )
 
-    # Verify scatter was called with the custom kwargs
-    mock_scatter.assert_called()
-
-    # Check that our custom kwargs were passed through
-    # Note: alpha and s are handled specially, but marker should pass through
-    call_kwargs = mock_scatter.call_args[1]
-    assert "marker" in call_kwargs
-    assert call_kwargs["marker"] == "^"
+    collection = result_ax.collections[0]
+    assert collection.get_alpha() == custom_alpha
 
 
 def test_plot_raises_error_when_no_data_in_bins(simple_price_dataframe):
@@ -393,109 +343,70 @@ def test_plot_raises_error_when_no_data_in_bins(simple_price_dataframe):
         )
 
 
-def test_percentages_sum_to_100_for_each_group(mocker):
-    """Test that percentages calculated by the plot function for each group sum to 100%."""
-    # Create test data with known distribution
+def test_percentages_sum_to_100_for_each_group():
+    """Per-group bubble sizes (proportions times scale_factor) sum to one full scale per retailer."""
     df = pd.DataFrame(
         {
-            "unit_price": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],  # 8 items
-            "retailer": ["Walmart", "Walmart", "Walmart", "Walmart", "Target", "Target", "Target", "Target"],  # 4 each
+            "unit_price": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            "retailer": ["Walmart", "Walmart", "Walmart", "Walmart", "Target", "Target", "Target", "Target"],
         },
     )
-
-    # Mock the scatter plot to capture the actual size values (percentages) being plotted
-    mock_scatter = mocker.patch("matplotlib.axes.Axes.scatter")
-
-    # Set a known scale factor for testing
     scale_factor = 1000
+    floating_point_tolerance = 0.001
 
-    # Call the actual plot function with known scale factor
-    price.plot(
+    result_ax = price.plot(
         df=df,
         value_col="unit_price",
         group_col="retailer",
-        bins=[1.0, 3.0, 5.0, 7.0, 9.0],  # 4 bins
+        bins=[1.0, 3.0, 5.0, 7.0, 9.0],
         s=scale_factor,
     )
 
-    # Extract the actual data passed to scatter
-    mock_scatter.assert_called_once()
-    scatter_call = mock_scatter.call_args
-    sizes = scatter_call.kwargs["s"]
-    x_positions = scatter_call[0][0]  # retailer positions
+    # All bubbles share a single PathCollection; offsets give x (retailer index) and
+    # y (bin index), and sizes are proportions scaled by `scale_factor`.
+    collection = result_ax.collections[0]
+    offsets = collection.get_offsets()
+    sizes = collection.get_sizes()
+    x_positions = offsets[:, 0]
 
-    # Group sizes by retailer position
-    walmart_sizes = [sizes[i] for i, x in enumerate(x_positions) if x == 0]  # x=0 is Walmart
-    target_sizes = [sizes[i] for i, x in enumerate(x_positions) if x == 1]  # x=1 is Target
+    rendered = pd.DataFrame({"x": x_positions, "size": sizes})
+    per_group_totals = rendered.groupby("x")["size"].sum() / scale_factor
 
-    # Test that bubble sizes for each group sum to 1.0 (100%) when divided by scale factor
-    # With absolute scaling: scaled_size = proportion_value * scale_factor
-    # So: sum(scaled_sizes) / scale_factor should equal 1.0 for each group
-
-    walmart_proportion_sum = sum(walmart_sizes) / scale_factor
-    target_proportion_sum = sum(target_sizes) / scale_factor
-
-    # Both groups should sum to 1.0 (within floating point tolerance)
-    tolerance = 0.001  # 0.1% tolerance for floating point precision
-    assert abs(walmart_proportion_sum - 1.0) < tolerance, (
-        f"Walmart proportions should sum to 1.0, got {walmart_proportion_sum}"
-    )
-    assert abs(target_proportion_sum - 1.0) < tolerance, (
-        f"Target proportions should sum to 1.0, got {target_proportion_sum}"
-    )
-
-    # Verify that all non-zero sizes were plotted (no data should be filtered incorrectly)
-    assert len(sizes) > 0, "Should have plotted some bubbles"
-    assert all(s > 0 for s in sizes), "All plotted bubbles should have positive size"
+    assert all(abs(total - 1.0) < floating_point_tolerance for total in per_group_totals)
+    assert (sizes > 0).all()
 
 
-def test_individual_percentage_calculations_are_correct(mocker):
-    """Test that the plot function calculates exact proportions correctly with known data distribution.
+def test_individual_percentage_calculations_are_correct():
+    """Each (retailer, bin) bubble has the exact proportion expected from the input distribution.
 
-    Includes edge case testing with a third retailer having 100% in one band and 0% in others.
+    Includes the edge case of a third retailer with 100% in one band and 0% in the others.
     """
-    # Create test data with known, predictable distribution that includes edge cases
     df = pd.DataFrame(
         {
-            "unit_price": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.5],  # 9 items total
-            "retailer": ["Walmart"] * 4
-            + ["Target"] * 4
-            + ["Amazon"],  # Walmart: 4 items, Target: 4 items, Amazon: 1 item
+            "unit_price": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.5],
+            "retailer": ["Walmart"] * 4 + ["Target"] * 4 + ["Amazon"],
         },
     )
-    scale_factor = 800  # Default s_scale
+    scale_factor = 800
 
-    # Mock scatter to capture the actual proportion values being plotted
-    mock_scatter = mocker.patch("matplotlib.axes.Axes.scatter")
-
-    # Call the actual plot function with bins that create predictable distributions
-    price.plot(
+    result_ax = price.plot(
         df=df,
         value_col="unit_price",
         group_col="retailer",
-        bins=[0.0, 2.5, 6.5, 9.0, 10.0],  # 4 bins: [0-2.5], (2.5-6.5], (6.5-9], (9-10]
+        bins=[0.0, 2.5, 6.5, 9.0, 10.0],
         s=scale_factor,
     )
 
-    # Extract the actual data passed to scatter
-    mock_scatter.assert_called_once()
-    scatter_call = mock_scatter.call_args
-    x_data = scatter_call[0][0]  # x coordinates (retailers)
-    y_data = scatter_call[0][1]  # y coordinates (bins)
-    sizes = scatter_call.kwargs["s"]  # sizes (scaled proportions)
-
-    # Expected distribution with bins [0.0, 2.5, 6.5, 9.0, 10.0]:
-    # Walmart [1,2,3,4]: bin0=[1,2] (2/4=50%), bin1=[3,4] (2/4=50%), bin2=[] (0%), bin3=[] (0%)
-    # Target [5,6,7,8]: bin0=[] (0%), bin1=[5,6] (2/4=50%), bin2=[7,8] (2/4=50%), bin3=[] (0%)
-    # Amazon [9.5]: bin0=[] (0%), bin1=[] (0%), bin2=[] (0%), bin3=[9.5] (1/1=100%)
-
-    # Retailer names in alphabetical order (same as pandas groupby)
-    # Amazon=0, Target=1, Walmart=2
-    expected_data = (
+    # Pandas groupby orders retailers alphabetically: Amazon=0, Target=1, Walmart=2.
+    # Distribution per retailer over bins (1-indexed for display, 0-indexed here):
+    #   Walmart [1,2,3,4]:  bin0=2/4, bin1=2/4, bin2=0,   bin3=0
+    #   Target  [5,6,7,8]:  bin0=0,   bin1=2/4, bin2=2/4, bin3=0
+    #   Amazon  [9.5]:      bin0=0,   bin1=0,   bin2=0,   bin3=1/1
+    expected = (
         pd.DataFrame(
             {
-                "x": [2, 2, 1, 1, 0],  # Walmart, Walmart, Target, Target, Amazon
-                "y": [0, 1, 1, 2, 3],  # bin indices
+                "x": np.array([2, 2, 1, 1, 0], dtype=float),
+                "y": np.array([0, 1, 1, 2, 3], dtype=float),
                 "size": np.array([0.5, 0.5, 0.5, 0.5, 1.0]) * scale_factor,
             },
         )
@@ -503,18 +414,12 @@ def test_individual_percentage_calculations_are_correct(mocker):
         .reset_index(drop=True)
     )
 
-    # Reconstruct actual data from scatter call
-    actual_data = (
-        pd.DataFrame(
-            {
-                "x": x_data,
-                "y": y_data,
-                "size": sizes,
-            },
-        )
+    collection = result_ax.collections[0]
+    offsets = collection.get_offsets()
+    actual = (
+        pd.DataFrame({"x": offsets[:, 0], "y": offsets[:, 1], "size": collection.get_sizes()})
         .sort_values(["x", "y"])
         .reset_index(drop=True)
     )
 
-    # Compare expected vs actual
-    pd.testing.assert_frame_equal(actual_data, expected_data)
+    pd.testing.assert_frame_equal(actual, expected)

--- a/tests/plots/test_price.py
+++ b/tests/plots/test_price.py
@@ -1,7 +1,5 @@
 """Tests for the price architecture bubble plot module."""
 
-from itertools import cycle
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -9,7 +7,6 @@ from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 
 from openretailscience.plots import price
-from openretailscience.plots.styles import graph_utils as gu
 
 
 @pytest.fixture(autouse=True)
@@ -48,25 +45,6 @@ def simple_price_dataframe():
         "retailer": ["Walmart", "Walmart", "Target", "Target", "Amazon", "Amazon"],
     }
     return pd.DataFrame(data)
-
-
-@pytest.fixture
-def _mock_color_generators(mocker):
-    """Mock the color generators for single and multi color maps."""
-    single_color_gen = cycle(["#FF0000"])  # Mocked single-color generator (e.g., red)
-    multi_color_gen = cycle(["#FF0000", "#00FF00", "#0000FF", "#FFFF00"])  # Mocked multi-color generator
-    mocker.patch("openretailscience.plots.styles.colors.get_single_color_cmap", return_value=single_color_gen)
-    mocker.patch("openretailscience.plots.styles.colors.get_multi_color_cmap", return_value=multi_color_gen)
-
-
-@pytest.fixture
-def _mock_gu_functions(mocker):
-    """Mock the standard graph utilities functions."""
-    mocker.patch(
-        "openretailscience.plots.styles.graph_utils.standard_graph_styles", side_effect=lambda ax, **kwargs: ax
-    )
-    mocker.patch("openretailscience.plots.styles.graph_utils.standard_tick_styles", side_effect=lambda ax: ax)
-    mocker.patch("openretailscience.plots.styles.graph_utils.add_source_text", side_effect=lambda ax, source_text: ax)
 
 
 def test_plot_with_empty_dataframe():
@@ -334,9 +312,8 @@ def test_plot_with_country_grouping(sample_price_dataframe):
     assert len(result_ax.get_xticks()) == expected_countries
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_calls_standard_styling(simple_price_dataframe):
-    """Test that standard graph styling functions are called."""
+    """Title, axis labels and the supplied legend_title are rendered on the axes."""
     title = "Test Title"
     x_label = "Test X Label"
     y_label = "Test Y Label"
@@ -354,22 +331,16 @@ def test_plot_calls_standard_styling(simple_price_dataframe):
         move_legend_outside=True,
     )
 
-    gu.standard_graph_styles.assert_called_once_with(
-        ax=result_ax,
-        title=title,
-        x_label=x_label,
-        y_label=y_label,
-        legend_title=None,
-        move_legend_outside=False,
-        show_legend=False,
-    )
-
-    gu.standard_tick_styles.assert_called_once_with(ax=result_ax)
+    assert result_ax.get_title() == title
+    assert result_ax.get_xlabel() == x_label
+    assert result_ax.get_ylabel() == y_label
+    legend = result_ax.get_legend()
+    assert legend is not None
+    assert legend.get_title().get_text() == legend_title
 
 
-@pytest.mark.usefixtures("_mock_color_generators", "_mock_gu_functions")
 def test_plot_adds_source_text(simple_price_dataframe):
-    """Test that source text is added when provided."""
+    """The price plot renders source_text as a figure-level text element."""
     source_text = "Source: Test Data"
 
     result_ax = price.plot(
@@ -380,7 +351,8 @@ def test_plot_adds_source_text(simple_price_dataframe):
         source_text=source_text,
     )
 
-    gu.add_source_text.assert_called_once_with(ax=result_ax, source_text=source_text)
+    rendered = [t.get_text() for t in result_ax.figure.texts]
+    assert source_text in rendered
 
 
 def test_plot_with_kwargs(simple_price_dataframe, mocker):

--- a/tests/plots/test_scatter.py
+++ b/tests/plots/test_scatter.py
@@ -181,10 +181,8 @@ def test_plot_single_column_series(sample_sales_dataframe):
     assert len(offsets) == len(sales_series), f"Expected {len(sales_series)} points from series, got {len(offsets)}"
 
 
-def test_plot_with_labels_single_series(sample_product_dataframe, mocker):
-    """Test scatter plot with labels on single series."""
-    mock_textalloc = mocker.patch("openretailscience.plots.scatter.ta.allocate")
-
+def test_plot_with_labels_single_series(sample_product_dataframe):
+    """Each row's label_col value is rendered as a Text annotation on the axes."""
     result_ax = scatter.plot(
         df=sample_product_dataframe,
         value_col="units_sold",
@@ -195,58 +193,16 @@ def test_plot_with_labels_single_series(sample_product_dataframe, mocker):
         y_label="Units Sold",
     )
 
-    # Verify basic plot structure
-    assert isinstance(result_ax, Axes)
     assert result_ax.get_title() == "Product Performance"
     assert result_ax.get_xlabel() == "Price"
     assert result_ax.get_ylabel() == "Units Sold"
 
-    # Verify scatter plot was created with correct data points
-    collections = [child for child in result_ax.get_children() if hasattr(child, "get_offsets")]
-    assert len(collections) >= 1, "No scatter plot collections found"
-    offsets = collections[0].get_offsets()
-    assert len(offsets) == len(sample_product_dataframe)
-
-    # Check that textalloc was called with correct parameters
-    mock_textalloc.assert_called_once()
-    args, _kwargs = mock_textalloc.call_args
-
-    ax_arg = args[0]
-    x_coords = args[1]
-    y_coords = args[2]
-    labels = args[3]
-
-    assert ax_arg == result_ax
-    assert len(x_coords) == len(sample_product_dataframe), (
-        f"Expected {len(sample_product_dataframe)} x coordinates, got {len(x_coords)}"
-    )
-    assert len(y_coords) == len(sample_product_dataframe), (
-        f"Expected {len(sample_product_dataframe)} y coordinates, got {len(y_coords)}"
-    )
-    assert len(labels) == len(sample_product_dataframe), (
-        f"Expected {len(sample_product_dataframe)} labels, got {len(labels)}"
-    )
-
-    # Verify labels match expected product names
-    expected_labels = sample_product_dataframe["product_name"].tolist()
-    expected_prices = sample_product_dataframe["price"].tolist()
-    expected_units = sample_product_dataframe["units_sold"].tolist()
-
-    assert set(labels) == set(expected_labels), f"Labels don't match: expected {expected_labels}, got {labels}"
-
-    # Verify coordinates match data points
-    assert list(x_coords) == expected_prices, (
-        f"X coordinates don't match: expected {expected_prices}, got {list(x_coords)}"
-    )
-    assert list(y_coords) == expected_units, (
-        f"Y coordinates don't match: expected {expected_units}, got {list(y_coords)}"
-    )
+    rendered_labels = {t.get_text() for t in result_ax.texts}
+    assert rendered_labels == set(sample_product_dataframe["product_name"])
 
 
-def test_plot_with_labels_grouped_series(sample_store_dataframe, mocker):
-    """Test scatter plot with labels on grouped series."""
-    mock_textalloc = mocker.patch("openretailscience.plots.scatter.ta.allocate")
-
+def test_plot_with_labels_grouped_series(sample_store_dataframe):
+    """Grouped scatter plot still renders one Text annotation per row."""
     result_ax = scatter.plot(
         df=sample_store_dataframe,
         value_col="revenue",
@@ -258,49 +214,16 @@ def test_plot_with_labels_grouped_series(sample_store_dataframe, mocker):
         y_label="Revenue",
     )
 
-    # Verify basic plot structure
-    assert isinstance(result_ax, Axes)
     assert result_ax.get_title() == "Store Performance by Region"
     assert result_ax.get_xlabel() == "Customer Count"
     assert result_ax.get_ylabel() == "Revenue"
 
-    # Verify scatter plot collections were created for groups
+    # One scatter collection per region (separate styling per group).
     collections = [child for child in result_ax.get_children() if hasattr(child, "get_offsets")]
-    assert len(collections) >= 1, "No scatter plot collections found"
+    assert len(collections) == sample_store_dataframe["region"].nunique()
 
-    # For grouped scatter plots, each group creates its own collection
-    # We expect one collection per unique region
-    unique_regions = sample_store_dataframe["region"].nunique()
-    assert len(collections) == unique_regions, (
-        f"Expected {unique_regions} collections for {unique_regions} regions, got {len(collections)}"
-    )
-
-    # Check that textalloc was called with correct parameters
-    mock_textalloc.assert_called_once()
-    args, _kwargs = mock_textalloc.call_args
-
-    ax_arg = args[0]
-    x_coords = args[1]
-    y_coords = args[2]
-    labels = args[3]
-
-    assert ax_arg == result_ax
-    assert len(x_coords) == len(sample_store_dataframe), (
-        f"Expected {len(sample_store_dataframe)} x coordinates, got {len(x_coords)}"
-    )
-    assert len(y_coords) == len(sample_store_dataframe), (
-        f"Expected {len(sample_store_dataframe)} y coordinates, got {len(y_coords)}"
-    )
-    assert len(labels) == len(sample_store_dataframe), (
-        f"Expected {len(sample_store_dataframe)} labels, got {len(labels)}"
-    )
-
-    # Verify labels contain correct store IDs
-    expected_store_ids = set(sample_store_dataframe["store_id"].tolist())
-    actual_labels = set(labels)
-    assert actual_labels == expected_store_ids, (
-        f"Store ID labels don't match: expected {expected_store_ids}, got {actual_labels}"
-    )
+    rendered_labels = {t.get_text() for t in result_ax.texts}
+    assert rendered_labels == set(sample_store_dataframe["store_id"])
 
 
 def test_plot_with_labels_custom_kwargs(sample_product_dataframe, mocker):
@@ -384,11 +307,8 @@ def test_plot_label_validation_errors(sample_product_dataframe, value_col, label
         )
 
 
-def test_plot_labels_with_nan_values(sample_product_dataframe, mocker):
-    """Test scatter plot with labels when data contains NaN values."""
-    mock_textalloc = mocker.patch("openretailscience.plots.scatter.ta.allocate")
-
-    # Add some NaN values to test filtering
+def test_plot_labels_with_nan_values(sample_product_dataframe):
+    """Rows with NaN in value_col or label_col are dropped before labels are rendered."""
     df_with_nan = sample_product_dataframe.copy()
     df_with_nan.loc[1, "units_sold"] = np.nan
     df_with_nan.loc[3, "product_name"] = np.nan
@@ -401,19 +321,12 @@ def test_plot_labels_with_nan_values(sample_product_dataframe, mocker):
         title="Product Performance with NaN values",
     )
 
-    assert isinstance(result_ax, Axes)
-    mock_textalloc.assert_called_once()
-    args, _kwargs = mock_textalloc.call_args
-    labels = args[3]
-    # Should have fewer texts due to NaN filtering
     expected_non_nan_count = len(df_with_nan.dropna(subset=["units_sold", "product_name"]))
-    assert len(labels) == expected_non_nan_count
+    assert len(result_ax.texts) == expected_non_nan_count
 
 
-def test_plot_labels_using_index_as_x(sample_product_dataframe, mocker):
-    """Test scatter plot with labels using index as x-axis."""
-    mock_textalloc = mocker.patch("openretailscience.plots.scatter.ta.allocate")
-
+def test_plot_labels_using_index_as_x(sample_product_dataframe):
+    """When x_col is omitted, every row still gets a label rendered against the index."""
     result_ax = scatter.plot(
         df=sample_product_dataframe,
         value_col="units_sold",
@@ -421,30 +334,12 @@ def test_plot_labels_using_index_as_x(sample_product_dataframe, mocker):
         title="Product Performance using Index",
     )
 
-    # Verify basic plot structure
-    assert isinstance(result_ax, Axes)
     assert result_ax.get_title() == "Product Performance using Index"
-
-    # Verify scatter plot was created
-    collections = [child for child in result_ax.get_children() if hasattr(child, "get_offsets")]
-    assert len(collections) >= 1, "No scatter plot collections found"
-
-    # Verify data points match input series length
-    offsets = collections[0].get_offsets()
-    assert len(offsets) == len(sample_product_dataframe), (
-        f"Expected {len(sample_product_dataframe)} points, got {len(offsets)}"
-    )
-
-    mock_textalloc.assert_called_once()
-    args, _kwargs = mock_textalloc.call_args
-    labels = args[3]
-    assert len(labels) == len(sample_product_dataframe)
+    assert {t.get_text() for t in result_ax.texts} == set(sample_product_dataframe["product_name"])
 
 
-def test_plot_without_labels_no_textalloc_called(sample_product_dataframe, mocker):
-    """Test that textalloc is not called when no labels are specified."""
-    mock_textalloc = mocker.patch("openretailscience.plots.scatter.ta.allocate")
-
+def test_plot_without_labels_no_textalloc_called(sample_product_dataframe):
+    """Without label_col the axes carry no Text annotations."""
     result_ax = scatter.plot(
         df=sample_product_dataframe,
         value_col="units_sold",
@@ -452,9 +347,7 @@ def test_plot_without_labels_no_textalloc_called(sample_product_dataframe, mocke
         title="Product Performance without Labels",
     )
 
-    assert isinstance(result_ax, Axes)
-    # textalloc should not have been called
-    mock_textalloc.assert_not_called()
+    assert len(result_ax.texts) == 0
 
 
 def test_plot_adds_source_text(sample_sales_dataframe):
@@ -713,10 +606,8 @@ class TestBubbleChartFeature:
         expected_sizes = df["store_sqft"].to_numpy()
         assert np.array_equal(sizes, expected_sizes), "Sizes should match data including zero values"
 
-    def test_bubble_chart_with_labels(self, bubble_chart_dataframe, mocker):
-        """Test bubble chart works correctly with point labels."""
-        mock_textalloc = mocker.patch("openretailscience.plots.scatter.ta.allocate")
-
+    def test_bubble_chart_with_labels(self, bubble_chart_dataframe):
+        """Bubble chart sizes come from size_col and store_id labels are rendered as text annotations."""
         result_ax = scatter.plot(
             df=bubble_chart_dataframe,
             x_col="sales",
@@ -726,21 +617,12 @@ class TestBubbleChartFeature:
             title="Labeled Bubble Chart",
         )
 
-        assert isinstance(result_ax, Axes)
-
-        # Verify sizes from size_col
         collections = [child for child in result_ax.get_children() if hasattr(child, "get_offsets")]
-        assert len(collections) >= 1, "No scatter plot collections found"
-        sizes = collections[0].get_sizes()
-        expected_sizes = bubble_chart_dataframe["store_sqft"].to_numpy()
-        assert np.array_equal(sizes, expected_sizes), "Sizes should match store_sqft values"
+        assert len(collections) >= 1
+        assert np.array_equal(collections[0].get_sizes(), bubble_chart_dataframe["store_sqft"].to_numpy())
 
-        # Verify labels were applied with correct values
-        mock_textalloc.assert_called_once()
-        args, _kwargs = mock_textalloc.call_args
-        labels = args[3]
-        expected_labels = set(bubble_chart_dataframe["store_id"].astype(str).tolist())
-        assert set(labels) == expected_labels, f"Labels don't match: expected {expected_labels}, got {set(labels)}"
+        rendered_labels = {t.get_text() for t in result_ax.texts}
+        assert rendered_labels == set(bubble_chart_dataframe["store_id"].astype(str))
 
     def test_bubble_chart_x_col_equals_size_col(self, bubble_chart_dataframe):
         """Test bubble chart when x_col and size_col reference the same column."""

--- a/tests/plots/test_venn.py
+++ b/tests/plots/test_venn.py
@@ -6,7 +6,6 @@ import pytest
 from matplotlib.axes import Axes
 
 from openretailscience.plots import venn
-from openretailscience.plots.styles import graph_utils as gu
 
 
 @pytest.fixture(autouse=True)
@@ -26,15 +25,6 @@ def sample_venn_dataframe():
     return pd.DataFrame(data)
 
 
-@pytest.fixture
-def _mock_gu_functions(mocker):
-    mocker.patch(
-        "openretailscience.plots.styles.graph_utils.add_source_text",
-        side_effect=lambda ax, source_text, is_venn_diagram=False: ax,
-    )
-
-
-@pytest.mark.usefixtures("_mock_gu_functions")
 def test_plot_two_set_venn(sample_venn_dataframe):
     """Test Venn diagram plotting with two sets."""
     result_ax = venn.plot(
@@ -46,7 +36,6 @@ def test_plot_two_set_venn(sample_venn_dataframe):
     assert len(result_ax.get_children()) > 0
 
 
-@pytest.mark.usefixtures("_mock_gu_functions")
 def test_plot_three_set_venn():
     """Test Venn diagram plotting with three sets."""
     df = pd.DataFrame(
@@ -64,7 +53,6 @@ def test_plot_three_set_venn():
     assert len(result_ax.get_children()) > 0
 
 
-@pytest.mark.usefixtures("_mock_gu_functions")
 def test_plot_invalid_sets():
     """Test Venn plot with invalid number of sets (should raise ValueError)."""
     df = pd.DataFrame({"groups": [(1,)], "percent": [1.0]})
@@ -72,9 +60,8 @@ def test_plot_invalid_sets():
         venn.plot(df=df, labels=["Set A"])
 
 
-@pytest.mark.usefixtures("_mock_gu_functions")
 def test_plot_adds_source_text(sample_venn_dataframe):
-    """Test Venn diagram adds source text."""
+    """The Venn diagram renders source_text as a figure-level text element."""
     source_text = "Source: Test Data"
     result_ax = venn.plot(
         df=sample_venn_dataframe,
@@ -82,7 +69,8 @@ def test_plot_adds_source_text(sample_venn_dataframe):
         title="Test Venn Diagram with Source",
         source_text=source_text,
     )
-    gu.add_source_text.assert_called_once_with(ax=result_ax, source_text=source_text, is_venn_diagram=True)
+    rendered = [t.get_text() for t in result_ax.figure.texts]
+    assert source_text in rendered
 
 
 def test_venn_default_ax(sample_venn_dataframe):


### PR DESCRIPTION
## Summary

The shared `_mock_gu_functions` fixtures across `tests/plots/` patched `standard_graph_styles`, `standard_tick_styles`, `add_source_text`, and `apply_hatches` so tests could read `.call_args.kwargs[...]` to verify the plot module forwarded arguments. That's an over-mock — it verifies plumbing, not what the chart actually renders, and pinning the kwarg shape made future call-signature changes in `graph_utils` ripple into unrelated test files.

This PR replaces every introspection assertion with one that reads the rendered output, then drops the now-unused fixtures (and the companion `_mock_color_generators`) from every file where the remaining tests pass without them.

### Behavioural rewrites

| Was checked via mock | Now checked on the rendered axes/figure |
|---|---|
| `gu.add_source_text.assert_called_once_with(...)` | `source_text in [t.get_text() for t in ax.figure.texts]` |
| `gu.standard_graph_styles.call_args.kwargs["title"]` | `ax.get_title()` / `ax.figure.texts` |
| `gu.standard_graph_styles.call_args.kwargs["x_label"/"y_label"]` | `ax.get_xlabel()` / `ax.get_ylabel()` |
| `gu.standard_graph_styles.call_args.kwargs["legend_title"]` | `ax.get_legend().get_title().get_text()` |
| `move_legend_outside=True` forwarded | `ax.get_legend().get_bbox_to_anchor()` matches `PlotStyleHelper().legend_bbox_to_anchor` |
| `gu.apply_hatches.assert_called_once_with(...)` | every `patch.get_hatch()` is non-None |
| `pandas.DataFrame.plot` call kwargs (linewidth/alpha/zorder/width) | rendered line/bar properties on `ax.get_lines()` / `ax.patches` |

### Other cleanups

- Two near-duplicate tests in `test_line.py` (legend_title with vs. without `move_legend_outside`) collapse into one parametrized test.
- The two `*_calls_dataframe_plot` introspection tests in `test_histogram.py` collapse into one parametrized `test_histogram_legend_and_alpha_by_grouping` that asserts the rendered legend visibility and patch alpha.

## Test plan

- [x] `uv run pytest` — all touched test files pass on the rebased main
- [x] `uv run pre-commit run --all-files` — ruff, ruff-format, nbstripout, pytest, etc. all clean
- [x] No behaviour change to the plot modules; only test-side rewrites

## Net diff

`9 files changed, 140 insertions(+), 465 deletions(-)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)