### PR TITLE
Eliminate mkdocs build warnings and gate docs build on --strict

### DIFF
--- a/.github/workflows/cloudflare-docs-preview.yml
+++ b/.github/workflows/cloudflare-docs-preview.yml
@@ -40,7 +40,7 @@ jobs:
         run: uv sync --locked
 
       - name: Build docs
-        run: uv run mkdocs build
+        run: uv run mkdocs build --strict
 
       - name: Verify build output
         run: |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,10 @@ site_url: https://openretailscience.datasimply.co
 repo_url: https://github.com/Data-Simply/openretailscience
 repo_name: Data-Simply/openretailscience
 
+# Build-helper tooling, not documentation pages — keep out of the rendered site.
+exclude_docs: |
+  scripts/
+
 nav:
   - Home: index.md
   - Getting Started:

--- a/openretailscience/analysis/product_association.py
+++ b/openretailscience/analysis/product_association.py
@@ -170,7 +170,7 @@ class ProductAssociation:
         """Initialize the ProductAssociation object.
 
         Args:
-            df (pd.DataFrame | ibis.Table) : The input DataFrame or ibis Table containing transaction data.
+            df (pd.DataFrame | ibis.Table): The input DataFrame or ibis Table containing transaction data.
             value_col (str): The name of the column in the input DataFrame that contains the product identifiers.
             group_col (str, optional): The name of the column that identifies unique transactions or customers. Defaults
                 to option column.unit_spend.
@@ -259,7 +259,7 @@ class ProductAssociation:
         helping to identify patterns in customer purchasing behavior.
 
         Args:
-            df (pd.DataFrame | ibis.Table) : The input DataFrame or ibis Table containing transaction data.
+            df (pd.DataFrame | ibis.Table): The input DataFrame or ibis Table containing transaction data.
             value_col (str): The name of the column in the input DataFrame that contains the product identifiers.
             group_col (str, optional): The name of the column that identifies unique transactions or customers. Defaults
                 to option column.unit_spend.

--- a/openretailscience/segmentation/segstats.py
+++ b/openretailscience/segmentation/segstats.py
@@ -245,8 +245,7 @@ class SegTransactionStats:
             rollup_value (Any | list[Any], optional): The value to use for rollup totals. Can be a single value
                 applied to all columns or a list of values matching the length of segment_col, with each value
                 cast to match the corresponding column type. Defaults to "Total".
-            unknown_customer_value
-                (int | str | ibis.Scalar | ibis.expr.types.BooleanColumn | None, optional):
+            unknown_customer_value (int | str | ibis.Scalar | ibis.expr.types.BooleanColumn | None, optional):
                 Value or expression identifying unknown customers for separate tracking.
                 When provided, metrics are split into identified, unknown, and total variants.
                 Accepts simple values (e.g., -1), ibis literals, or boolean expressions
@@ -908,8 +907,7 @@ class SegTransactionStats:
             rollup_value (Any | list[Any], optional): The value to use for rollup totals. Can be a single value
                 applied to all columns or a list of values matching the length of segment_col, with each value
                 cast to match the corresponding column type. Defaults to "Total".
-            unknown_customer_value
-                (int | str | ibis.Scalar | ibis.expr.types.BooleanColumn | None, optional):
+            unknown_customer_value (int | str | ibis.Scalar | ibis.expr.types.BooleanColumn | None, optional):
                 Value or expression identifying unknown customers for separate tracking.
                 When provided, metrics are split into identified, unknown, and total variants.
                 Accepts simple values (e.g., -1), ibis literals, or boolean expressions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ docs = [
     "mkdocs-jupyter>=0.24.6,<0.25",
     "mkdocs-material>=9.5.4,<10",
     "mkdocs>=1.5.3,<2",
-    "mkdocstrings[python]>=0.26,<0.30",
+    "mkdocstrings>=0.26,<0.30",
     "mkdocstrings-python>=1.11,<2",
 ]
 examples = [ "jupyterlab>=4.2.5,<5", "tqdm>=4.66.1,<5" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ docs = [
     "mkdocs-jupyter>=0.24.6,<0.25",
     "mkdocs-material>=9.5.4,<10",
     "mkdocs>=1.5.3,<2",
-    "mkdocstrings[python]>=0.24.0,<0.25",
+    "mkdocstrings[python]>=0.26,<0.30",
+    "mkdocstrings-python>=1.11,<2",
 ]
 examples = [ "jupyterlab>=4.2.5,<5", "tqdm>=4.66.1,<5" ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1818,11 +1818,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/14/22533a578bf8b187e05d67e2c1721ce10e3f526610eebaf7a149d557ea7a/mkdocstrings-0.29.1-py3-none-any.whl", hash = "sha256:37a9736134934eea89cbd055a513d40a020d87dfcae9e3052c2a6b8cd4af09b6", size = 1631075, upload-time = "2025-03-31T08:33:09.661Z" },
 ]
 
-[package.optional-dependencies]
-python = [
-    { name = "mkdocstrings-python" },
-]
-
 [[package]]
 name = "mkdocstrings-python"
 version = "1.16.12"
@@ -2043,7 +2038,7 @@ docs = [
     { name = "mkdocs" },
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-material" },
-    { name = "mkdocstrings", extra = ["python"] },
+    { name = "mkdocstrings" },
     { name = "mkdocstrings-python" },
 ]
 examples = [
@@ -2084,7 +2079,7 @@ docs = [
     { name = "mkdocs", specifier = ">=1.5.3,<2" },
     { name = "mkdocs-jupyter", specifier = ">=0.24.6,<0.25" },
     { name = "mkdocs-material", specifier = ">=9.5.4,<10" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26,<0.30" },
+    { name = "mkdocstrings", specifier = ">=0.26,<0.30" },
     { name = "mkdocstrings-python", specifier = ">=1.11,<2" },
 ]
 examples = [

--- a/uv.lock
+++ b/uv.lock
@@ -139,15 +139,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backports-strenum"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/c7/2ed54c32fed313591ffb21edbd48db71e68827d43a61938e5a0bc2b6ec91/backports_strenum-1.3.1.tar.gz", hash = "sha256:77c52407342898497714f0596e86188bb7084f89063226f4ba66863482f42414", size = 7257, upload-time = "2023-12-09T14:36:40.937Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/50/56cf20e2ee5127b603b81d5a69580a1a325083e2b921aa8f067da83927c0/backports_strenum-1.3.1-py3-none-any.whl", hash = "sha256:cdcfe36dc897e2615dc793b7d3097f54d359918fc448754a517e6f23044ccf83", size = 8304, upload-time = "2023-12-09T14:36:39.905Z" },
-]
-
-[[package]]
 name = "beautifulsoup4"
 version = "4.12.3"
 source = { registry = "https://pypi.org/simple" }
@@ -916,15 +907,37 @@ wheels = [
 
 [[package]]
 name = "griffe"
-version = "0.48.0"
+version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-strenum", marker = "python_full_version < '3.11'" },
-    { name = "colorama" },
+    { name = "griffecli" },
+    { name = "griffelib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/3c/7f439fe3f55373602c66fcd100abfdbf274f9f4cc832cdc67f2bfd013180/griffe-0.48.0.tar.gz", hash = "sha256:f099461c02f016b6be4af386d5aa92b01fb4efe6c1c2c360dda9a5d0a863bb7f", size = 369612, upload-time = "2024-07-15T09:23:42.318Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/49/eb6d2935e27883af92c930ed40cc4c69bcd32c402be43b8ca4ab20510f67/griffe-2.0.2.tar.gz", hash = "sha256:c5d56326d159f274492e9bf93a9895cec101155d944caa66d0fc4e0c13751b92", size = 293757, upload-time = "2026-03-27T11:34:52.205Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/de/521ff6028fc8977d5669b48d84b002b7bf5c99a3e9c551c92d4c6bf95ec1/griffe-0.48.0-py3-none-any.whl", hash = "sha256:f944c6ff7bd31cf76f264adcd6ab8f3d00a2f972ae5cc8db2d7b6dcffeff65a2", size = 140816, upload-time = "2024-07-15T09:23:36.966Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c0/2bb018eecf9a83c68db9cd9fffd9dab25f102ad30ed869451046e46d1187/griffe-2.0.2-py3-none-any.whl", hash = "sha256:2b31816460aee1996af26050a1fc6927a2e5936486856707f55508e4c9b5960b", size = 5141, upload-time = "2026-03-27T11:34:47.721Z" },
+]
+
+[[package]]
+name = "griffecli"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/e0/6a7d661d71bb043656a109b91d84a42b5342752542074ec83b16a6eb97f0/griffecli-2.0.2.tar.gz", hash = "sha256:40a1ad4181fc39685d025e119ae2c5b669acdc1f19b705fb9bf971f4e6f6dffb", size = 56281, upload-time = "2026-03-27T11:34:50.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/e8/90d93356c88ac34c20cb5edffca68138df55ca9bbd1a06eccfbcec8fdbe5/griffecli-2.0.2-py3-none-any.whl", hash = "sha256:0d44d39e59afa81e288a3e1c3bf352cc4fa537483326ac06b8bb6a51fd8303a0", size = 9500, upload-time = "2026-03-27T11:34:48.81Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -1714,16 +1727,16 @@ wheels = [
 
 [[package]]
 name = "mkdocs-autorefs"
-version = "1.0.1"
+version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "markupsafe" },
     { name = "mkdocs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/75/0ced93354fd9df40531c548f07d6462912eea9519e8cd78a8e6b42d73c4a/mkdocs_autorefs-1.0.1.tar.gz", hash = "sha256:f684edf847eced40b570b57846b15f0bf57fb93ac2c510450775dcf16accb971", size = 17743, upload-time = "2024-02-29T15:52:19.753Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/01/d413c98335ed75d8c211afb91320811366d55fb0ef7f4b01b9ab19630eac/mkdocs_autorefs-1.0.1-py3-none-any.whl", hash = "sha256:aacdfae1ab197780fb7a2dac92ad8a3d8f7ca8049a9cbe56a4218cd52e8da570", size = 13444, upload-time = "2024-02-29T15:51:52.989Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
 ]
 
 [[package]]
@@ -1790,21 +1803,19 @@ wheels = [
 
 [[package]]
 name = "mkdocstrings"
-version = "0.24.3"
+version = "0.29.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
     { name = "jinja2" },
     { name = "markdown" },
     { name = "markupsafe" },
     { name = "mkdocs" },
     { name = "mkdocs-autorefs" },
-    { name = "platformdirs" },
     { name = "pymdown-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/0b/424efa5498ede474a8104f57dc35666b7e2f0025c370e469b9ea00ab23d9/mkdocstrings-0.24.3.tar.gz", hash = "sha256:f327b234eb8d2551a306735436e157d0a22d45f79963c60a8b585d5f7a94c1d2", size = 31936, upload-time = "2024-04-05T14:56:35.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/e8/d22922664a627a0d3d7ff4a6ca95800f5dde54f411982591b4621a76225d/mkdocstrings-0.29.1.tar.gz", hash = "sha256:8722f8f8c5cd75da56671e0a0c1bbed1df9946c0cef74794d6141b34011abd42", size = 1212686, upload-time = "2025-03-31T08:33:11.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/c2/5d2fa50f67b270d67f867fe2c8814ffa910c2d49fda1910428a55cb6df54/mkdocstrings-0.24.3-py3-none-any.whl", hash = "sha256:5c9cf2a32958cd161d5428699b79c8b0988856b0d4a8c5baf8395fc1bf4087c3", size = 28478, upload-time = "2024-04-05T14:56:33.417Z" },
+    { url = "https://files.pythonhosted.org/packages/98/14/22533a578bf8b187e05d67e2c1721ce10e3f526610eebaf7a149d557ea7a/mkdocstrings-0.29.1-py3-none-any.whl", hash = "sha256:37a9736134934eea89cbd055a513d40a020d87dfcae9e3052c2a6b8cd4af09b6", size = 1631075, upload-time = "2025-03-31T08:33:09.661Z" },
 ]
 
 [package.optional-dependencies]
@@ -1814,15 +1825,17 @@ python = [
 
 [[package]]
 name = "mkdocstrings-python"
-version = "1.10.0"
+version = "1.16.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffe" },
+    { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/83/73fc9137c599754616e018997706f8403bb4c0b122ac96f3b76a813c0cab/mkdocstrings_python-1.10.0.tar.gz", hash = "sha256:71678fac657d4d2bb301eed4e4d2d91499c095fd1f8a90fa76422a87a5693828", size = 34135, upload-time = "2024-04-19T13:10:47.009Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/ed/b886f8c714fd7cccc39b79646b627dbea84cd95c46be43459ef46852caf0/mkdocstrings_python-1.16.12.tar.gz", hash = "sha256:9b9eaa066e0024342d433e332a41095c4e429937024945fea511afe58f63175d", size = 206065, upload-time = "2025-06-03T12:52:49.276Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/19/8a83ce7eb29ca23d65726e99c83f6d4f80c9759dbae83c1cf4c6bee2a5dc/mkdocstrings_python-1.10.0-py3-none-any.whl", hash = "sha256:ba833fbd9d178a4b9d5cb2553a4df06e51dc1f51e41559a4d2398c16a6f69ecc", size = 58697, upload-time = "2024-04-19T13:10:42.727Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dd/a24ee3de56954bfafb6ede7cd63c2413bb842cc48eb45e41c43a05a33074/mkdocstrings_python-1.16.12-py3-none-any.whl", hash = "sha256:22ded3a63b3d823d57457a70ff9860d5a4de9e8b1e482876fc9baabaf6f5f374", size = 124287, upload-time = "2025-06-03T12:52:47.819Z" },
 ]
 
 [[package]]
@@ -2031,6 +2044,7 @@ docs = [
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "mkdocstrings-python" },
 ]
 examples = [
     { name = "jupyterlab" },
@@ -2070,7 +2084,8 @@ docs = [
     { name = "mkdocs", specifier = ">=1.5.3,<2" },
     { name = "mkdocs-jupyter", specifier = ">=0.24.6,<0.25" },
     { name = "mkdocs-material", specifier = ">=9.5.4,<10" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.24.0,<0.25" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26,<0.30" },
+    { name = "mkdocstrings-python", specifier = ">=1.11,<2" },
 ]
 examples = [
     { name = "jupyterlab", specifier = ">=4.2.5,<5" },


### PR DESCRIPTION
## Summary

Makes `mkdocs build` warning-free and enforces it in CI so doc regressions are caught before merge. Also folds in the related refactors that were already on this branch.

### Docs build warnings (the main goal)
- **griffe deprecation spam:** the docs deps were pinned to `mkdocstrings[python]>=0.24,<0.25`, which resolved to the old `mkdocstrings-python 1.10` handler that imports from griffe via paths griffe later deprecated. Bumped to `mkdocstrings>=0.26,<0.30` + `mkdocstrings-python>=1.11,<2` (the handler that imports from griffe directly), capped below the breaking `mkdocstrings-python 2.0` rewrite. Lockfile updated.
- **Malformed Google-style docstrings** that griffe couldn't parse:
  - `segstats.py`: `unknown_customer_value` had its name and `(type)` split across two lines.
  - `product_association.py`: `df (...) :` had a stray space before the colon.
- **`docs/scripts/` noise:** build-helper tooling (an SVG-regen script + its README) was being treated as doc pages (the `.py` even rendered as a notebook). Excluded via `exclude_docs` in `mkdocs.yml`.

Result: `uv run mkdocs build --strict` now exits 0 with no warnings.

### CI
- `cloudflare-docs-preview.yml` now runs `mkdocs build --strict`, so any future warning (broken link, missing nav page, unparseable docstring) fails the per-PR preview build instead of shipping silently.

### Refactors already on this branch (included in the diff)
- Replace manual `self._df = None` caching with `@functools.cached_property` across the analysis/segmentation/metrics classes, dropping the always-true `hasattr` guard.
- Move `openretailscience/metrics/` → `openretailscience/experimental/metrics/` (imports, tests, and docs nav/reference pages updated accordingly).

## Testing
- `uv run mkdocs build --strict` → clean, exit 0.
- `uv run pytest tests/experimental tests/segmentation tests/analysis/test_composite_rank.py tests/analysis/test_product_association.py` → 286 passed.
- `uv run ruff check` on the edited modules → clean.

## Note
The `@functools.cached_property` conversion is a clean win for single-threaded use. On Python 3.10/3.11 `cached_property` uses a single shared lock per descriptor, so concurrent first-access to `.df` across *different instances of the same class* serializes (resolved on 3.12+). Worth being aware of given the large-dataset `.execute()` workloads, but not a correctness issue.

https://claude.ai/code/session_01DE3VmsxGH1e8P8cgirKve6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DE3VmsxGH1e8P8cgirKve6)_