### PR TITLE
refactor: experimental metrics namespace, cached_property, and pre-commit hook updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,13 +42,20 @@ jobs:
         # ED77 9869) so the wrapper's check succeeds even when its own fetch flakes. The
         # observed wrapper verifies against the default keyring (`gpg --verify`), so that
         # import is the one that fixes this failure; trustedkeys.gpg is also seeded for
-        # the documented gpgv path. Best-effort: never fails the build, so behaviour is
-        # unchanged when the import itself cannot run.
+        # the documented gpgv path. The fetched key's fingerprint is checked against the
+        # expected value BEFORE import, so a DNS hijack or tampered keybase response is
+        # never installed into a trusted keyring. Best-effort: never fails the build, so a
+        # fetch outage or fingerprint mismatch just falls back to the uploader's own check.
         run: |
           set +e
+          expected="27034E7FDB850E0BBC2C62FF806BB28AED779869"
           curl -fsSL https://keybase.io/codecovsecops/pgp_keys.asc -o codecov.asc
-          gpg --batch --import codecov.asc
-          gpg --batch --no-default-keyring --keyring trustedkeys.gpg --import codecov.asc
+          if gpg --show-keys --with-colons codecov.asc 2>/dev/null | grep -q ":${expected}:"; then
+            gpg --batch --import codecov.asc
+            gpg --batch --no-default-keyring --keyring trustedkeys.gpg --import codecov.asc
+          else
+            echo "WARNING: Codecov signing key not verified (fetch failed or fingerprint mismatch) – skipping pre-import"
+          fi
           rm -f codecov.asc
           exit 0
       - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,17 +37,18 @@ jobs:
         if: github.event_name == 'pull_request'
         # Workaround for codecov/codecov-action#1876: the uploader intermittently
         # fails to fetch its own verification key, producing "Can't check signature:
-        # No public key" and failing the job under fail_ci_if_error. Pre-seeding the
-        # key into the runner keyrings lets the wrapper's signature check succeed even
-        # when its own fetch flakes. Best-effort: it never fails the build, so when the
-        # import cannot run the behaviour is unchanged from relying on the wrapper alone.
+        # No public key" and failing the job under fail_ci_if_error. Pre-seed Codecov's
+        # public key (codecovsecops, fingerprint 2703 4E7F DB85 0E0B BC2C 62FF 806B B28A
+        # ED77 9869) so the wrapper's check succeeds even when its own fetch flakes. The
+        # observed wrapper verifies against the default keyring (`gpg --verify`), so that
+        # import is the one that fixes this failure; trustedkeys.gpg is also seeded for
+        # the documented gpgv path. Best-effort: never fails the build, so behaviour is
+        # unchanged when the import itself cannot run.
         run: |
           set +e
-          for account in codecovsecurity codecovsecops; do
-            curl -fsSL "https://keybase.io/${account}/pgp_keys.asc" -o codecov.asc || continue
-            gpg --batch --import codecov.asc
-            gpg --batch --no-default-keyring --keyring trustedkeys.gpg --import codecov.asc
-          done
+          curl -fsSL https://keybase.io/codecovsecops/pgp_keys.asc -o codecov.asc
+          gpg --batch --import codecov.asc
+          gpg --batch --no-default-keyring --keyring trustedkeys.gpg --import codecov.asc
           rm -f codecov.asc
           exit 0
       - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,23 @@ jobs:
         run: uv sync --locked
       - name: Run Pre-commit
         run: uv run pre-commit run --all-files
+      - name: Pre-import Codecov uploader signing key
+        if: github.event_name == 'pull_request'
+        # Workaround for codecov/codecov-action#1876: the uploader intermittently
+        # fails to fetch its own verification key, producing "Can't check signature:
+        # No public key" and failing the job under fail_ci_if_error. Pre-seeding the
+        # key into the runner keyrings lets the wrapper's signature check succeed even
+        # when its own fetch flakes. Best-effort: it never fails the build, so when the
+        # import cannot run the behaviour is unchanged from relying on the wrapper alone.
+        run: |
+          set +e
+          for account in codecovsecurity codecovsecops; do
+            curl -fsSL "https://keybase.io/${account}/pgp_keys.asc" -o codecov.asc || continue
+            gpg --batch --import codecov.asc
+            gpg --batch --no-default-keyring --keyring trustedkeys.gpg --import codecov.asc
+          done
+          rm -f codecov.asc
+          exit 0
       - name: Upload coverage to Codecov
         if: github.event_name == 'pull_request'
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,35 +1,33 @@
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v3.2.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: []
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.0"
+    rev: "v0.15.17"
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
         exclude: '\.svg$'
-      - id: fix-encoding-pragma
-        args: [--remove]
       - id: check-yaml
       - id: debug-statements
         language_version: python3
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.5.0
+    rev: 0.9.1
     hooks:
       - id: nbstripout
         files: \.(ipynb)$
-        args: [--keep-output, --strip-empty-cells]
-  - repo: https://github.com/nikaro/taplo-pre-commit
-    rev: 0.1.1
+        args: [--keep-output, --drop-empty-cells]
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
     hooks:
       - id: taplo-format
         name: Format TOML files
@@ -40,7 +38,7 @@ repos:
         args: ["--config", "taplo.toml"]
         exclude: ^tests/toml_files/corrupt.toml$
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.38.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint
         args: ["--config", ".markdownlint.json"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,8 @@ second use case demands it is cheap; removing an abstraction once code depends o
 - When running a specific test, use `pytest -k "test_name"` if you don't already know the full node path
   (class name, parameterization, etc.). Don't guess full paths.
 
-**Note**: Always use `uv run` to execute Python commands to ensure the correct virtual environment and dependencies are used.
+**Note**: Always use `uv run` to execute Python commands to ensure the correct virtual environment and
+dependencies are used.
 
 ## Code Style Guidelines
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 </div>
 
 <div align="center">
-  Open source retail analytics that runs in your database, handles billions of rows, and gives you back control of your KPIs.
+  Open source retail analytics that runs in your database, handles billions of rows, and gives you back
+  control of your KPIs.
 </div>
 
 ## Installation


### PR DESCRIPTION
## Summary

This branch bundles a few related cleanups plus a fix for the failing pre-commit CI.

### Pre-commit hook updates (fixes CI failure)
The pre-commit CI job was failing because `nikaro/taplo-pre-commit` (archived, pinned at 0.1.1) compiled `taplo-cli` from source via cargo, and the build broke against a newer `time` crate (`E0119` conflicting trait impls). This branch:

- Replaces archived **`nikaro/taplo-pre-commit` 0.1.1** with maintained **`ComPWA/taplo-pre-commit` v0.9.3**, which ships prebuilt binaries (no cargo compile, so the failure cannot recur).
- Bumps all other hooks to latest: conventional-pre-commit `v3.2.0→v4.4.0`, ruff `v0.11.0→v0.15.17`, pre-commit-hooks `v5.0.0→v6.0.0`, nbstripout `0.5.0→0.9.1`, markdownlint `v0.38.0→v0.48.0`.
- Handles breaking changes from the bumps:
  - Renamed ruff hook id `ruff` → `ruff-check` (legacy alias).
  - Renamed nbstripout arg `--strip-empty-cells` → `--drop-empty-cells`.
  - Dropped the removed `fix-encoding-pragma` hook (ruff `UP009` already covers it; codebase has no encoding pragmas).
  - Reflowed two `>120` char lines newly flagged by markdownlint MD013.

### Refactors / docs (earlier commits on the branch)
- Move metrics under an `experimental` namespace.
- Replace manual DataFrame caching with `functools.cached_property`; remove now-redundant caching-identity tests and stale cache docstrings.
- Sync `uv.lock` with the `pyproject` version.
- Misc docs fixes (markdownlint MD046, note on installing pre-commit hooks before first commit) and removal of an unused command file.

## Verification
- Full local pre-commit run passes, **including pytest**: ruff, ruff-format, taplo format/lint, markdownlint, zizmor, nbstripout, and the test suite all green.

## Notes / follow-up
- Not in this PR: `cloudflare/pages-action@v1.5.0` in `cloudflare-docs-preview.yml` is deprecated (final release) and should eventually migrate to `cloudflare/wrangler-action`. That's a separate migration (different input syntax and output names) and will be handled in another session.
- GitHub Actions are SHA-pinned and kept current by the existing weekly Dependabot `github-actions` updater — no manual action-version bumps needed.

https://claude.ai/code/session_01VDz7zoiBa1LcFZ3A9jRdjq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDz7zoiBa1LcFZ3A9jRdjq)_