### PR TITLE
chore(deps): bump soupsieve to 2.8.4 to resolve OSV security advisories

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -667,7 +667,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -3173,7 +3173,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.11'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -3234,7 +3234,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.11'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
 wheels = [
@@ -3421,11 +3421,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.5"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/21/952a240de1c196c7e3fbcd4e559681f0419b1280c617db21157a0390717b/soupsieve-2.5.tar.gz", hash = "sha256:5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690", size = 100943, upload-time = "2023-09-02T12:48:22.131Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/f3/038b302fdfbe3be7da016777069f26ceefe11a681055ea1f7817546508e3/soupsieve-2.5-py3-none-any.whl", hash = "sha256:eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7", size = 36131, upload-time = "2023-09-02T12:48:20.552Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The scheduled **OSV-Scanner security audit** (`.github/workflows/security-audit.yml`) has been failing because a locked dependency carries two known High-severity advisories.

The culprit is a single transitive package:

| Package | Version | Advisories | Severity | Fixed in |
|---|---|---|---|---|
| `soupsieve` | 2.5 → **2.8.4** | [GHSA-2wc2-fm75-p42x](https://osv.dev/GHSA-2wc2-fm75-p42x), [GHSA-836r-79rf-4m37](https://osv.dev/GHSA-836r-79rf-4m37) | 2 × High (CVSS 7.5) | 2.8.4 |

## Dependency chain

`soupsieve` is not a direct dependency. It is pulled in transitively by the docs toolchain:

```
[dependency-groups] docs
   └─ mkdocs-jupyter
        └─ nbconvert
             └─ beautifulsoup4
                  └─ soupsieve   ← vulnerable
```

`beautifulsoup4` 4.12.3 requires only `soupsieve >1.2` (no upper bound), so bumping `soupsieve` to 2.8.4 satisfies the tree without touching `beautifulsoup4`, `nbconvert`, or the docs stack.

## Changes

- `uv lock --upgrade-package soupsieve` → `soupsieve` 2.5 → 2.8.4.
- The lockfile also picks up a few incidental dependency-marker normalizations on `exceptiongroup` and `scipy` from the resolver; package versions are unchanged and the markers are semantically equivalent (redundant markers inside already-version-scoped package entries).

## Verification

Ran OSV-Scanner v2.3.8 (the same version CI uses) against the updated `uv.lock`:

```
Scanned uv.lock file and found 208 packages
No issues found
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhA8nh3YmtEBjTy9iQ1U8d

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhA8nh3YmtEBjTy9iQ1U8d)_