### PR TITLE
ci: wire integration test workflows into release pipeline

### DIFF
--- a/.github/workflows/bigquery-integration.yml
+++ b/.github/workflows/bigquery-integration.yml
@@ -2,24 +2,7 @@ name: BigQuery Integration Tests
 
 on:
   workflow_dispatch:
-    inputs:
-      test_suite:
-        type: choice
-        description: Test Suite to Run
-        default: "all"
-        options:
-          - all
-          - cohort_analysis
-          - composite_rank
-          - cross_shop
-          - customer_decision_hierarchy
-          - haversine
-          - hml_segmentation
-          - product_association
-          - revenue_tree
-          - rfm_segmentation
-          - segstats_segmentation
-          - threshold_segmentation
+  workflow_call:
 
 permissions:
   contents: read
@@ -32,6 +15,7 @@ jobs:
   integration-tests:
     name: Run BigQuery Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,11 +41,6 @@ jobs:
 
       - name: Run Integration Tests
         env:
-          TEST_SUITE: ${{ inputs.test_suite }}
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
-          if [ "$TEST_SUITE" == "all" ]; then
-            uv run pytest tests/integration -k "bigquery" -v
-          else
-            uv run pytest tests/integration -k "bigquery and $TEST_SUITE" -v
-          fi
+          uv run pytest tests/integration -k "bigquery" -v

--- a/.github/workflows/bigquery-integration.yml
+++ b/.github/workflows/bigquery-integration.yml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: "bigquery-tests"
-  cancel-in-progress: true
-
 jobs:
   integration-tests:
     name: Run BigQuery Integration Tests

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -17,6 +17,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pyspark-integration.yml
+++ b/.github/workflows/pyspark-integration.yml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: "pyspark-tests"
-  cancel-in-progress: true
-
 jobs:
   integration-tests:
     name: Run PySpark Integration Tests

--- a/.github/workflows/pyspark-integration.yml
+++ b/.github/workflows/pyspark-integration.yml
@@ -2,26 +2,7 @@ name: PySpark Integration Tests
 
 on:
   workflow_dispatch:
-    inputs:
-      test_suite:
-        type: choice
-        description: Test Suite to Run
-        default: "all"
-        options:
-          - all
-          - cohort_analysis
-          - composite_rank
-          - cross_shop
-          - customer_decision_hierarchy
-          - date
-          - filter_and_label
-          - haversine
-          - hml_segmentation
-          - product_association
-          - revenue_tree
-          - rfm_segmentation
-          - segstats_segmentation
-          - threshold_segmentation
+  workflow_call:
 
 permissions:
   contents: read
@@ -34,6 +15,7 @@ jobs:
   integration-tests:
     name: Run PySpark Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,11 +35,5 @@ jobs:
           uv sync
 
       - name: Run Integration Tests
-        env:
-          TEST_SUITE: ${{ inputs.test_suite }}
         run: |
-          if [ "$TEST_SUITE" == "all" ]; then
-            uv run pytest tests/integration -k "pyspark" -v
-          else
-            uv run pytest tests/integration -k "pyspark and $TEST_SUITE" -v
-          fi
+          uv run pytest tests/integration -k "pyspark" -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
   pre-commit:
     name: Pre-Commit Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,55 +41,23 @@ jobs:
 
   bigquery-integration-tests:
     name: BigQuery Integration Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install uv Package
-        run: |
-          pip install --upgrade pip
-          pip install uv==0.5.30
-      - name: Install Dependencies
-        run: |
-          uv sync
-      - name: Set up GCP Authentication
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - name: Run BigQuery Integration Tests
-        env:
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-        run: |
-          uv run pytest tests/integration -k "bigquery" -v
+    uses: ./.github/workflows/bigquery-integration.yml
+    secrets: inherit
 
   pyspark-integration-tests:
     name: PySpark Integration Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install uv Package
-        run: |
-          pip install --upgrade pip
-          pip install uv==0.5.30
-      - name: Install Dependencies
-        run: |
-          uv sync
-      - name: Run PySpark Integration Tests
-        run: |
-          uv run pytest tests/integration -k "pyspark" -v
+    uses: ./.github/workflows/pyspark-integration.yml
+    secrets: inherit
+
+  snowflake-integration-tests:
+    name: Snowflake Integration Tests
+    uses: ./.github/workflows/snowflake-integration.yml
+    secrets: inherit
 
   multi-python-tests:
     name: Multi-Python Version Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -114,7 +83,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [pre-commit, bigquery-integration-tests, pyspark-integration-tests, multi-python-tests]
+    timeout-minutes: 15
+    needs: [pre-commit, bigquery-integration-tests, pyspark-integration-tests, snowflake-integration-tests, multi-python-tests]
     env:
       CI_COMMIT_MESSAGE: Continuous Integration Version Bump ${{ inputs.release }}
     steps:
@@ -196,6 +166,7 @@ jobs:
   pypi-publish:
     name: Upload release to PyPI
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     environment:
       name: production

--- a/.github/workflows/snowflake-integration.yml
+++ b/.github/workflows/snowflake-integration.yml
@@ -7,10 +7,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: "snowflake-tests"
-  cancel-in-progress: true
-
 jobs:
   integration-tests:
     name: Run Snowflake Integration Tests

--- a/.github/workflows/snowflake-integration.yml
+++ b/.github/workflows/snowflake-integration.yml
@@ -2,26 +2,7 @@ name: Snowflake Integration Tests
 
 on:
   workflow_dispatch:
-    inputs:
-      test_suite:
-        type: choice
-        description: Test Suite to Run
-        default: "all"
-        options:
-          - all
-          - cohort_analysis
-          - composite_rank
-          - cross_shop
-          - customer_decision_hierarchy
-          - date
-          - filter_and_label
-          - haversine
-          - hml_segmentation
-          - product_association
-          - revenue_tree
-          - rfm_segmentation
-          - segstats_segmentation
-          - threshold_segmentation
+  workflow_call:
 
 permissions:
   contents: read
@@ -59,15 +40,16 @@ jobs:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Fetch Snowflake CI Key
+        env:
+          GCP_INFRA_PROJECT_ID: ${{ secrets.GCP_INFRA_PROJECT_ID }}
         run: |
           umask 077
           gcloud secrets versions access latest \
             --secret=snowflake-ci-private-key \
-            --project=pyretailscience-infra > /tmp/snowflake_ci_key.p8
+            --project="$GCP_INFRA_PROJECT_ID" > /tmp/snowflake_ci_key.p8
 
       - name: Run Integration Tests
         env:
-          TEST_SUITE: ${{ inputs.test_suite }}
           SNOWFLAKE_CI_ACCOUNT: ${{ secrets.SNOWFLAKE_CI_ACCOUNT }}
           SNOWFLAKE_CI_USER: ${{ secrets.SNOWFLAKE_CI_USER }}
           SNOWFLAKE_CI_WAREHOUSE: ${{ secrets.SNOWFLAKE_CI_WAREHOUSE }}
@@ -75,11 +57,7 @@ jobs:
           SNOWFLAKE_CI_SCHEMA: ${{ secrets.SNOWFLAKE_CI_SCHEMA }}
           SNOWFLAKE_CI_PRIVATE_KEY_PATH: /tmp/snowflake_ci_key.p8
         run: |
-          if [ "$TEST_SUITE" == "all" ]; then
-            uv run pytest tests/integration -k "snowflake" -v
-          else
-            uv run pytest tests/integration -k "snowflake and $TEST_SUITE" -v
-          fi
+          uv run pytest tests/integration -k "snowflake" -v
 
       - name: Cleanup private key
         if: always()


### PR DESCRIPTION
## Summary

Wires the database integration test workflows into the release pipeline and removes per-run configuration that was only useful for manual debugging.

- Converted the BigQuery, PySpark, and Snowflake integration workflows into **reusable workflows** (`workflow_call`), dropping the manual `test_suite` choice input that ran a subset of tests.
- `release.yml` now **calls all three** integration workflows (previously it inlined BigQuery and PySpark and omitted Snowflake) and gates `build` on the Snowflake job as well.
- Added job **timeouts** across `release.yml` and the integration workflows so hung runs fail fast.
- Replaced the hardcoded `pyretailscience-infra` GCP project with a **`GCP_INFRA_PROJECT_ID` secret** when fetching the Snowflake CI key.

## Test plan

- [ ] Trigger a release run and confirm all three integration workflows execute and gate the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)