### PR TITLE
fix(security): unblock Security Audit and route its failures to Slack

### DIFF
--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -11,6 +11,7 @@ on:
       - "Tests"
       - "PyPi Package Deploy"
       - "Page Deploy"
+      - "Security Audit"
       - "BigQuery Integration Tests"
       - "PySpark Integration Tests"
       - "Snowflake Integration Tests"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -5,15 +5,7 @@
 # advisory resurfaces for re-review; entries for permanent false positives omit
 # it. Both the PyPI (PYSEC) and GitHub/CVE identifiers are listed per advisory so
 # the ignore matches whichever id OSV-Scanner surfaces.
-
-# joblib CVE-2024-34997 / PYSEC-2024-277 — disputed by the maintainer as a false
-# positive (https://github.com/joblib/joblib/issues/1588). NumpyArrayWrapper
-# deserializes only trusted cached content, never untrusted input. No fix will be
-# released, so this suppression is permanent (no ignoreUntil).
-[[IgnoredVulns]]
-id     = "PYSEC-2024-277"
-reason = "joblib CVE-2024-34997: disputed false positive (https://github.com/joblib/joblib/issues/1588); deserializes only trusted cache content. No fix planned."
-
-[[IgnoredVulns]]
-id     = "CVE-2024-34997"
-reason = "joblib CVE-2024-34997: disputed false positive (https://github.com/joblib/joblib/issues/1588); deserializes only trusted cache content. No fix planned."
+#
+# No active suppressions. (OSV-Scanner v2 exits non-zero on ignore entries that
+# match nothing in the current scan, so stale suppressions must be removed once
+# the advisory no longer surfaces.)

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -6,6 +6,4 @@
 # it. Both the PyPI (PYSEC) and GitHub/CVE identifiers are listed per advisory so
 # the ignore matches whichever id OSV-Scanner surfaces.
 #
-# No active suppressions. (OSV-Scanner v2 exits non-zero on ignore entries that
-# match nothing in the current scan, so stale suppressions must be removed once
-# the advisory no longer surfaces.)
+# No active suppressions.


### PR DESCRIPTION
## Summary

The **Security Audit** workflow has been failing on `main` (e.g. [run 27669555335](https://github.com/Data-Simply/openretailscience/actions/runs/27669555335), the Dependabot dev-dependency bump), and the failure was never announced in Slack. This PR fixes both.

### 1. Stale OSV-Scanner suppression → failing job

The scan found **zero vulnerabilities**, but exited non-zero:

```
osv-scanner.toml has unused ignores:
 - PYSEC-2024-277
 - CVE-2024-34997
Exit code: 1
```

`osv-scanner.toml` suppressed the disputed joblib `CVE-2024-34997` / `PYSEC-2024-277` advisory. joblib `1.4.2` is still pinned, but OSV no longer surfaces that advisory for it, so both ignore entries match nothing — and OSV-Scanner v2 treats unused ignores as a non-clean run. On a `push` to `main` the workflow's gate is hard, so the job failed. Removing the now-dead suppressions lets the scan pass.

### 2. Security Audit failures weren't reaching Slack

`slack-notifications.yml` only reacts to workflows listed in its `workflow_run` trigger, and `"Security Audit"` was missing. So even a genuine vulnerability gate failure would have gone unannounced. Added it to the watched list, alongside the other gating workflows.

## Changes

- `osv-scanner.toml` — drop the two unused `[[IgnoredVulns]]` entries; keep the policy header and note why stale suppressions must be removed.
- `.github/workflows/slack-notifications.yml` — add `"Security Audit"` to the watched `workflow_run` workflows.

## Notes

- No real vulnerability was being masked: the dispute that justified the original suppression was a maintainer-confirmed false positive, and OSV no longer flags joblib 1.4.2 at all.
- If that advisory (or any other) resurfaces, the scan will fail again as intended — and now Slack will say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Su9dsdnq5qaQyTZ9CdkVBb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Su9dsdnq5qaQyTZ9CdkVBb)_