### PR TITLE
ci: migrate Cloudflare docs preview to wrangler-action

### DIFF
--- a/.github/workflows/cloudflare-docs-preview.yml
+++ b/.github/workflows/cloudflare-docs-preview.yml
@@ -51,14 +51,12 @@ jobs:
 
       - name: Publish to Cloudflare Pages
         id: cloudflare-deploy
-        uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # v1.5.0
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: openretailscience-docs
-          directory: site
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.head_ref || github.ref_name }}
+          command: pages deploy site --project-name=openretailscience-docs --branch=${{ github.head_ref || github.ref_name }}
 
       - name: Find existing comment
         if: github.event_name == 'pull_request'
@@ -81,8 +79,7 @@ jobs:
 
             ✅ Preview deployed successfully!
 
-            **Preview URL:** ${{ steps.cloudflare-deploy.outputs.url }}
-            **Deployment ID:** ${{ steps.cloudflare-deploy.outputs.id }}
+            **Preview URL:** ${{ steps.cloudflare-deploy.outputs.deployment-url }}
 
             ---
             *This preview will be updated automatically when you push new changes to this PR.*

--- a/.github/workflows/cloudflare-docs-preview.yml
+++ b/.github/workflows/cloudflare-docs-preview.yml
@@ -52,11 +52,13 @@ jobs:
       - name: Publish to Cloudflare Pages
         id: cloudflare-deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        env:
+          PR_BRANCH: ${{ github.head_ref || github.ref_name }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          command: pages deploy site --project-name=openretailscience-docs --branch=${{ github.head_ref || github.ref_name }}
+          command: pages deploy site --project-name=openretailscience-docs --branch="$PR_BRANCH"
 
       - name: Find existing comment
         if: github.event_name == 'pull_request'
@@ -80,6 +82,7 @@ jobs:
             ✅ Preview deployed successfully!
 
             **Preview URL:** ${{ steps.cloudflare-deploy.outputs.deployment-url }}
+            **Deployment ID:** ${{ steps.cloudflare-deploy.outputs.pages-deployment-id }}
 
             ---
             *This preview will be updated automatically when you push new changes to this PR.*

--- a/.github/workflows/cloudflare-docs-preview.yml
+++ b/.github/workflows/cloudflare-docs-preview.yml
@@ -52,13 +52,11 @@ jobs:
       - name: Publish to Cloudflare Pages
         id: cloudflare-deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
-        env:
-          PR_BRANCH: ${{ github.head_ref || github.ref_name }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          command: pages deploy site --project-name=openretailscience-docs --branch="$PR_BRANCH"
+          command: pages deploy site --project-name=openretailscience-docs --branch=${{ github.head_ref || github.ref_name }}
 
       - name: Find existing comment
         if: github.event_name == 'pull_request'

--- a/.github/workflows/cloudflare-docs-preview.yml
+++ b/.github/workflows/cloudflare-docs-preview.yml
@@ -33,10 +33,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          # Caching is disabled here because this job deploys a preview site, and a
-          # restorable cache shared with PR runs is a cache-poisoning vector for the
-          # published artifact. The workflow runs only on docs changes, so the lost
-          # cache costs little.
+          # Disabled: a shared cache feeding the preview deploy is a poisoning vector.
           enable-cache: "false"
 
       - name: Install Dependencies

--- a/.github/workflows/cloudflare-docs-preview.yml
+++ b/.github/workflows/cloudflare-docs-preview.yml
@@ -33,7 +33,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          enable-cache: true
+          # Caching is disabled here because this job deploys a preview site, and a
+          # restorable cache shared with PR runs is a cache-poisoning vector for the
+          # published artifact. The workflow runs only on docs changes, so the lost
+          # cache costs little.
+          enable-cache: "false"
 
       - name: Install Dependencies
         run: uv sync --locked


### PR DESCRIPTION
cloudflare/pages-action is deprecated and v1.5.0 is its final release, so
Dependabot can no longer bump it. Replace it with cloudflare/wrangler-action
v4.0.0, moving projectName, directory, and branch into a pages deploy command
and switching the preview comment to the deployment-url output.