### PR TITLE
Remove scheduled security audit scan

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -12,8 +12,10 @@ name: Security Audit
 #
 # On pull requests the scan runs only when dependencies or this workflow change,
 # and is advisory (results still post to code scanning); pushes to main (same
-# path filter) refresh the default-branch code-scanning state, and scheduled
-# runs, manual dispatches, and release calls are hard gates.
+# path filter) refresh the default-branch code-scanning state, and manual
+# dispatches and release calls are hard gates. Detection of newly-disclosed CVEs
+# against already-pinned dependencies (with no repo change) is left to Dependabot
+# alerts and security updates, so no scheduled scan is needed here.
 
 on:
   pull_request:
@@ -30,8 +32,6 @@ on:
       - "pyproject.toml"
       - "osv-scanner.toml"
       - ".github/workflows/security-audit.yml"
-  schedule:
-    - cron: "0 6 * * 1" # Mondays 06:00 UTC
   workflow_dispatch:
   workflow_call:
 


### PR DESCRIPTION
## Summary
Removes the scheduled weekly security audit workflow in favor of relying on Dependabot for continuous vulnerability detection. This simplifies the CI/CD pipeline by eliminating redundant scanning.

## Changes
- Removed the `schedule` trigger (Monday 06:00 UTC cron job) from the security-audit workflow
- Updated workflow documentation to clarify that:
  - Pull requests run scans only when dependencies or the workflow itself changes (advisory)
  - Pushes to main refresh code-scanning state
  - Manual dispatches and release calls remain hard gates
  - Dependabot alerts and security updates handle detection of newly-disclosed CVEs against pinned dependencies

## Rationale
The scheduled scan was redundant because Dependabot already provides continuous monitoring for newly-disclosed CVEs against pinned dependencies. By removing the scheduled trigger, we reduce unnecessary CI runs while maintaining security coverage through Dependabot's automated alerts and security updates. The workflow still runs on relevant changes (dependencies, workflow file) and serves as a hard gate for releases and manual triggers.

https://claude.ai/code/session_01L6duQyAidZHdk7qHv9KTzA