### PR TITLE
Remove proprietary license classifier from project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [project]
 classifiers = [
-    "License :: Other/Proprietary License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Summary
Removes the "License :: Other/Proprietary License" classifier from the project's `pyproject.toml` file.

## Changes
- Removed the proprietary license classifier from the `[project]` classifiers list in `pyproject.toml`

## Rationale
This change simplifies the project metadata by removing a classifier that is no longer applicable or desired. The remaining classifiers accurately describe the project's compatibility and Python version support.

https://claude.ai/code/session_016fTFTPjrWFxQ5uGc2dUNWc