### PR TITLE
fix(plots): re-wrap chart chrome to the current figure width on resize

### DIFF
--- a/openretailscience/plots/index.py
+++ b/openretailscience/plots/index.py
@@ -291,8 +291,9 @@ def plot(  # noqa: C901, PLR0913
             threshold use the ``plot.color.negative`` option, and values between use the ``plot.color.neutral`` option.
             Requires highlight_range to be set (not None). Only applicable when series_col is None. Defaults to False.
         **kwargs: Additional keyword arguments to pass to the Pandas plot function. When
-            ``color_by_threshold`` is True, kwargs are passed to matplotlib's ``Axes.barh()`` instead
-            and pandas-specific kwargs (figsize, stacked, legend, subplots, layout) are filtered out.
+            ``color_by_threshold`` is True, kwargs are passed to matplotlib's ``Axes.barh()`` instead.
+            ``figsize`` still sizes the figure when ``ax`` is None; it and the other pandas-specific
+            kwargs (stacked, legend, subplots, layout) are excluded only from the ``barh`` call.
 
     Returns:
         SubplotBase: The matplotlib axes object.

--- a/openretailscience/plots/styles/styling_helpers.py
+++ b/openretailscience/plots/styles/styling_helpers.py
@@ -17,6 +17,7 @@ from openretailscience.plots.styles.graph_utils import draw_end_of_line_labels
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
+    from matplotlib.backend_bases import RendererBase
     from matplotlib.figure import Figure
     from matplotlib.text import Text
 
@@ -95,91 +96,138 @@ def _resolve_end_of_line_legend_args(
     return False, None, False
 
 
-def _freeze_text_wrap(text: Text) -> None:
-    """Bake matplotlib's soft wrap into ``text`` and stop it re-wrapping on later draws.
+def _rewrap_text_to_width(text: Text, original: str, renderer: RendererBase) -> None:
+    """Bake ``original`` into ``text``, wrapped to the figure's current width.
 
-    ``wrap=True`` recomputes line breaks every draw from the figure width, so a later resize (or
-    the extra draw ``bbox_inches='tight'`` triggers) can change the line count and invalidate the
-    layout positioned against the measured height. Baking the wrapped lines as explicit newlines
-    and turning wrap off freezes the count. Requires a prior draw so the wrap is already computed;
-    the caller measures the baked text afterwards via ``get_window_extent``, which re-lays it out
-    without another draw. No-op when wrapping is already off.
+    matplotlib's ``wrap=True`` only re-wraps during ``draw`` and ``get_window_extent`` ignores it,
+    so chrome bakes the wrap into explicit newlines to measure a stable height. Pointing the text
+    at the live ``renderer`` first makes the bake follow the figure's *current* width: re-deriving
+    it on every draw is what stops a post-call resize from leaving the wrap frozen at the
+    build-time width. ``original`` (the unwrapped source) is supplied by the caller because the
+    baked artist no longer holds it.
     """
-    if not text.get_wrap():
-        return
+    text.set_text(original)
+    text.set_wrap(True)
+    text._renderer = renderer
     text.set_text(text._get_wrapped_text())
     text.set_wrap(False)
 
 
-def _place_header_text(
-    ax: Axes,
-    x_fig: float,
-    prev_bottom_fig_y: float,
-    text_str: str,
-    font_name: str,
-    font_size: float,
-    color: str,
-    wrap: bool,
-    gid: str,
-) -> float:
-    """Place a header text element with its top at ``prev_bottom_fig_y`` and return its measured bottom.
+def _active_renderer(fig: Figure) -> RendererBase:
+    """Return the renderer for the figure's current draw, across backends.
 
-    Each element is placed and drawn in turn so that wrapped lines from
-    the previous element are reflected in the y position of the next.
+    The chrome engine measures text on every draw, including ``savefig``, during which matplotlib
+    swaps in a vector canvas (``FigureCanvasSVG``/``Pdf``) that has no ``get_renderer``. Use
+    ``fig._get_renderer()`` (what matplotlib's own tight/constrained layout engines use), not
+    ``fig.canvas.get_renderer()``, which exists only on the Agg canvas.
     """
-    fig = ax.figure
-    t = fig.text(
-        x_fig,
-        prev_bottom_fig_y,
-        text_str,
-        ha="left",
-        va="top",
-        fontproperties=get_font_properties(font_name),
-        fontsize=font_size,
-        color=color,
-        wrap=wrap,
-    )
-    t.set_gid(gid)
-    fig.canvas.draw()
-    _freeze_text_wrap(t)
-    renderer = fig.canvas.get_renderer()
-    return t.get_window_extent(renderer=renderer).y0 / fig.bbox.height
+    return fig._get_renderer()
+
+
+@dataclass
+class _ChromeTextSpec:
+    """A chrome text element plus the inputs needed to re-place it at any figure width.
+
+    Attributes:
+        text: The figure-text artist. Its own content is the baked (newlined) form.
+        original: The unwrapped source string, re-wrapped to the current width on each draw.
+        gap_after_in: Absolute inch gap from this element's bottom to the next stacked element
+            (the trailing slot for the final / bottom-anchored element).
+        wrap: Whether the element re-wraps to the figure width. Eyebrows stay single-line.
+    """
+
+    text: Text
+    original: str
+    gap_after_in: float
+    wrap: bool = True
+
+
+def _layout_chrome_header(
+    specs: list[_ChromeTextSpec],
+    top_offset_in: float,
+    fig_h: float,
+    dpi: float,
+    renderer: RendererBase,
+) -> float:
+    """Re-wrap and stack the top-anchored header elements; return the block's bottom offset in inches.
+
+    Each element is re-wrapped to the current width, positioned with its top ``top_in`` inches below
+    the figure top, then measured so the next element starts below its actual rendered height. The
+    returned bottom offset (inches from the figure top, including the final element's trailing gap)
+    anchors the axes top.
+    """
+    top_in = top_offset_in
+    for spec in specs:
+        if spec.wrap:
+            _rewrap_text_to_width(spec.text, spec.original, renderer)
+        spec.text.set_y(1.0 - top_in / fig_h)
+        height_in = spec.text.get_window_extent(renderer=renderer).height / dpi
+        top_in += height_in + spec.gap_after_in
+    return top_in
+
+
+def _layout_chrome_source(
+    source: _ChromeTextSpec,
+    bottom_offset_in: float,
+    fig_h: float,
+    dpi: float,
+    renderer: RendererBase,
+) -> float:
+    """Re-wrap the bottom-anchored source line; return its top offset in inches from the figure bottom."""
+    if source.wrap:
+        _rewrap_text_to_width(source.text, source.original, renderer)
+    source.text.set_y(bottom_offset_in / fig_h)
+    height_in = source.text.get_window_extent(renderer=renderer).height / dpi
+    return bottom_offset_in + height_in
 
 
 @dataclass
 class _ChromeLayout:
-    """One axes' chrome placement, stored as absolute inch offsets so it survives a resize.
+    """One axes' chrome placement recipe, stored as resize-invariant inputs.
 
-    Text is sized in points (absolute), so its gaps must be absolute too. Fractions captured at
-    layout time go stale when the figure is later resized; inch offsets re-derived at draw time
-    do not. Vertical offsets only — horizontal placement stays in fractions, which already track
-    width and keep the chrome aligned to the axes spine.
+    Text is sized in points, so the inch offsets and gaps are absolute; the engine re-derives the
+    figure-fraction positions from them on every draw, re-wrapping the header and source to the
+    current width so a post-call resize re-flows instead of freezing the wrap at the build-time
+    width. Horizontal placement stays in fractions, which keep the chrome aligned to the axes spine.
 
     Attributes:
         ax: The axes whose box is reflowed beneath the header.
-        top_texts: ``(text, top_offset_in)`` per top-anchored header element; offset measured
-            from the figure top to the text's top.
-        source: ``(text, bottom_offset_in)`` for the bottom-anchored source line, or None.
+        header_top_offset_in: Inches from the figure top to the first header element's top.
+        header: Top-anchored header elements (eyebrow/title/subtitle) in stacking order.
+        header_to_axes_gap_in: Inches from the header block's bottom to the axes top edge. Captured
+            from tight_layout, so it folds in the header-to-axes gap and any top-tick headroom.
+        source: The bottom-anchored source line, or None.
+        source_to_axes_gap_in: Inches from the source's top to the axes bottom edge.
+        axes_bottom_offset_in: Inches from the figure bottom to the axes bottom edge, used when
+            there is no source line.
         tab: ``(rectangle, top_offset_in, height_in, width_in)`` for the tab mark, or None.
-        axes_top_offset_in: Inches from the figure top to the axes top edge.
-        axes_bottom_offset_in: Inches from the figure bottom to the axes bottom edge.
     """
 
     ax: Axes
-    top_texts: list[tuple[Text, float]]
-    source: tuple[Text, float] | None
-    tab: tuple[Rectangle, float, float, float] | None
-    axes_top_offset_in: float
+    header_top_offset_in: float
+    header: list[_ChromeTextSpec]
+    header_to_axes_gap_in: float
+    source: _ChromeTextSpec | None
+    source_to_axes_gap_in: float
     axes_bottom_offset_in: float
+    tab: tuple[Rectangle, float, float, float] | None
 
 
-def _apply_chrome_layout(layout: _ChromeLayout, fig_h: float, fig_w: float) -> None:
-    """Re-derive figure fractions from ``layout``'s inch offsets for the current figure size."""
-    for text, top_offset_in in layout.top_texts:
-        text.set_y(1.0 - top_offset_in / fig_h)
+def _apply_chrome_layout(
+    layout: _ChromeLayout,
+    fig_h: float,
+    fig_w: float,
+    dpi: float,
+    renderer: RendererBase,
+) -> None:
+    """Re-wrap the chrome texts and re-place every artist for the current figure size."""
+    header_bottom_in = _layout_chrome_header(layout.header, layout.header_top_offset_in, fig_h, dpi, renderer)
+    axes_top_in = header_bottom_in + layout.header_to_axes_gap_in
     if layout.source is not None:
-        source_text, bottom_offset_in = layout.source
-        source_text.set_y(bottom_offset_in / fig_h)
+        source_top_in = _layout_chrome_source(layout.source, _CHROME_BOTTOM_MARGIN_IN, fig_h, dpi, renderer)
+        axes_bottom_in = source_top_in + layout.source_to_axes_gap_in
+    else:
+        axes_bottom_in = layout.axes_bottom_offset_in
     if layout.tab is not None:
         tab, tab_top_offset_in, tab_height_in, tab_width_in = layout.tab
         tab_height_fig = tab_height_in / fig_h
@@ -187,30 +235,45 @@ def _apply_chrome_layout(layout: _ChromeLayout, fig_h: float, fig_w: float) -> N
         tab.set_height(tab_height_fig)
         tab.set_width(tab_width_in / fig_w)
     pos = layout.ax.get_position()
-    axes_top = 1.0 - layout.axes_top_offset_in / fig_h
-    axes_bottom = layout.axes_bottom_offset_in / fig_h
+    axes_top = 1.0 - axes_top_in / fig_h
+    axes_bottom = axes_bottom_in / fig_h
     layout.ax.set_position((pos.x0, axes_bottom, pos.width, axes_top - axes_bottom))
 
 
 def _apply_chrome_layouts(fig: Figure) -> None:
-    """Re-apply every stored chrome layout on ``fig`` at its current height."""
+    """Re-apply every stored chrome layout on ``fig`` at its current size."""
     layouts = getattr(fig, "_ors_chrome_layouts", None)
     if layouts is None:
         return
+    renderer = _active_renderer(fig)
     fig_h = fig.get_figheight()
     fig_w = fig.get_figwidth()
+    dpi = fig.dpi
     for layout in layouts.values():
-        _apply_chrome_layout(layout, fig_h, fig_w)
+        _apply_chrome_layout(layout, fig_h, fig_w, dpi, renderer)
 
 
-def _axes_offsets_in(ax: Axes, fig_h: float) -> tuple[float, float]:
-    """Return the axes box's ``(top_offset_in, bottom_offset_in)`` — inches from the figure top/bottom."""
-    pos = ax.get_position()
-    return (1.0 - pos.y1) * fig_h, pos.y0 * fig_h
+def _recompute_chrome_axes_gaps(layout: _ChromeLayout, fig: Figure, renderer: RendererBase) -> None:
+    """Set ``layout``'s header/source-to-axes gaps from the axes box's current position.
+
+    The engine derives the axes top/bottom from these gaps, so they must be re-captured whenever the
+    box is reflowed: at initial layout, and after any later reflow that moved it.
+    """
+    fig_h = fig.get_figheight()
+    dpi = fig.dpi
+    header_bottom_in = _layout_chrome_header(layout.header, layout.header_top_offset_in, fig_h, dpi, renderer)
+    pos = layout.ax.get_position()
+    layout.header_to_axes_gap_in = (1.0 - pos.y1) * fig_h - header_bottom_in
+    axes_bottom_in = pos.y0 * fig_h
+    if layout.source is not None:
+        source_top_in = _layout_chrome_source(layout.source, _CHROME_BOTTOM_MARGIN_IN, fig_h, dpi, renderer)
+        layout.source_to_axes_gap_in = axes_bottom_in - source_top_in
+    else:
+        layout.axes_bottom_offset_in = axes_bottom_in
 
 
 def _refresh_chrome_axes_offsets(fig: Figure) -> None:
-    """Re-snapshot each layout's axes box after a post-install reflow moved it.
+    """Re-derive each layout's axes gaps after a post-install reflow moved the axes box.
 
     ``_auto_rotate_categorical_x_ticks`` reflows the axes to reserve room for rotated labels;
     without this the engine would re-apply the pre-rotation box and push the labels off-figure.
@@ -218,18 +281,18 @@ def _refresh_chrome_axes_offsets(fig: Figure) -> None:
     layouts = getattr(fig, "_ors_chrome_layouts", None)
     if layouts is None:
         return
-    fig_h = fig.get_figheight()
+    renderer = _active_renderer(fig)
     for layout in layouts.values():
-        layout.axes_top_offset_in, layout.axes_bottom_offset_in = _axes_offsets_in(layout.ax, fig_h)
+        _recompute_chrome_axes_gaps(layout, fig, renderer)
 
 
 class _ChromeLayoutEngine(LayoutEngine):
-    """Re-applies chrome geometry before each draw so it tracks the figure's current height.
+    """Re-applies chrome geometry before each draw so it tracks the figure's current size.
 
     Matplotlib runs ``execute`` at the start of every draw (including ``savefig``), before
     artists render, so repositioning lands in the same render even for a single headless save.
-    ``execute`` is pure arithmetic on the stored inch offsets — it never draws or measures — so
-    it cannot recurse.
+    ``execute`` re-wraps the chrome text to the current width and measures it against the live
+    renderer, but never triggers a draw of its own, so it cannot recurse.
     """
 
     # Match tight_layout's flags: the chrome reflow runs through fig.tight_layout (gridspec
@@ -247,41 +310,6 @@ def _install_chrome_layout_engine(fig: Figure) -> None:
     """Register the chrome layout engine on ``fig`` unless it is already active."""
     if not isinstance(fig.get_layout_engine(), _ChromeLayoutEngine):
         fig.set_layout_engine(_ChromeLayoutEngine())
-
-
-def _capture_chrome_layout(fig: Figure, ax: Axes, chrome_gid: str, source_text: Text | None) -> _ChromeLayout:
-    """Snapshot the placed chrome artists and axes box as resize-invariant inch offsets.
-
-    ``source_text`` is passed by reference rather than recovered from the figure, so the source
-    (the one bottom-anchored element) is identified explicitly; every other chrome text is a
-    top-anchored header element.
-    """
-    renderer = fig.canvas.get_renderer()
-    fig_h = fig.get_figheight()
-    fig_w = fig.get_figwidth()
-    bbox_h = fig.bbox.height
-    top_texts: list[tuple[Text, float]] = []
-    for text in fig.texts:
-        if text.get_gid() != chrome_gid or text is source_text:
-            continue
-        extent = text.get_window_extent(renderer=renderer)
-        top_texts.append((text, (1.0 - extent.y1 / bbox_h) * fig_h))
-    source: tuple[Text, float] | None = None
-    if source_text is not None:
-        source = (source_text, source_text.get_window_extent(renderer=renderer).y0 / bbox_h * fig_h)
-    tab: tuple[Rectangle, float, float, float] | None = None
-    for patch in [p for p in fig.patches if p.get_gid() == chrome_gid]:
-        top_frac = patch.get_y() + patch.get_height()
-        tab = (patch, (1.0 - top_frac) * fig_h, patch.get_height() * fig_h, patch.get_width() * fig_w)
-    axes_top_offset_in, axes_bottom_offset_in = _axes_offsets_in(ax, fig_h)
-    return _ChromeLayout(
-        ax=ax,
-        top_texts=top_texts,
-        source=source,
-        tab=tab,
-        axes_top_offset_in=axes_top_offset_in,
-        axes_bottom_offset_in=axes_bottom_offset_in,
-    )
 
 
 def _resolve_chrome_left(fig: Figure, ax: Axes) -> float:
@@ -384,12 +412,18 @@ def apply_chart_chrome(
 ) -> None:
     """Place the figure-level chrome (eyebrow, tab, title, subtitle, source) and reflow the axes.
 
-    Sequential layout: each header element is placed and drawn in turn so
-    the next element starts directly below the previous one's measured
-    bbox. Wrapped titles therefore push subsequent elements down by their
-    actual rendered height, never their estimated height. After the header
-    and source are placed, ``tight_layout`` reflows the axes (with their
-    tick and axis labels) into the remaining vertical band.
+    Sequential layout: each header element is placed in turn so the next
+    starts directly below the previous one's measured bbox. Wrapped titles
+    therefore push subsequent elements down by their actual rendered height,
+    never their estimated height. After the header and source are placed,
+    ``tight_layout`` reflows the axes (with their tick and axis labels) into
+    the remaining vertical band.
+
+    The placement is stored as a resize-invariant recipe and re-derived on
+    every draw by ``_ChromeLayoutEngine``: the title and subtitle re-wrap to
+    the figure's current width, so resizing the figure after this call (e.g.
+    ``fig.set_size_inches``) re-flows the chrome instead of freezing the wrap
+    at the build-time width.
 
     Each absent element collapses its slot, so a chart with only a title
     takes only the vertical space the title needs.
@@ -418,6 +452,12 @@ def apply_chart_chrome(
     chrome_gid = f"_ors_chrome:{id(ax)}"
 
     _clear_prior_chrome(fig, chrome_gid)
+    # Drop any prior layout for this axes too: _clear_prior_chrome just detached its chrome texts
+    # (their figure is now None), so the reflow below and the engine must not try to re-wrap them.
+    # The fresh layout replaces this entry at the end of the call.
+    prior_layouts = getattr(fig, "_ors_chrome_layouts", None)
+    if prior_layouts is not None:
+        prior_layouts.pop(id(ax), None)
 
     if any_chrome:
         _track_chrome_axes(fig, ax, warn_stacklevel=warn_stacklevel)
@@ -425,17 +465,22 @@ def apply_chart_chrome(
     chrome_x = _resolve_chrome_left(fig, ax) if any_chrome else _CHROME_FALLBACK_LEFT_MARGIN
 
     fig_h = fig.get_figheight()
+    fig_w = fig.get_figwidth()
+    dpi = fig.dpi
+    renderer = _active_renderer(fig)
     cur_y = 1.0 - _CHROME_TOP_MARGIN_IN / fig_h
 
     # Always reserve the tab's vertical slot when a header is present, even when
     # the tab is hidden. This keeps the title's distance from the figure edge
     # consistent whether the tab is drawn or hidden, so suppressing the tab
     # doesn't push the title against the top margin.
+    tab_spec: tuple[Rectangle, float, float, float] | None = None
+    header_top_offset_in = _CHROME_TOP_MARGIN_IN
     if has_header:
         tab_height_fig = _CHROME_TAB_HEIGHT_IN / fig_h
         tab_to_eyebrow_fig = _CHROME_TAB_TO_EYEBROW_GAP_IN / fig_h
         if show_tab:
-            tab_width_fig = _CHROME_TAB_WIDTH_IN / fig.get_figwidth()
+            tab_width_fig = _CHROME_TAB_WIDTH_IN / fig_w
             tab = Rectangle(
                 (chrome_x, cur_y - tab_height_fig),
                 tab_width_fig,
@@ -447,11 +492,14 @@ def apply_chart_chrome(
             )
             tab.set_gid(chrome_gid)
             fig.patches.append(tab)
+            tab_spec = (tab, _CHROME_TOP_MARGIN_IN, _CHROME_TAB_HEIGHT_IN, _CHROME_TAB_WIDTH_IN)
         cur_y -= tab_height_fig + tab_to_eyebrow_fig
+        header_top_offset_in = (1.0 - cur_y) * fig_h
 
     # Eyebrow's gap is always applied; the title→subtitle gap only when both
     # are present. Subtitle has no trailing gap — _CHROME_GAP_HEADER_TO_AXES_IN
-    # below covers the whitespace down to the plot.
+    # below covers the whitespace down to the plot. Eyebrows stay single-line; the
+    # title and subtitle re-wrap to the figure's current width on every draw.
     header_specs = (
         (
             eyebrow.upper() if eyebrow is not None else None,
@@ -459,7 +507,7 @@ def apply_chart_chrome(
             style.eyebrow_size,
             style.eyebrow_color,
             False,
-            _CHROME_GAP_EYEBROW_TO_TITLE_IN / fig_h,
+            _CHROME_GAP_EYEBROW_TO_TITLE_IN,
         ),
         (
             title,
@@ -467,7 +515,7 @@ def apply_chart_chrome(
             style.title_size,
             style.title_color,
             True,
-            _CHROME_GAP_TITLE_TO_SUBTITLE_IN / fig_h if subtitle is not None else 0.0,
+            _CHROME_GAP_TITLE_TO_SUBTITLE_IN if subtitle is not None else 0.0,
         ),
         (
             subtitle,
@@ -478,11 +526,25 @@ def apply_chart_chrome(
             0.0,
         ),
     )
-    for text, font, size, color, wrap, gap_after in header_specs:
-        if text is None:
+    header: list[_ChromeTextSpec] = []
+    for text_str, font, size, color, wrap, gap_after_in in header_specs:
+        if text_str is None:
             continue
-        cur_y = _place_header_text(ax, chrome_x, cur_y, text, font, size, color, wrap=wrap, gid=chrome_gid)
-        cur_y -= gap_after
+        artist = fig.text(
+            chrome_x,
+            1.0 - header_top_offset_in / fig_h,
+            text_str,
+            ha="left",
+            va="top",
+            fontproperties=get_font_properties(font),
+            fontsize=size,
+            color=color,
+            wrap=wrap,
+        )
+        artist.set_gid(chrome_gid)
+        header.append(_ChromeTextSpec(artist, text_str, gap_after_in, wrap=wrap))
+
+    header_bottom_in = _layout_chrome_header(header, header_top_offset_in, fig_h, dpi, renderer)
 
     # tight_layout reserves most top tick-label height inside [bottom, header_bottom],
     # but its default label padding leaves a little less visible subtitle-to-content
@@ -490,15 +552,15 @@ def apply_chart_chrome(
     # to keep that visible gap consistent.
     has_top_labels = any(t.label2.get_visible() for t in [*ax.xaxis.get_major_ticks(), *ax.yaxis.get_major_ticks()])
     extra_gap_in = style.tick_size * _CHROME_TOP_LABEL_HEADROOM_FACTOR / 72.0 if has_top_labels else 0.0
-    header_bottom = cur_y - (_CHROME_GAP_HEADER_TO_AXES_IN + extra_gap_in) / fig_h if has_header else cur_y
+    rect_top_in = header_bottom_in + _CHROME_GAP_HEADER_TO_AXES_IN + extra_gap_in if has_header else header_bottom_in
+    header_bottom = 1.0 - rect_top_in / fig_h
 
-    bottom_margin_fig = _CHROME_BOTTOM_MARGIN_IN / fig_h
-    axes_bottom = bottom_margin_fig
-    source_t = None
+    source_spec: _ChromeTextSpec | None = None
+    axes_bottom_in = _CHROME_BOTTOM_MARGIN_IN
     if source_text is not None:
-        source_t = fig.text(
+        source_artist = fig.text(
             chrome_x,
-            bottom_margin_fig,
+            _CHROME_BOTTOM_MARGIN_IN / fig_h,
             source_text,
             ha="left",
             va="bottom",
@@ -507,13 +569,11 @@ def apply_chart_chrome(
             color=style.source_color,
             wrap=True,
         )
-        source_t.set_gid(chrome_gid)
-        fig.canvas.draw()
-        # Freeze the wrap like the header: an unfrozen source re-wraps to a different line count
-        # on a width resize, invalidating the axes_bottom reserved here and crowding the axes.
-        _freeze_text_wrap(source_t)
-        source_top_px = source_t.get_window_extent(renderer=fig.canvas.get_renderer()).y1
-        axes_bottom = source_top_px / fig.bbox.height + _CHROME_GAP_SOURCE_TO_AXES_IN / fig_h
+        source_artist.set_gid(chrome_gid)
+        source_spec = _ChromeTextSpec(source_artist, source_text, 0.0, wrap=True)
+        source_top_in = _layout_chrome_source(source_spec, _CHROME_BOTTOM_MARGIN_IN, fig_h, dpi, renderer)
+        axes_bottom_in = source_top_in + _CHROME_GAP_SOURCE_TO_AXES_IN
+    axes_bottom = axes_bottom_in / fig_h
 
     # Cache the chrome rect so callers (e.g. _auto_rotate_categorical_x_ticks)
     # can re-reflow after they change tick label heights. Without this, a
@@ -524,15 +584,25 @@ def apply_chart_chrome(
     if not _reflow_axes(fig, top=header_bottom, bottom=axes_bottom):
         fig.subplots_adjust(top=header_bottom, bottom=axes_bottom)
 
-    # Snapshot the placement as inch offsets and install the engine so the chrome tracks the
-    # figure's current height on later draws; otherwise the fraction-based gaps balloon (or
-    # overlap, when shrunk) on resize. Header/source placement and the reflow above already
-    # drew, so artist extents are current for the snapshot.
+    # Store the placement as a resize-invariant recipe and install the engine so the chrome
+    # re-wraps and re-flows to the figure's current size on later draws; otherwise the wrap
+    # freezes at the build-time width and the fraction-based gaps balloon (or overlap) on resize.
     layouts = getattr(fig, "_ors_chrome_layouts", None)
     if layouts is None:
         layouts = {}
         fig._ors_chrome_layouts = layouts
-    layouts[id(ax)] = _capture_chrome_layout(fig, ax, chrome_gid, source_t)
+    layout = _ChromeLayout(
+        ax=ax,
+        header_top_offset_in=header_top_offset_in,
+        header=header,
+        header_to_axes_gap_in=0.0,
+        source=source_spec,
+        source_to_axes_gap_in=0.0,
+        axes_bottom_offset_in=_CHROME_BOTTOM_MARGIN_IN,
+        tab=tab_spec,
+    )
+    _recompute_chrome_axes_gaps(layout, fig, _active_renderer(fig))
+    layouts[id(ax)] = layout
     _install_chrome_layout_engine(fig)
 
 

--- a/openretailscience/plots/styles/styling_helpers.py
+++ b/openretailscience/plots/styles/styling_helpers.py
@@ -105,6 +105,10 @@ def _rewrap_text_to_width(text: Text, original: str, renderer: RendererBase) -> 
     it on every draw is what stops a post-call resize from leaving the wrap frozen at the
     build-time width. ``original`` (the unwrapped source) is supplied by the caller because the
     baked artist no longer holds it.
+
+    Leans on matplotlib's private wrap internals (``_get_wrapped_text`` and the ``_renderer``
+    attribute) — there is no public width-wrap API. A rename fails loudly at the bare call; a
+    silent contract change is caught by the line-count assertions in the chrome tests.
     """
     text.set_text(original)
     text.set_wrap(True)
@@ -168,17 +172,19 @@ def _layout_chrome_header(
 
 def _layout_chrome_source(
     source: _ChromeTextSpec,
-    bottom_offset_in: float,
     fig_h: float,
     dpi: float,
     renderer: RendererBase,
 ) -> float:
-    """Re-wrap the bottom-anchored source line; return its top offset in inches from the figure bottom."""
+    """Re-wrap the bottom-anchored source line; return its top offset in inches from the figure bottom.
+
+    The source is anchored at ``_CHROME_BOTTOM_MARGIN_IN`` from the figure bottom.
+    """
     if source.wrap:
         _rewrap_text_to_width(source.text, source.original, renderer)
-    source.text.set_y(bottom_offset_in / fig_h)
+    source.text.set_y(_CHROME_BOTTOM_MARGIN_IN / fig_h)
     height_in = source.text.get_window_extent(renderer=renderer).height / dpi
-    return bottom_offset_in + height_in
+    return _CHROME_BOTTOM_MARGIN_IN + height_in
 
 
 @dataclass
@@ -224,7 +230,7 @@ def _apply_chrome_layout(
     header_bottom_in = _layout_chrome_header(layout.header, layout.header_top_offset_in, fig_h, dpi, renderer)
     axes_top_in = header_bottom_in + layout.header_to_axes_gap_in
     if layout.source is not None:
-        source_top_in = _layout_chrome_source(layout.source, _CHROME_BOTTOM_MARGIN_IN, fig_h, dpi, renderer)
+        source_top_in = _layout_chrome_source(layout.source, fig_h, dpi, renderer)
         axes_bottom_in = source_top_in + layout.source_to_axes_gap_in
     else:
         axes_bottom_in = layout.axes_bottom_offset_in
@@ -257,7 +263,9 @@ def _recompute_chrome_axes_gaps(layout: _ChromeLayout, fig: Figure, renderer: Re
     """Set ``layout``'s header/source-to-axes gaps from the axes box's current position.
 
     The engine derives the axes top/bottom from these gaps, so they must be re-captured whenever the
-    box is reflowed: at initial layout, and after any later reflow that moved it.
+    box is reflowed: at initial layout, and after any later reflow that moved it. Re-wraps and
+    repositions the header and source artists as a side effect, since the gaps are measured against
+    their freshly laid-out heights.
     """
     fig_h = fig.get_figheight()
     dpi = fig.dpi
@@ -266,7 +274,7 @@ def _recompute_chrome_axes_gaps(layout: _ChromeLayout, fig: Figure, renderer: Re
     layout.header_to_axes_gap_in = (1.0 - pos.y1) * fig_h - header_bottom_in
     axes_bottom_in = pos.y0 * fig_h
     if layout.source is not None:
-        source_top_in = _layout_chrome_source(layout.source, _CHROME_BOTTOM_MARGIN_IN, fig_h, dpi, renderer)
+        source_top_in = _layout_chrome_source(layout.source, fig_h, dpi, renderer)
         layout.source_to_axes_gap_in = axes_bottom_in - source_top_in
     else:
         layout.axes_bottom_offset_in = axes_bottom_in
@@ -530,6 +538,7 @@ def apply_chart_chrome(
     for text_str, font, size, color, wrap, gap_after_in in header_specs:
         if text_str is None:
             continue
+        # y is a placeholder; _layout_chrome_header stacks the elements into their real positions below.
         artist = fig.text(
             chrome_x,
             1.0 - header_top_offset_in / fig_h,
@@ -558,6 +567,7 @@ def apply_chart_chrome(
     source_spec: _ChromeTextSpec | None = None
     axes_bottom_in = _CHROME_BOTTOM_MARGIN_IN
     if source_text is not None:
+        # y is a placeholder; _layout_chrome_source sets the real position below.
         source_artist = fig.text(
             chrome_x,
             _CHROME_BOTTOM_MARGIN_IN / fig_h,
@@ -571,7 +581,7 @@ def apply_chart_chrome(
         )
         source_artist.set_gid(chrome_gid)
         source_spec = _ChromeTextSpec(source_artist, source_text, 0.0, wrap=True)
-        source_top_in = _layout_chrome_source(source_spec, _CHROME_BOTTOM_MARGIN_IN, fig_h, dpi, renderer)
+        source_top_in = _layout_chrome_source(source_spec, fig_h, dpi, renderer)
         axes_bottom_in = source_top_in + _CHROME_GAP_SOURCE_TO_AXES_IN
     axes_bottom = axes_bottom_in / fig_h
 
@@ -601,7 +611,7 @@ def apply_chart_chrome(
         axes_bottom_offset_in=_CHROME_BOTTOM_MARGIN_IN,
         tab=tab_spec,
     )
-    _recompute_chrome_axes_gaps(layout, fig, _active_renderer(fig))
+    _recompute_chrome_axes_gaps(layout, fig, renderer)
     layouts[id(ax)] = layout
     _install_chrome_layout_engine(fig)
 

--- a/openretailscience/plots/styles/styling_helpers.py
+++ b/openretailscience/plots/styles/styling_helpers.py
@@ -97,18 +97,16 @@ def _resolve_end_of_line_legend_args(
 
 
 def _rewrap_text_to_width(text: Text, original: str, renderer: RendererBase) -> None:
-    """Bake ``original`` into ``text``, wrapped to the figure's current width.
+    """Bake ``original`` into ``text`` as newlines wrapped to the figure's current width.
 
-    matplotlib's ``wrap=True`` only re-wraps during ``draw`` and ``get_window_extent`` ignores it,
-    so chrome bakes the wrap into explicit newlines to measure a stable height. Pointing the text
-    at the live ``renderer`` first makes the bake follow the figure's *current* width: re-deriving
-    it on every draw is what stops a post-call resize from leaving the wrap frozen at the
-    build-time width. ``original`` (the unwrapped source) is supplied by the caller because the
-    baked artist no longer holds it.
+    matplotlib's ``wrap=True`` re-wraps only during ``draw`` and ``get_window_extent`` ignores it,
+    so chrome bakes the wrap to measure a stable height. Pointing the text at the live ``renderer``
+    first makes the bake track the *current* width, so a post-call resize re-wraps instead of
+    freezing at the build-time width. ``original`` is passed in because the baked artist no longer
+    holds the unwrapped source.
 
-    Leans on matplotlib's private wrap internals (``_get_wrapped_text`` and the ``_renderer``
-    attribute) — there is no public width-wrap API. A rename fails loudly at the bare call; a
-    silent contract change is caught by the line-count assertions in the chrome tests.
+    Uses matplotlib internals (``_get_wrapped_text``, ``_renderer``); no public width-wrap API
+    exists. A rename fails loudly here, and the chrome line-count tests catch a silent change.
     """
     text.set_text(original)
     text.set_wrap(True)
@@ -120,10 +118,9 @@ def _rewrap_text_to_width(text: Text, original: str, renderer: RendererBase) -> 
 def _active_renderer(fig: Figure) -> RendererBase:
     """Return the renderer for the figure's current draw, across backends.
 
-    The chrome engine measures text on every draw, including ``savefig``, during which matplotlib
-    swaps in a vector canvas (``FigureCanvasSVG``/``Pdf``) that has no ``get_renderer``. Use
-    ``fig._get_renderer()`` (what matplotlib's own tight/constrained layout engines use), not
-    ``fig.canvas.get_renderer()``, which exists only on the Agg canvas.
+    The engine measures on every draw including ``savefig``, where matplotlib swaps in a vector
+    canvas (SVG/PDF) with no ``get_renderer``. ``fig._get_renderer()`` (used by matplotlib's own
+    layout engines) works on every backend; ``fig.canvas.get_renderer()`` is Agg-only.
     """
     return fig._get_renderer()
 
@@ -178,10 +175,9 @@ def _layout_chrome_source(
 ) -> float:
     """Re-wrap the bottom-anchored source line; return its top offset in inches from the figure bottom.
 
-    The source is anchored at ``_CHROME_BOTTOM_MARGIN_IN`` from the figure bottom.
+    The source always wraps and is anchored at ``_CHROME_BOTTOM_MARGIN_IN`` from the figure bottom.
     """
-    if source.wrap:
-        _rewrap_text_to_width(source.text, source.original, renderer)
+    _rewrap_text_to_width(source.text, source.original, renderer)
     source.text.set_y(_CHROME_BOTTOM_MARGIN_IN / fig_h)
     height_in = source.text.get_window_extent(renderer=renderer).height / dpi
     return _CHROME_BOTTOM_MARGIN_IN + height_in
@@ -262,10 +258,9 @@ def _apply_chrome_layouts(fig: Figure) -> None:
 def _recompute_chrome_axes_gaps(layout: _ChromeLayout, fig: Figure, renderer: RendererBase) -> None:
     """Set ``layout``'s header/source-to-axes gaps from the axes box's current position.
 
-    The engine derives the axes top/bottom from these gaps, so they must be re-captured whenever the
-    box is reflowed: at initial layout, and after any later reflow that moved it. Re-wraps and
-    repositions the header and source artists as a side effect, since the gaps are measured against
-    their freshly laid-out heights.
+    The engine derives the axes top/bottom from these gaps, so re-capture them after every reflow.
+    Re-wraps and repositions the header and source artists as a side effect, since the gaps are
+    measured against their fresh heights.
     """
     fig_h = fig.get_figheight()
     dpi = fig.dpi
@@ -427,11 +422,9 @@ def apply_chart_chrome(
     ``tight_layout`` reflows the axes (with their tick and axis labels) into
     the remaining vertical band.
 
-    The placement is stored as a resize-invariant recipe and re-derived on
-    every draw by ``_ChromeLayoutEngine``: the title and subtitle re-wrap to
-    the figure's current width, so resizing the figure after this call (e.g.
-    ``fig.set_size_inches``) re-flows the chrome instead of freezing the wrap
-    at the build-time width.
+    The placement is stored as a resize-invariant recipe and re-derived on every
+    draw by ``_ChromeLayoutEngine``, so resizing the figure after this call (e.g.
+    ``fig.set_size_inches``) re-wraps and re-flows the chrome to the new size.
 
     Each absent element collapses its slot, so a chart with only a title
     takes only the vertical space the title needs.
@@ -580,7 +573,7 @@ def apply_chart_chrome(
             wrap=True,
         )
         source_artist.set_gid(chrome_gid)
-        source_spec = _ChromeTextSpec(source_artist, source_text, 0.0, wrap=True)
+        source_spec = _ChromeTextSpec(source_artist, source_text, 0.0)
         source_top_in = _layout_chrome_source(source_spec, fig_h, dpi, renderer)
         axes_bottom_in = source_top_in + _CHROME_GAP_SOURCE_TO_AXES_IN
     axes_bottom = axes_bottom_in / fig_h
@@ -595,8 +588,7 @@ def apply_chart_chrome(
         fig.subplots_adjust(top=header_bottom, bottom=axes_bottom)
 
     # Store the placement as a resize-invariant recipe and install the engine so the chrome
-    # re-wraps and re-flows to the figure's current size on later draws; otherwise the wrap
-    # freezes at the build-time width and the fraction-based gaps balloon (or overlap) on resize.
+    # re-wraps and re-flows to the figure's current size on later draws.
     layouts = getattr(fig, "_ors_chrome_layouts", None)
     if layouts is None:
         layouts = {}
@@ -704,7 +696,7 @@ def _set_xtick_rotation(ax: Axes, angle: float) -> None:
 def _xtick_labels_overlap(ax: Axes, fig: Figure) -> bool:
     """Return True when adjacent x-tick label bboxes encroach on the configured gap."""
     fig.canvas.draw()
-    renderer = fig.canvas.get_renderer()
+    renderer = _active_renderer(fig)
     bboxes = sorted(
         (label.get_window_extent(renderer=renderer) for label in ax.get_xticklabels()),
         key=lambda b: b.x0,

--- a/tests/plots/styles/test_chart_chrome.py
+++ b/tests/plots/styles/test_chart_chrome.py
@@ -1,5 +1,6 @@
 """Tests for the chart chrome layout engine."""
 
+import io
 import warnings
 
 import matplotlib.pyplot as plt
@@ -79,6 +80,32 @@ def _measure_chrome_spacing(figheight: float, build_height: float | None = None)
 
 
 _CHROME_TEST_FIGHEIGHT_IN = 5.0
+
+_TITLE_WRAP_RESIZE_TITLE = "Two regions are carrying the entire quarter while the rest of the portfolio lags"
+_TITLE_WRAP_RESIZE_SUBTITLE = "Sales index by region versus the company-wide average baseline of one hundred"
+
+# A real chrome figure rendered to SVG/PDF is tens of KB; a failed/empty render is far smaller.
+_MIN_RENDERED_VECTOR_BYTES = 1000
+
+
+def _render_title_wrap(build_w: float, final_w: float) -> tuple[int, float]:
+    """Build chrome at ``build_w`` wide, resize to ``final_w``, and return the title's line count and width fraction.
+
+    The width fraction is the title's rendered width as a fraction of the figure width. Resizing
+    after the build reproduces the export flow that froze the wrap at the build-time width.
+    """
+    fig, ax = plt.subplots(figsize=(build_w, 5))
+    ax.barh(["North", "South"], [120, 80])
+    apply_chart_chrome(ax, title=_TITLE_WRAP_RESIZE_TITLE, subtitle=_TITLE_WRAP_RESIZE_SUBTITLE)
+    if build_w != final_w:
+        fig.set_size_inches(final_w, 5)
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    title_artist = next(t for t in fig.texts if t.get_text().replace("\n", " ") == _TITLE_WRAP_RESIZE_TITLE)
+    line_count = title_artist.get_text().count("\n") + 1
+    width_frac = title_artist.get_window_extent(renderer=renderer).width / fig.bbox.width
+    plt.close(fig)
+    return line_count, width_frac
 
 
 def _topmost_axes_content_fig_y(*, labeltop: bool) -> float:
@@ -196,24 +223,21 @@ class TestApplyChartChrome:
         # Subtitle's top must sit below the title's bottom (no overlap).
         assert subtitle_top <= title_bottom
 
-    def test_wrap_is_frozen_so_redraws_do_not_change_line_count(self):
-        """Chrome must bake matplotlib's wrap into the text content with explicit newlines.
+    def test_title_wrap_is_baked_into_explicit_newlines(self):
+        """Chrome bakes the title's wrap into explicit newlines (wrap off), not matplotlib soft-wrap.
 
-        matplotlib's ``wrap=True`` recomputes line breaks on every draw based on the
-        current figure bbox. ``bbox_inches='tight'`` (used by jupyter notebook saves)
-        triggers an extra draw cycle with a different bbox, which can change the
-        line count. Chrome positions sibling elements relative to the title's
-        measured bottom, so any post-layout re-wrap leaves an oversized gap.
-        Freezing the wrap ensures the layout stays correct across redraws.
+        ``get_window_extent`` ignores ``wrap=True``, so a soft-wrapped title would measure a
+        single-line height and collapse the layout. Chrome instead bakes the wrapped lines into the
+        text content with wrap off, giving a stable multi-line height to position siblings against;
+        the engine re-bakes to the current width on each draw.
         """
         fig, ax = plt.subplots(figsize=(6.4, 4.8))
         long_title = "High-AOV stores convert fewer visits but earn the most revenue per day"
         apply_chart_chrome(ax, title=long_title)
 
         title_artist = fig.texts[0]
-        # Wrap must be off so the text doesn't re-wrap on subsequent draws.
+        # Wrap is baked into explicit newlines with soft-wrap off, so a redraw measures a stable height.
         assert title_artist.get_wrap() is False
-        # The wrapped form is baked into the text content as explicit newlines.
         assert "\n" in title_artist.get_text()
         # All original words preserved, only whitespace replaced with newlines.
         assert title_artist.get_text().replace("\n", " ") == long_title
@@ -259,11 +283,12 @@ class TestApplyChartChrome:
                 f"track the resized figure height"
             )
 
-    def test_source_text_does_not_rewrap_into_axes_on_width_resize(self):
-        """Narrowing the figure after layout must not re-wrap the source line into the axes.
+    def test_source_rewraps_but_axes_follow_on_width_resize(self):
+        """Narrowing the figure re-wraps the source to more lines, and the axes bottom follows it.
 
-        The source wrap is frozen like the header; otherwise a width change re-wraps it to more
-        lines, growing it up into the reserved source-to-axes gap.
+        The source re-wraps to the current width like the header; the engine then pushes the axes
+        bottom up so the reserved source-to-axes gap is preserved, instead of the taller source
+        crowding into the data area.
         """
         long_source = (
             "Source: 2024 loyalty-program transactions across all banners, excluding staff "
@@ -276,16 +301,75 @@ class TestApplyChartChrome:
 
         fig.canvas.draw()
         renderer = fig.canvas.get_renderer()
+        wide_lines = source_artist.get_text().count("\n") + 1
         gap_wide = ax.get_position().y0 * fig.bbox.height - source_artist.get_window_extent(renderer=renderer).y1
 
         fig.set_size_inches(4, 5)
         fig.canvas.draw()
         renderer = fig.canvas.get_renderer()
+        narrow_lines = source_artist.get_text().count("\n") + 1
         gap_narrow = ax.get_position().y0 * fig.bbox.height - source_artist.get_window_extent(renderer=renderer).y1
 
+        assert narrow_lines > wide_lines, (
+            f"source stayed at {wide_lines} lines when the figure narrowed; its wrap did not track the current width"
+        )
         assert abs(gap_narrow - gap_wide) <= 1.0, (
-            f"source-to-axes gap changed from {gap_wide:.1f}px to {gap_narrow:.1f}px when the "
-            "figure narrowed; the source re-wrapped because its wrap was not frozen"
+            f"source-to-axes gap changed from {gap_wide:.1f}px to {gap_narrow:.1f}px when the figure "
+            "narrowed; the axes bottom did not follow the re-wrapped source"
+        )
+
+    # The build-time width is narrow enough that the title wraps there; each target is wide enough
+    # that a direct build wraps to fewer lines.
+    _NARROW_BUILD_WIDTH_IN = 6.0
+    # A title still frozen on the narrow figure's breaks spans only ~40-55% of the widened figure;
+    # a re-wrapped one spans ~80-90%. 0.7 sits cleanly between the two regimes.
+    _TITLE_SPANS_WIDTH_FRAC = 0.7
+
+    @pytest.mark.parametrize("final_w", [10.0, 12.0, 14.0])
+    def test_title_rewraps_to_match_width_after_resize(self, final_w):
+        """A title built narrow then widened must re-wrap to match the line count of a direct wide build.
+
+        Chrome baked matplotlib's wrap at the build-time width, so widening the figure afterwards
+        left the title broken onto the narrow figure's line breaks, spanning only a fraction of the
+        wider figure. The wrap must re-flow to the figure's current width.
+        """
+        lines_resized, width_frac_resized = _render_title_wrap(build_w=self._NARROW_BUILD_WIDTH_IN, final_w=final_w)
+        lines_direct, _ = _render_title_wrap(build_w=final_w, final_w=final_w)
+
+        assert lines_resized == lines_direct, (
+            f"title wrapped to {lines_resized} lines after widening to {final_w}in but {lines_direct} "
+            "when built wide directly; the wrap stayed frozen at the build-time width"
+        )
+        assert width_frac_resized > self._TITLE_SPANS_WIDTH_FRAC, (
+            f"title spans only {width_frac_resized:.0%} of the widened figure; it stayed collapsed on "
+            "the narrow figure's line breaks instead of re-wrapping to the current width"
+        )
+
+    @pytest.mark.parametrize(("fmt", "signature"), [("svg", b"<svg"), ("pdf", b"%PDF")])
+    def test_chrome_saves_to_vector_backend_after_resize(self, fmt, signature):
+        """Saving a chromed figure to a vector backend (SVG/PDF) must work, including after a resize.
+
+        The layout engine re-measures on every draw via the figure renderer. Saving to a vector
+        format swaps in a canvas with no Agg ``get_renderer``, so looking the renderer up off the
+        canvas crashed the save; the export is the bug report's own repro and was untested.
+        """
+        fig, ax = plt.subplots(figsize=(6, 4))
+        ax.barh(["North", "South"], [120, 80])
+        apply_chart_chrome(
+            ax,
+            title="Two regions are carrying the entire quarter while the rest of the portfolio lags",
+            subtitle="Sales index by region versus the company-wide average baseline of one hundred",
+            source_text="Source: 2024 loyalty transactions",
+        )
+        fig.set_size_inches(11, 9)  # resize after layout, then export
+
+        buf = io.BytesIO()
+        fig.savefig(buf, format=fmt)
+        data = buf.getvalue()
+
+        assert signature in data[:1024], f"{fmt} output is missing its format signature; the save did not render"
+        assert len(data) > _MIN_RENDERED_VECTOR_BYTES, (
+            f"{fmt} output is only {len(data)} bytes; the chrome figure did not render"
         )
 
     def test_chrome_survives_resize_on_figure_with_colorbar(self):


### PR DESCRIPTION
## Summary

`index.plot(..., color_by_threshold=True)` chrome (title/subtitle) wrapped to ~40% of the width when the figure was resized **after** the call (e.g. `fig.set_size_inches(11, 9.5)`), stacking the text toward the middle and leaving the right side empty. This is a follow-up to the merged chart-title-spacing work.

### Root cause

Chrome text was added with matplotlib `wrap=True`, then **frozen** — the line breaks were baked at the figure's build-time width and never recomputed. Resizing afterward kept the narrow figure's breaks, so a wider figure showed a title that spanned only a fraction of the width.

### Minimal repro (from the issue)

```python
ax = index.plot(df, value_col="sales", group_col="region", index_col="period",
                value_to_index="Current", color_by_threshold=True, highlight_range=(80, 120),
                title="Two regions are carrying the quarter",
                subtitle="Sales index by region vs the national average (100)")
ax.get_figure().set_size_inches(11, 9.5)              # resize AFTER plotting
ax.get_figure().savefig("bug.svg", bbox_inches="tight")  # title wrapped to ~40%
```

## The fix

- Store the chrome placement as a **resize-invariant recipe** (`_ChromeLayout`) and re-derive positions on every draw via the layout engine, **re-wrapping** the header and source to the figure's *current* width. The source re-wraps too, and the axes bottom follows it so the source-to-axes gap is preserved.
- Correct the `index.plot` docstring that wrongly implied `figsize` is ignored in `color_by_threshold` mode — it sizes the figure when `ax is None` and is only excluded from the `barh` call.

### Vector-backend regression (caught in review)

The per-draw engine now measures via the figure renderer. A naive `fig.canvas.get_renderer()` exists only on the Agg canvas, so saving to SVG/PDF (the issue's own `savefig("bug.svg")` repro) crashed with `AttributeError` on the swapped canvas. Routed through `fig._get_renderer()` — the backend-agnostic call matplotlib's own tight/constrained layout engines use.

## Testing

- New `test_title_rewraps_to_match_width_after_resize` (parametrized over target widths): a title built narrow then widened re-wraps to the line count of a direct wide build and spans the width.
- Rewrote the source test to assert it re-wraps on narrowing **and** the axes follow it (gap preserved).
- New `test_chrome_saves_to_vector_backend_after_resize` (SVG + PDF) — the gap that let the renderer crash ship.
- Full suite: **1105 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)