### PR TITLE
Fix net bar corruption when zero amounts are removed

### DIFF
--- a/openretailscience/plots/waterfall.py
+++ b/openretailscience/plots/waterfall.py
@@ -107,7 +107,7 @@ def plot(
     df = pd.DataFrame({"labels": labels, "amounts": amounts})
 
     if remove_zero_amounts:
-        df = df[df["amounts"] != 0]
+        df = df[df["amounts"] != 0].reset_index(drop=True)
 
     amount_total = df["amounts"].sum()
 

--- a/tests/plots/test_waterfall.py
+++ b/tests/plots/test_waterfall.py
@@ -102,6 +102,22 @@ class TestWaterfallPlot:
         assert isinstance(result_ax, plt.Axes)
         assert len(result_ax.patches) == non_zero_amounts
 
+    def test_net_bar_with_zero_amount_removed_preserves_remaining_bars(self):
+        """Dropping a zero amount must not let the appended net bar clobber a surviving bar."""
+        # Revenue by customer segment, with a zero "Repeating" segment that gets dropped.
+        amounts = [311475.0, 66444.0, 0.0, -284585.0]
+        labels = ["Pre Period", "New", "Repeating", "Lapsed"]
+
+        result_ax = plot(amounts, labels, display_net_bar=True)
+
+        surviving = [(label, amount) for label, amount in zip(labels, amounts, strict=True) if amount != 0]
+        net_total = sum(amount for _, amount in surviving)
+
+        assert len(result_ax.patches) == len(surviving) + 1
+        assert [t.get_text() for t in result_ax.get_xticklabels()] == [label for label, _ in surviving] + ["Net"]
+        bar_heights = [patch.get_height() for patch in result_ax.patches]
+        assert bar_heights == [amount for _, amount in surviving] + [net_total]
+
     # Raises a ValueError for an invalid data label format
     def test_raises_value_error_for_invalid_data_label_format(self, test_data):
         """Test that the function raises a ValueError for an invalid data label format."""


### PR DESCRIPTION
## Summary

Fixed a bug in the waterfall plot where removing zero amounts caused the net bar to overwrite an existing bar due to non-contiguous DataFrame indices. The fix ensures the net bar is appended at the correct position after filtering.

## Changes

- **waterfall.py**: Added `.reset_index(drop=True)` after filtering zero amounts to ensure contiguous indices before appending the net bar row
- **test_waterfall.py**: Added comprehensive test case `test_net_bar_with_zero_amount_removed_preserves_remaining_bars` that verifies:
  - Zero amounts are correctly removed
  - Remaining bars retain their correct values
  - The net bar is appended without corrupting existing bars
  - All labels and bar heights are preserved in the correct order

## Implementation Details

The bug occurred because when a zero amount was filtered out, the DataFrame retained its original indices (e.g., `[0, 1, 3]` after removing index 2). When the net bar was appended using positional length (`len(df)`), it would be inserted at the wrong position, overwriting an existing bar. Resetting the index to be contiguous (`[0, 1, 2]`) ensures the net bar is appended at the correct position after all surviving categories.

https://claude.ai/code/session_01SV7ZqbFWNQvhpS71fhvp3E