### PR TITLE
refactor: migrate inline column validation to validate_columns

### DIFF
--- a/openretailscience/analysis/cohort.py
+++ b/openretailscience/analysis/cohort.py
@@ -41,6 +41,7 @@ import numpy as np
 import pandas as pd
 
 from openretailscience.options import ColumnHelper
+from openretailscience.utils.validation import validate_columns
 
 
 class CohortAnalysis:
@@ -81,11 +82,7 @@ class CohortAnalysis:
             cols.transaction_date,
             aggregation_column,
         ]
-        missing_cols = [col for col in required_cols if col not in df.columns]
-
-        if missing_cols:
-            error_message = f"Missing required columns: {missing_cols}"
-            raise ValueError(error_message)
+        validate_columns(df, required_cols)
 
         self.df = self._calculate_cohorts(
             df=df,

--- a/openretailscience/analysis/cross_shop.py
+++ b/openretailscience/analysis/cross_shop.py
@@ -67,6 +67,7 @@ from matplotlib.axes import Axes, SubplotBase
 
 from openretailscience.options import get_option
 from openretailscience.plots import venn
+from openretailscience.utils.validation import validate_columns
 
 
 class CrossShop:
@@ -180,10 +181,7 @@ class CrossShop:
             group_3_col = group_1_col
 
         required_cols = [group_col, value_col]
-        missing_cols = set(required_cols) - set(df.columns)
-        if len(missing_cols) > 0:
-            msg = f"The following columns are required but missing: {missing_cols}"
-            raise ValueError(msg)
+        validate_columns(df, required_cols)
 
         self.group_count = 2 if group_3_col is None else 3
 

--- a/openretailscience/analysis/customer.py
+++ b/openretailscience/analysis/customer.py
@@ -44,6 +44,7 @@ import operator
 import pandas as pd
 
 from openretailscience.options import ColumnHelper
+from openretailscience.utils.validation import validate_columns
 
 
 class PurchasesPerCustomer:
@@ -67,10 +68,7 @@ class PurchasesPerCustomer:
         """
         cols = ColumnHelper()
         required_cols = [cols.customer_id, cols.transaction_id]
-        missing_cols = set(required_cols) - set(df.columns)
-        if len(missing_cols) > 0:
-            msg = f"The following columns are required but missing: {missing_cols}"
-            raise ValueError(msg)
+        validate_columns(df, required_cols)
 
         self.cust_purchases_s = df.groupby(cols.customer_id)[cols.transaction_id].nunique()
 
@@ -135,10 +133,7 @@ class DaysBetweenPurchases:
         """
         cols = ColumnHelper()
         required_cols = [cols.customer_id, cols.transaction_date]
-        missing_cols = set(required_cols) - set(df.columns)
-        if len(missing_cols) > 0:
-            msg = f"The following columns are required but missing: {missing_cols}"
-            raise ValueError(msg)
+        validate_columns(df, required_cols)
 
         self.purchase_dist_s = self._calculate_days_between_purchases(df)
 
@@ -155,10 +150,7 @@ class DaysBetweenPurchases:
         """
         cols = ColumnHelper()
         required_cols = [cols.customer_id, cols.transaction_date]
-        missing_cols = set(required_cols) - set(df.columns)
-        if len(missing_cols) > 0:
-            msg = f"The following columns are required but missing: {missing_cols}"
-            raise ValueError(msg)
+        validate_columns(df, required_cols)
 
         purchase_dist_df = df[[cols.customer_id, cols.transaction_date]].copy()
         purchase_dist_df[cols.transaction_date] = df[cols.transaction_date].dt.floor("D")
@@ -202,10 +194,7 @@ class TransactionChurn:
         """
         cols = ColumnHelper()
         required_cols = [cols.customer_id, cols.transaction_date]
-        missing_cols = set(required_cols) - set(df.columns)
-        if len(missing_cols) > 0:
-            msg = f"The following columns are required but missing: {missing_cols}"
-            raise ValueError(msg)
+        validate_columns(df, required_cols)
 
         purchase_dist_df = df[[cols.customer_id, cols.transaction_date]].copy()
         # Truncate the transaction_date to the day

--- a/openretailscience/analysis/customer_decision_hierarchy.py
+++ b/openretailscience/analysis/customer_decision_hierarchy.py
@@ -74,6 +74,7 @@ from scipy.spatial.distance import squareform
 
 from openretailscience.options import ColumnHelper, get_option
 from openretailscience.plots.styles.styling_helpers import standard_graph_styles
+from openretailscience.utils.validation import validate_columns
 
 
 class CustomerDecisionHierarchy:
@@ -157,10 +158,7 @@ class CustomerDecisionHierarchy:
         """
         cols = ColumnHelper()
         required_cols = [cols.customer_id, cols.transaction_id, product_col]
-        missing_cols = set(required_cols) - set(df.columns)
-        if len(missing_cols) > 0:
-            msg = f"The following columns are required but missing: {missing_cols}"
-            raise ValueError(msg)
+        validate_columns(df, required_cols)
 
         self.random_state = random_state
         self.product_col = product_col

--- a/openretailscience/analysis/gain_loss.py
+++ b/openretailscience/analysis/gain_loss.py
@@ -26,6 +26,7 @@ from matplotlib.axes import Axes, SubplotBase
 from openretailscience.options import ColumnHelper, get_option
 from openretailscience.plots import bar
 from openretailscience.plots.styles.colors import COLORS
+from openretailscience.utils.validation import validate_columns
 
 
 class GainLoss:
@@ -74,10 +75,7 @@ class GainLoss:
             )
 
         required_cols = [get_option("column.customer_id"), value_col] + ([group_col] if group_col is not None else [])
-        missing_cols = set(required_cols) - set(df.columns)
-        if len(missing_cols) > 0:
-            msg = f"The following columns are required but missing: {missing_cols}"
-            raise ValueError(msg)
+        validate_columns(df, required_cols)
 
         self.focus_group_name = focus_group_name
         self.comparison_group_name = comparison_group_name

--- a/openretailscience/analysis/product_association.py
+++ b/openretailscience/analysis/product_association.py
@@ -111,6 +111,7 @@ import pandas as pd
 from ibis import _
 
 from openretailscience.options import get_option
+from openretailscience.utils.validation import validate_columns
 
 
 class ProductAssociation:
@@ -194,10 +195,7 @@ class ProductAssociation:
         self._df: pd.DataFrame | None = None
         group_col = group_col or get_option("column.customer_id")
         required_cols = [group_col, value_col]
-        missing_cols = set(required_cols) - set(df.columns)
-        if len(missing_cols) > 0:
-            msg = f"The following columns are required but missing: {missing_cols}"
-            raise ValueError(msg)
+        validate_columns(df, required_cols)
 
         self.table = self._calc_association(
             df=df,

--- a/openretailscience/analysis/revenue_tree.py
+++ b/openretailscience/analysis/revenue_tree.py
@@ -34,6 +34,7 @@ from openretailscience.options import ColumnHelper, get_option
 from openretailscience.plots.styles import graph_utils as gu
 from openretailscience.plots.tree_diagram import DetailedTreeNode, TreeGrid
 from openretailscience.plugin import plugin_manager
+from openretailscience.utils.validation import validate_columns
 
 
 @plugin_manager.extensible
@@ -253,10 +254,7 @@ class RevenueTree:
         if group_col is not None:
             required_cols.extend(group_col)
 
-        missing_cols = set(required_cols) - set(df.columns)
-        if len(missing_cols) > 0:
-            msg = f"The following columns are required but missing: {missing_cols}"
-            raise ValueError(msg)
+        validate_columns(df, required_cols)
 
         df, p1_index, p2_index = self._agg_data(df, period_col, p1_value, p2_value, group_col)
 

--- a/openretailscience/segmentation/nlr.py
+++ b/openretailscience/segmentation/nlr.py
@@ -53,6 +53,7 @@ import ibis
 import pandas as pd
 
 from openretailscience.options import ColumnHelper
+from openretailscience.utils.validation import validate_columns
 
 SEGMENT_NEW = "New"
 SEGMENT_REPEATING = "Repeating"
@@ -149,10 +150,7 @@ class NLRSegmentation:
         if self._group_col is not None:
             required_cols.extend(self._group_col)
 
-        missing_cols = set(required_cols) - set(df.columns)
-        if len(missing_cols) > 0:
-            msg = f"The following columns are required but missing: {missing_cols}"
-            raise ValueError(msg)
+        validate_columns(df, required_cols)
 
         p1_expr = p1_value if isinstance(p1_value, ibis.Expr) else ibis.literal(p1_value)
         p2_expr = p2_value if isinstance(p2_value, ibis.Expr) else ibis.literal(p2_value)

--- a/openretailscience/segmentation/rfm.py
+++ b/openretailscience/segmentation/rfm.py
@@ -29,7 +29,7 @@ import ibis
 import pandas as pd
 
 from openretailscience.options import ColumnHelper, get_option
-from openretailscience.utils.validation import ensure_ibis_table
+from openretailscience.utils.validation import ensure_ibis_table, validate_columns
 
 
 class RFMSegmentation:
@@ -99,10 +99,7 @@ class RFMSegmentation:
         ]
         df = ensure_ibis_table(df)
 
-        missing_cols = set(required_cols) - set(df.columns)
-        if missing_cols:
-            error_message = f"Missing required columns: {missing_cols}"
-            raise ValueError(error_message)
+        validate_columns(df, required_cols)
 
         if isinstance(current_date, str):
             current_date = datetime.date.fromisoformat(current_date)

--- a/openretailscience/segmentation/segstats.py
+++ b/openretailscience/segmentation/segstats.py
@@ -53,6 +53,7 @@ import ibis
 import pandas as pd
 
 from openretailscience.options import ColumnHelper, get_option
+from openretailscience.utils.validation import validate_columns
 
 __all__ = ["SegTransactionStats", "cube", "rollup"]
 
@@ -319,10 +320,7 @@ class SegTransactionStats:
             *filter(lambda x: x in data.columns, [cols.unit_qty, cols.customer_id]),
         ]
 
-        missing_cols = set(required_cols) - set(data.columns)
-        if len(missing_cols) > 0:
-            msg = f"The following columns are required but missing: {missing_cols}"
-            raise ValueError(msg)
+        validate_columns(data, required_cols)
 
         # Validate extra_aggs if provided
         self._validate_extra_aggs(data, extra_aggs)

--- a/openretailscience/segmentation/threshold.py
+++ b/openretailscience/segmentation/threshold.py
@@ -49,6 +49,7 @@ import ibis
 import pandas as pd
 
 from openretailscience.options import ColumnHelper
+from openretailscience.utils.validation import validate_columns
 
 
 class ThresholdSegmentation:
@@ -110,10 +111,7 @@ class ThresholdSegmentation:
         if self._group_col is not None:
             required_cols.extend(self._group_col)
 
-        missing_cols = set(required_cols) - set(df.columns)
-        if len(missing_cols) > 0:
-            msg = f"The following columns are required but missing: {missing_cols}"
-            raise ValueError(msg)
+        validate_columns(df, required_cols)
 
         # Build group_by columns: customer_id + optional group columns
         group_by_cols = [cols.customer_id]

--- a/tests/analysis/test_cohort.py
+++ b/tests/analysis/test_cohort.py
@@ -71,7 +71,7 @@ class TestCohortAnalysis:
     def test_missing_columns(self):
         """Test if missing columns raise an error."""
         df = pd.DataFrame({"customer_id": [1, 2, 3], "unit_spend": [10, 20, 30]})
-        with pytest.raises(ValueError, match="Missing required columns"):
+        with pytest.raises(ValueError, match="The following columns are required but missing"):
             CohortAnalysis(
                 df=df,
                 aggregation_column="unit_spend",

--- a/tests/segmentation/test_rfm.py
+++ b/tests/segmentation/test_rfm.py
@@ -192,7 +192,7 @@ class TestRFMSegmentation:
             },
         )
 
-        with pytest.raises(ValueError, match="Missing required columns"):
+        with pytest.raises(ValueError, match="The following columns are required but missing"):
             RFMSegmentation(df=incomplete_df, current_date="2025-03-17")
 
     @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -1986,7 +1986,7 @@ wheels = [
 
 [[package]]
 name = "openretailscience"
-version = "0.45.0"
+version = "0.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Summary

Closes #448.

Replaces the duplicated 3-line `set(required_cols) - set(df.columns)` pattern across 11 analysis/segmentation modules with the shared `validate_columns()` helper from `openretailscience.utils.validation`.

Net diff is -34 lines.

### Files migrated

**Identical behavior (no test changes needed):**
- `analysis/customer.py` (4 occurrences)
- `analysis/cross_shop.py`
- `analysis/gain_loss.py`
- `analysis/customer_decision_hierarchy.py`
- `analysis/revenue_tree.py`
- `analysis/product_association.py`
- `segmentation/segstats.py`
- `segmentation/threshold.py`
- `segmentation/nlr.py` (not on the original issue's list — found during codebase-wide search)

**Error-message prefix changed (test `match` updated):**
- `segmentation/rfm.py` — was `"Missing required columns: {...}"`, now uses `validate_columns`'s `"The following columns are required but missing: [...]"` (sorted).
- `analysis/cohort.py` — same change. Not on the original list but follows the same pattern.

### Not migrated

- `analysis/composite_rank.py` — uses a semantically distinct message (`"Group column(s) ... not found in the DataFrame"`) for a different validation concern.

### Also includes

- `chore: sync uv.lock with pyproject.toml version 0.46.0` — `uv sync` corrected an existing drift between `pyproject.toml` (0.46.0) and `uv.lock` (0.45.0).

## Test plan

- [x] `uv run ruff check` on all touched files — clean
- [x] `uv run pytest` on all module test files + `tests/utils/test_validation.py` — 322 passed
- [ ] CI on the PR



---
_Generated by [Claude Code](https://claude.ai/code/session_01UBDL41mqNv6sXF7EGmQVM8)_