### PR TITLE
feat(plots): add figsize parameter to scatter and price plots

### DIFF
--- a/openretailscience/plots/price.py
+++ b/openretailscience/plots/price.py
@@ -141,6 +141,7 @@ def plot(
     x_label: str | None = None,
     y_label: str | None = None,
     legend_title: str | None = None,
+    figsize: tuple[int, int] | None = None,
     ax: Axes | None = None,
     source_text: str | None = None,
     move_legend_outside: bool = False,
@@ -162,6 +163,7 @@ def plot(
         x_label (str, optional): The label for the x-axis. Defaults to None.
         y_label (str, optional): The label for the y-axis. Defaults to None.
         legend_title (str, optional): The title for the legend. Defaults to None.
+        figsize (tuple[int, int], optional): Size of the new figure when ``ax`` is None. Defaults to None.
         ax (Axes, optional): The Matplotlib Axes object to plot on. Defaults to None.
         source_text (str, optional): Text to be displayed as a source at the bottom of the plot. Defaults to None.
         move_legend_outside (bool, optional): Whether to move the legend outside the plot area. Defaults to False.
@@ -188,7 +190,8 @@ def plot(
     # Convert to proportions (0-1 range)
     proportions = bin_counts.div(group_totals, axis=0)
 
-    ax = ax or plt.gca()
+    if ax is None:
+        _, ax = plt.subplots(figsize=figsize)
 
     # Get unique groups and bins
     groups = proportions.index.tolist()

--- a/openretailscience/plots/scatter.py
+++ b/openretailscience/plots/scatter.py
@@ -254,6 +254,7 @@ def plot(  # noqa: PLR0913
     group_col: str | None = None,
     size_col: str | None = None,
     size_scale: float = 1.0,
+    figsize: tuple[int, int] | None = None,
     ax: Axes | None = None,
     source_text: str | None = None,
     legend_title: str | None = None,
@@ -279,6 +280,7 @@ def plot(  # noqa: PLR0913
             When used with multiple value_col columns, the same size values apply to all series.
         size_scale (float, optional): Scaling factor for point sizes. Default: 1.0.
             Actual size = size_col_value * size_scale.
+        figsize (tuple[int, int], optional): Size of the new figure when ``ax`` is None. Defaults to None.
         ax (Axes, optional): Matplotlib axes object to plot on.
         source_text (str, optional): The source text to add to the plot.
         legend_title (str, optional): The title of the legend.
@@ -345,7 +347,8 @@ def plot(  # noqa: PLR0913
     # Process size data if size_col is specified
     size_data = _process_size_data(df, size_col, size_scale, x_col, group_col)
 
-    ax = ax or plt.gca()
+    if ax is None:
+        _, ax = plt.subplots(figsize=figsize)
     alpha = kwargs.pop("alpha", 0.7)
 
     _create_scatter_plot(ax, pivot_df, colors, size_data, group_col, is_multi_scatter, alpha, **kwargs)

--- a/tests/plots/test_price.py
+++ b/tests/plots/test_price.py
@@ -352,6 +352,21 @@ def test_plot_legend_outside_reflows_axes_to_reserve_room(simple_price_dataframe
     )
 
 
+def test_plot_with_figsize(simple_price_dataframe):
+    """Test price plot sizes the figure when figsize is passed and no ax is provided."""
+    width, height = 12, 8
+    result_ax = price.plot(
+        df=simple_price_dataframe,
+        value_col="unit_price",
+        group_col="retailer",
+        bins=3,
+        figsize=(width, height),
+    )
+
+    assert result_ax.figure.get_size_inches()[0] == width
+    assert result_ax.figure.get_size_inches()[1] == height
+
+
 def test_plot_adds_source_text(simple_price_dataframe):
     """The price plot renders source_text as a figure-level text element."""
     source_text = "Source: Test Data"

--- a/tests/plots/test_scatter.py
+++ b/tests/plots/test_scatter.py
@@ -70,6 +70,20 @@ def bubble_chart_dataframe():
     return pd.DataFrame(data)
 
 
+def test_plot_with_figsize(sample_sales_dataframe):
+    """Test scatter plot sizes the figure when figsize is passed and no ax is provided."""
+    width, height = 12, 8
+    result_ax = scatter.plot(
+        df=sample_sales_dataframe,
+        value_col="sales",
+        x_col="date",
+        figsize=(width, height),
+    )
+
+    assert result_ax.figure.get_size_inches()[0] == width
+    assert result_ax.figure.get_size_inches()[1] == height
+
+
 def test_plot_single_column(sample_sales_dataframe):
     """Test scatter plot with a single value column."""
     result_ax = scatter.plot(

--- a/tests/plots/test_scatter.py
+++ b/tests/plots/test_scatter.py
@@ -84,6 +84,21 @@ def test_plot_with_figsize(sample_sales_dataframe):
     assert result_ax.figure.get_size_inches()[1] == height
 
 
+def test_plot_draws_on_provided_ax(sample_sales_dataframe):
+    """Scatter plot reuses a caller-provided ax instead of creating a new figure."""
+    _, ax = plt.subplots()
+    result_ax = scatter.plot(
+        df=sample_sales_dataframe,
+        value_col="sales",
+        x_col="date",
+        ax=ax,
+    )
+
+    assert result_ax is ax
+    collections = [child for child in ax.get_children() if hasattr(child, "get_offsets")]
+    assert len(collections) == 1
+
+
 def test_plot_single_column(sample_sales_dataframe):
     """Test scatter plot with a single value column."""
     result_ax = scatter.plot(


### PR DESCRIPTION
Both plots previously fell back to plt.gca() when no axes were provided,
so the figure size could not be controlled. Add an explicit figsize
parameter that sizes the new figure via plt.subplots when ax is None,
matching the convention already used by heatmap, venn, cohort and the
other figure-creating plots.

https://claude.ai/code/session_01Uy7vFgH8WCQfo2XCoGKfNP