### PR TITLE
Support dict argument in option_context for cleaner multi-option overrides

### DIFF
--- a/docs/getting_started/options_guide.md
+++ b/docs/getting_started/options_guide.md
@@ -65,8 +65,7 @@ df = df.rename(columns={
 Tell OpenRetailScience what your column names are using `option_context()`. This doesn't rename your columns - it
 configures OpenRetailScience's internal settings to look for your column names instead of the defaults. Options can be
 supplied as alternating name/value pairs (below) or as a single dictionary such as
-`option_context({"column.customer_id": "cust_id"})` - the dict form is handy when overriding a single option, since you
-don't have to track its position in the argument list:
+`option_context({"column.customer_id": "cust_id"})`:
 
 ```python
 from openretailscience.options import option_context

--- a/docs/getting_started/options_guide.md
+++ b/docs/getting_started/options_guide.md
@@ -92,6 +92,15 @@ with option_context(
 # Configuration automatically resets after the block
 ```
 
+You can also pass a single dictionary instead of alternating name/value pairs. This is handy when overriding one
+named option, since you don't have to track its position in a flat argument list:
+
+```python
+with option_context({"column.customer_id": "cust_id"}):
+    # OpenRetailScience uses "cust_id" within this block
+    ...
+```
+
 ### Option 3: Use a TOML Configuration File (Recommended)
 
 !!! tip "Recommended Approach"

--- a/docs/getting_started/options_guide.md
+++ b/docs/getting_started/options_guide.md
@@ -63,7 +63,10 @@ df = df.rename(columns={
     Scripts where you want to keep your original column names throughout.
 
 Tell OpenRetailScience what your column names are using `option_context()`. This doesn't rename your columns - it
-configures OpenRetailScience's internal settings to look for your column names instead of the defaults:
+configures OpenRetailScience's internal settings to look for your column names instead of the defaults. Options can be
+supplied as alternating name/value pairs (below) or as a single dictionary such as
+`option_context({"column.customer_id": "cust_id"})` - the dict form is handy when overriding a single option, since you
+don't have to track its position in the argument list:
 
 ```python
 from openretailscience.options import option_context
@@ -90,15 +93,6 @@ with option_context(
     gl.plot()
 
 # Configuration automatically resets after the block
-```
-
-You can also pass a single dictionary instead of alternating name/value pairs. This is handy when overriding one
-named option, since you don't have to track its position in a flat argument list:
-
-```python
-with option_context({"column.customer_id": "cust_id"}):
-    # OpenRetailScience uses "cust_id" within this block
-    ...
 ```
 
 ### Option 3: Use a TOML Configuration File (Recommended)

--- a/openretailscience/options.py
+++ b/openretailscience/options.py
@@ -527,7 +527,8 @@ def option_context(*args: OptionTypes) -> Generator[None, None, None]:
         None
 
     Raises:
-        ValueError: If an odd number of arguments is supplied (positional form).
+        ValueError: If an odd number of arguments is supplied (positional form), or if an
+            unknown option name is supplied (either form).
 
     Example:
         >>> with option_context('column.customer_id', 'cust_id', 'column.store_id', 'outlet_id'):

--- a/openretailscience/options.py
+++ b/openretailscience/options.py
@@ -5,14 +5,14 @@ of data display and processing. The module also includes a context manager for
 temporarily changing options.
 
 Example:
-    >>> set_option('display.max_rows', 100)
-    >>> print(get_option('display.max_rows'))
-    100
-    >>> with option_context('display.max_rows', 10):
-    ...     print(get_option('display.max_rows'))
-    10
-    >>> print(get_option('display.max_rows'))
-    100
+    >>> set_option('column.customer_id', 'cust_id')
+    >>> print(get_option('column.customer_id'))
+    cust_id
+    >>> with option_context('column.customer_id', 'shopper_id'):
+    ...     print(get_option('column.customer_id'))
+    shopper_id
+    >>> print(get_option('column.customer_id'))
+    cust_id
 
 """
 
@@ -530,10 +530,10 @@ def option_context(*args: OptionTypes) -> Generator[None, None, None]:
         ValueError: If an odd number of arguments is supplied (positional form).
 
     Example:
-        >>> with option_context('display.max_rows', 10, 'display.max_columns', 5):
+        >>> with option_context('column.customer_id', 'cust_id', 'column.store_id', 'outlet_id'):
         ...     # Do something with modified options
         ...     pass
-        >>> with option_context({'display.max_rows': 10, 'display.max_columns': 5}):
+        >>> with option_context({'column.customer_id': 'cust_id', 'column.store_id': 'outlet_id'}):
         ...     # Equivalent dict form
         ...     pass
         >>> # Options are restored to their previous values here

--- a/openretailscience/options.py
+++ b/openretailscience/options.py
@@ -541,11 +541,11 @@ def option_context(*args: OptionTypes) -> Generator[None, None, None]:
         >>> # Options are restored to their previous values here
     """
     if len(args) == 1 and isinstance(args[0], dict):
-        items = list(args[0].items())
+        items = args[0].items()
+    elif len(args) % 2 != 0:
+        raise ValueError("The context manager requires an even number of arguments")
     else:
-        if len(args) % 2 != 0:
-            raise ValueError("The context manager requires an even number of arguments")
-        items = list(zip(args[::2], args[1::2], strict=True))
+        items = zip(args[::2], args[1::2], strict=True)
 
     old_options: dict[str, OptionTypes] = {}
     try:

--- a/openretailscience/options.py
+++ b/openretailscience/options.py
@@ -516,9 +516,7 @@ def option_context(*args: OptionTypes) -> Generator[None, None, None]:
 
     Temporarily set options and restore them to their previous values after the
     context exits. Options may be supplied either as alternating option names and
-    values, or as a single mapping of option names to values. The mapping form is
-    convenient when overriding a single named option without tracking its position
-    in a flat argument list.
+    values, or as a single mapping of option names to values.
 
     Args:
         *args: Either an even number of arguments alternating between option names

--- a/openretailscience/options.py
+++ b/openretailscience/options.py
@@ -515,31 +515,41 @@ def option_context(*args: OptionTypes) -> Generator[None, None, None]:
     """Context manager to temporarily set options.
 
     Temporarily set options and restore them to their previous values after the
-    context exits. The arguments should be supplied as alternating option names
-    and values.
+    context exits. Options may be supplied either as alternating option names and
+    values, or as a single mapping of option names to values. The mapping form is
+    convenient when overriding a single named option without tracking its position
+    in a flat argument list.
 
     Args:
-        *args: An even number of arguments, alternating between option names (str)
-               and their corresponding values.
+        *args: Either an even number of arguments alternating between option names
+               (str) and their corresponding values, or a single dict mapping
+               option names to values.
 
     Yields:
         None
 
     Raises:
-        ValueError: If an odd number of arguments is supplied.
+        ValueError: If an odd number of arguments is supplied (positional form).
 
     Example:
         >>> with option_context('display.max_rows', 10, 'display.max_columns', 5):
         ...     # Do something with modified options
         ...     pass
+        >>> with option_context({'display.max_rows': 10, 'display.max_columns': 5}):
+        ...     # Equivalent dict form
+        ...     pass
         >>> # Options are restored to their previous values here
     """
-    if len(args) % 2 != 0:
-        raise ValueError("The context manager requires an even number of arguments")
+    if len(args) == 1 and isinstance(args[0], dict):
+        items = list(args[0].items())
+    else:
+        if len(args) % 2 != 0:
+            raise ValueError("The context manager requires an even number of arguments")
+        items = list(zip(args[::2], args[1::2], strict=True))
 
     old_options: dict[str, OptionTypes] = {}
     try:
-        for pat, val in zip(args[::2], args[1::2], strict=True):
+        for pat, val in items:
             old_options[pat] = get_option(pat)
             set_option(pat, val)
         yield

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -45,12 +45,29 @@ class TestOptions:
             assert key in description
             assert "(current value:" in description
 
-    def test_context_manager_overrides_option(self):
-        """Test that the context manager overrides the option value correctly at the global level."""
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ("column.customer_id", "new_customer_id"),
+            ({"column.customer_id": "new_customer_id"},),
+        ],
+    )
+    def test_context_manager_overrides_option(self, args):
+        """Test that the context manager overrides the option value for both positional and dict call styles."""
         original_value = opt.get_option("column.customer_id")
-        with opt.option_context("column.customer_id", "new_customer_id"):
+        with opt.option_context(*args):
             assert opt.get_option("column.customer_id") == "new_customer_id"
         assert opt.get_option("column.customer_id") == original_value
+
+    def test_context_manager_dict_overrides_multiple_options(self):
+        """Test that a dict argument overrides multiple options and restores them all on exit."""
+        original_customer = opt.get_option("column.customer_id")
+        original_store = opt.get_option("column.store_id")
+        with opt.option_context({"column.customer_id": "shopper_id", "column.store_id": "outlet_id"}):
+            assert opt.get_option("column.customer_id") == "shopper_id"
+            assert opt.get_option("column.store_id") == "outlet_id"
+        assert opt.get_option("column.customer_id") == original_customer
+        assert opt.get_option("column.store_id") == original_store
 
     def test_context_manager_odd_number_of_arguments_raises_value_error(self):
         """Test that the context manager raises a ValueError when an odd number of arguments is passed."""

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -14,14 +14,14 @@ class TestOptions:
     def test_unknown_option_raises_value_error(self):
         """Test setting/getting/resetting an unknown option raises a ValueError."""
         options = opt.Options()
-        with pytest.raises(ValueError, match=r"Unknown option: unknown.option"):
+        with pytest.raises(ValueError, match=r"Unknown option: unknown\.option"):
             options.set_option("unknown.option", "some_value")
-        with pytest.raises(ValueError, match=r"Unknown option: unknown.option"):
-            options.get_option("unknown_option")
-        with pytest.raises(ValueError, match=r"Unknown option: unknown.option"):
-            options.reset_option("unknown_option")
-        with pytest.raises(ValueError, match=r"Unknown option: unknown.option"):
-            options.describe_option("unknown_option")
+        with pytest.raises(ValueError, match=r"Unknown option: unknown\.option"):
+            options.get_option("unknown.option")
+        with pytest.raises(ValueError, match=r"Unknown option: unknown\.option"):
+            options.reset_option("unknown.option")
+        with pytest.raises(ValueError, match=r"Unknown option: unknown\.option"):
+            options.describe_option("unknown.option")
 
     def test_set_option_updates_value(self):
         """Test setting an option updates the option value correctly."""

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -11,17 +11,21 @@ import openretailscience.options as opt
 class TestOptions:
     """Test for option handling class."""
 
-    def test_unknown_option_raises_value_error(self):
-        """Test setting/getting/resetting an unknown option raises a ValueError."""
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            lambda o: o.set_option("unknown.option", "some_value"),
+            lambda o: o.get_option("unknown.option"),
+            lambda o: o.reset_option("unknown.option"),
+            lambda o: o.describe_option("unknown.option"),
+        ],
+        ids=["set_option", "get_option", "reset_option", "describe_option"],
+    )
+    def test_unknown_option_raises_value_error(self, operation):
+        """Test that each option accessor raises ValueError for an unknown option."""
         options = opt.Options()
         with pytest.raises(ValueError, match=r"Unknown option: unknown\.option"):
-            options.set_option("unknown.option", "some_value")
-        with pytest.raises(ValueError, match=r"Unknown option: unknown\.option"):
-            options.get_option("unknown.option")
-        with pytest.raises(ValueError, match=r"Unknown option: unknown\.option"):
-            options.reset_option("unknown.option")
-        with pytest.raises(ValueError, match=r"Unknown option: unknown\.option"):
-            options.describe_option("unknown.option")
+            operation(options)
 
     def test_set_option_updates_value(self):
         """Test setting an option updates the option value correctly."""


### PR DESCRIPTION
## Summary
Extend `option_context()` to accept options as a single dictionary argument in addition to the existing alternating name/value pairs. This provides a cleaner API when overriding multiple options without sacrificing backward compatibility.

## Changes
- **`openretailscience/options.py`**: Modified `option_context()` to detect and handle dict arguments. When a single dict is passed, it is unpacked as option name/value pairs. The positional form (alternating args) remains unchanged and fully supported.
- **`tests/test_options.py`**: 
  - Parameterized `test_context_manager_overrides_option` to verify both calling styles work identically
  - Added `test_context_manager_dict_overrides_multiple_options` to validate dict form with multiple options
  - Fixed test assertions to use consistent option names (`unknown.option` instead of mixing `unknown.option` and `unknown_option`)
  - Fixed regex patterns to properly escape dots in option names
- **`docs/getting_started/options_guide.md`**: Updated documentation to show both calling styles with examples

## Implementation Details
The implementation checks if exactly one argument is passed and it is a dict; if so, it uses that dict's items directly. Otherwise, it validates the argument count is even and zips alternating pairs as before. This approach is simple and maintains full backward compatibility while enabling the more ergonomic dict form for multi-option scenarios.

https://claude.ai/code/session_01AiVBeegCwWPUhNHr2dqLi6