### PR TITLE
Skip Codecov and code review jobs for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,9 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
+    # Skip automated dependency PRs: Dependabot runs without access to secrets and
+    # claude-code-action refuses to run for bot actors, so the job can only ever fail.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run Pre-commit
         run: uv run pre-commit run --all-files
       - name: Pre-import Codecov uploader signing key
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         # Workaround for codecov/codecov-action#1876: the uploader intermittently
         # fails to fetch its own verification key, producing "Can't check signature:
         # No public key" and failing the job under fail_ci_if_error. Pre-seed Codecov's
@@ -59,7 +59,7 @@ jobs:
           rm -f codecov.asc
           exit 0
       - name: Upload coverage to Codecov
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Exclude Dependabot automated dependency PRs from Codecov upload and Claude code review workflows. These jobs cannot succeed for bot actors due to missing secret access and tool restrictions, so skipping them prevents unnecessary failures and wasted CI resources.

## Changes

- **test.yml**: Added `&& github.actor != 'dependabot[bot]'` condition to both the "Pre-import Codecov uploader signing key" and "Upload coverage to Codecov" steps. Dependabot PRs run without access to `CODECOV_TOKEN`, causing these steps to fail.

- **claude-code-review.yml**: Added job-level `if: github.actor != 'dependabot[bot]'` condition. The claude-code-action tool explicitly refuses to run for bot actors, making the job unable to succeed regardless of configuration.

## Implementation Details

These changes follow the principle of simplicity by removing unnecessary job executions rather than adding workarounds. Dependabot PRs are automated and don't require human code review or coverage tracking in the same way as regular PRs, so skipping these jobs is the correct behavior rather than a limitation to work around.

https://claude.ai/code/session_01HRhb5z6bvWenagUZb8gK9d