### PR TITLE
Fix zero-label blanking to track value instead of tick index

### DIFF
--- a/openretailscience/plots/styles/styling_helpers.py
+++ b/openretailscience/plots/styles/styling_helpers.py
@@ -42,6 +42,7 @@ class _ZeroBlankingFormatter(Formatter):
 
     def __init__(self, base: Formatter) -> None:
         """Store the wrapped ``base`` formatter to delegate to."""
+        super().__init__()
         self._base = base
 
     def __call__(self, x: float, pos: int | None = None) -> str:

--- a/openretailscience/plots/styles/styling_helpers.py
+++ b/openretailscience/plots/styles/styling_helpers.py
@@ -29,53 +29,48 @@ GridAxis = Literal["both", "x", "y", "none"]
 class _ZeroBlankingFormatter(Formatter):
     """Wrap an axis's major formatter, rendering the value ``0`` as an empty label.
 
-    The zero label is dropped by the *value* the formatter is asked to render,
-    not by a persistent visibility flag on a tick artist. matplotlib consults
-    the major formatter on every draw against the live tick value, so the blank
-    tracks the real ``0`` even after a caller changes the tick positions or
-    limits, and can never leak onto whichever value later occupies a reused tick
-    artist. Every other call delegates to the wrapped formatter, so its numeric
-    formatting and shared offset text (e.g. ``ScalarFormatter``'s ``1e6``) are
-    preserved. A caller who installs their own formatter replaces the wrapper,
-    which cleanly turns the zero-drop off — they have taken over the axis.
+    Dropping the zero label by *value* on every draw — rather than by hiding the
+    tick artist at zero's index — is what fixes the leak: matplotlib reuses tick
+    artists by index, so an index-pinned flag would blank whatever value later
+    lands on that index. All other calls delegate to the base formatter, so its
+    numeric formatting and offset text (e.g. ``ScalarFormatter``'s ``1e6``) are
+    preserved; a caller who sets their own formatter replaces the wrapper, which
+    stops the zero-drop. Any other attribute is delegated to the base as well
+    (see ``__getattr__``), so a caller's ``Axes.ticklabel_format`` still reaches
+    the real ``ScalarFormatter`` underneath instead of raising.
     """
 
     def __init__(self, base: Formatter) -> None:
-        """Store the wrapped formatter.
-
-        Args:
-            base (Formatter): The axis's existing major formatter to delegate to.
-        """
+        """Store the wrapped ``base`` formatter to delegate to."""
         self._base = base
 
     def __call__(self, x: float, pos: int | None = None) -> str:
-        """Format ``x``, returning an empty string at ``x == 0``.
-
-        Args:
-            x (float): The tick value to format.
-            pos (int | None): The tick position index, forwarded to the base formatter.
-
-        Returns:
-            str: The base formatter's label, or ``""`` when ``x`` is exactly ``0``.
-        """
+        """Return the base label for ``x``, or ``""`` when ``x`` is exactly ``0``."""
         return "" if x == 0 else self._base(x, pos)
 
     def set_locs(self, locs: Sequence[float]) -> None:
-        """Forward the tick locations so the base formatter can compute its offset/scale.
-
-        Args:
-            locs (Sequence[float]): The major tick locations for the current draw.
-        """
+        """Forward the tick locations so the base formatter can compute its offset and scale."""
         self._base.set_locs(locs)
 
     def get_offset(self) -> str:
-        """Return the base formatter's offset text (e.g. ``ScalarFormatter``'s ``1e6``).
-
-        Returns:
-            str: The offset string rendered alongside the axis, or ``""`` if the
-                base formatter has none.
-        """
+        """Return the base formatter's offset text (e.g. ``ScalarFormatter``'s ``1e6``)."""
         return self._base.get_offset()
+
+    def __getattr__(self, name: str) -> object:
+        """Delegate any non-overridden attribute to the base formatter.
+
+        Keeps the wrapper a transparent stand-in for what it wraps: callers that
+        configure the axis via ``Axes.ticklabel_format`` — which calls
+        ``ScalarFormatter``-only setters (``set_scientific``, ``set_powerlimits``,
+        ``set_useOffset`` …) on the major formatter — reach the real formatter
+        instead of hitting ``AttributeError``. The return is whatever attribute
+        the base exposes, so ``object`` is the only honest annotation here.
+        """
+        # __getattr__ only fires for names missing on the wrapper; guard ``_base``
+        # itself so a half-built instance raises cleanly instead of recursing.
+        if name == "_base":
+            raise AttributeError(name)
+        return getattr(self._base, name)
 
 
 def _hide_zero_value_ticks(ax: Axes) -> None:
@@ -89,16 +84,14 @@ def _hide_zero_value_ticks(ax: Axes) -> None:
     categorical axes (``FixedLocator``) and date axes (``AutoDateLocator``) are
     untouched, since their position-0 tick is a category index, not a data zero.
 
-    The blank is applied by wrapping the axis's major formatter (see
-    ``_ZeroBlankingFormatter``) rather than hiding a tick artist, so it is
-    re-derived from the tick value on every draw and cannot leak onto another
-    value when the caller later changes ticks or limits.
+    The blank is applied via a formatter wrapper (see ``_ZeroBlankingFormatter``)
+    so it is keyed to the tick value, not to a reused tick artist.
     """
     for axis in (ax.xaxis, ax.yaxis):
         if not isinstance(axis.get_major_locator(), MaxNLocator | AutoLocator):
             continue
         formatter = axis.get_major_formatter()
-        # Idempotent: a repeated styling pass must not nest the wrapper in itself.
+        # Idempotent: don't nest the wrapper on a repeated styling pass.
         if isinstance(formatter, _ZeroBlankingFormatter):
             continue
         axis.set_major_formatter(_ZeroBlankingFormatter(formatter))

--- a/openretailscience/plots/styles/styling_helpers.py
+++ b/openretailscience/plots/styles/styling_helpers.py
@@ -9,13 +9,15 @@ from typing import TYPE_CHECKING, Literal
 
 from matplotlib.layout_engine import LayoutEngine
 from matplotlib.patches import Rectangle
-from matplotlib.ticker import AutoLocator, FixedFormatter, FixedLocator, MaxNLocator
+from matplotlib.ticker import AutoLocator, FixedFormatter, FixedLocator, Formatter, MaxNLocator
 
 from openretailscience.options import PlotStyleHelper
 from openretailscience.plots.styles.font_utils import get_font_properties
 from openretailscience.plots.styles.graph_utils import draw_end_of_line_labels
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from matplotlib.axes import Axes
     from matplotlib.backend_bases import RendererBase
     from matplotlib.figure import Figure
@@ -24,8 +26,60 @@ if TYPE_CHECKING:
 GridAxis = Literal["both", "x", "y", "none"]
 
 
+class _ZeroBlankingFormatter(Formatter):
+    """Wrap an axis's major formatter, rendering the value ``0`` as an empty label.
+
+    The zero label is dropped by the *value* the formatter is asked to render,
+    not by a persistent visibility flag on a tick artist. matplotlib consults
+    the major formatter on every draw against the live tick value, so the blank
+    tracks the real ``0`` even after a caller changes the tick positions or
+    limits, and can never leak onto whichever value later occupies a reused tick
+    artist. Every other call delegates to the wrapped formatter, so its numeric
+    formatting and shared offset text (e.g. ``ScalarFormatter``'s ``1e6``) are
+    preserved. A caller who installs their own formatter replaces the wrapper,
+    which cleanly turns the zero-drop off — they have taken over the axis.
+    """
+
+    def __init__(self, base: Formatter) -> None:
+        """Store the wrapped formatter.
+
+        Args:
+            base (Formatter): The axis's existing major formatter to delegate to.
+        """
+        self._base = base
+
+    def __call__(self, x: float, pos: int | None = None) -> str:
+        """Format ``x``, returning an empty string at ``x == 0``.
+
+        Args:
+            x (float): The tick value to format.
+            pos (int | None): The tick position index, forwarded to the base formatter.
+
+        Returns:
+            str: The base formatter's label, or ``""`` when ``x`` is exactly ``0``.
+        """
+        return "" if x == 0 else self._base(x, pos)
+
+    def set_locs(self, locs: Sequence[float]) -> None:
+        """Forward the tick locations so the base formatter can compute its offset/scale.
+
+        Args:
+            locs (Sequence[float]): The major tick locations for the current draw.
+        """
+        self._base.set_locs(locs)
+
+    def get_offset(self) -> str:
+        """Return the base formatter's offset text (e.g. ``ScalarFormatter``'s ``1e6``).
+
+        Returns:
+            str: The offset string rendered alongside the axis, or ``""`` if the
+                base formatter has none.
+        """
+        return self._base.get_offset()
+
+
 def _hide_zero_value_ticks(ax: Axes) -> None:
-    """Hide tick labels at value 0 on numeric axes (Economist editorial convention).
+    """Blank the ``0`` tick label on numeric axes (Economist editorial convention).
 
     The ``0`` tick sits in the bottom-left corner where the x and y spines meet,
     crowding the orthogonal axis's first tick label. The spine itself implies
@@ -34,18 +88,20 @@ def _hide_zero_value_ticks(ax: Axes) -> None:
     Only acts on numeric continuous axes (``MaxNLocator`` / ``AutoLocator``);
     categorical axes (``FixedLocator``) and date axes (``AutoDateLocator``) are
     untouched, since their position-0 tick is a category index, not a data zero.
+
+    The blank is applied by wrapping the axis's major formatter (see
+    ``_ZeroBlankingFormatter``) rather than hiding a tick artist, so it is
+    re-derived from the tick value on every draw and cannot leak onto another
+    value when the caller later changes ticks or limits.
     """
     for axis in (ax.xaxis, ax.yaxis):
         if not isinstance(axis.get_major_locator(), MaxNLocator | AutoLocator):
             continue
-        # get_major_ticks() returns one Tick per locator position, so the
-        # lengths match deterministically. get_majorticklabels() filters by
-        # visibility and changes length once this function has already hidden
-        # a label or under tick_params(labeltop=True)/labelright=True.
-        for tick, loc in zip(axis.get_major_ticks(), axis.get_majorticklocs(), strict=True):
-            if loc == 0:
-                tick.label1.set_visible(False)
-                tick.label2.set_visible(False)
+        formatter = axis.get_major_formatter()
+        # Idempotent: a repeated styling pass must not nest the wrapper in itself.
+        if isinstance(formatter, _ZeroBlankingFormatter):
+            continue
+        axis.set_major_formatter(_ZeroBlankingFormatter(formatter))
 
 
 # Chrome layout constants. Vertical spacings are in absolute inches so the

--- a/tests/plots/styles/test_styling_helper.py
+++ b/tests/plots/styles/test_styling_helper.py
@@ -128,10 +128,7 @@ class TestStylingHelpers:
         fig.canvas.draw()
 
         for axis in (ax.xaxis, ax.yaxis):
-            formatter = axis.get_major_formatter()
-            assert isinstance(formatter, _ZeroBlankingFormatter)
-            # A second wrap would nest the wrapper inside itself.
-            assert not isinstance(formatter._base, _ZeroBlankingFormatter)
+            assert isinstance(axis.get_major_formatter(), _ZeroBlankingFormatter)
             assert self._blank_tick_locs(axis) == {0.0}
 
     def test_apply_ticks_blanks_zero_on_both_label_rows(self, fig_ax):
@@ -176,6 +173,23 @@ class TestStylingHelpers:
         assert formatter.get_offset() == base.get_offset()
         assert formatter(0) == ""
         assert formatter(1_500_000) == base(1_500_000)
+
+    def test_ticklabel_format_still_works_after_apply_ticks(self, fig_ax):
+        """A caller's ``ax.ticklabel_format`` succeeds after styling and 0 stays blanked.
+
+        matplotlib's ``ticklabel_format`` calls ``ScalarFormatter``-only setters
+        (``set_scientific``/``set_powerlimits``/...) on the major formatter and
+        raises "only works with the ScalarFormatter" if they are missing. The
+        wrapper must delegate them to the base rather than shadow the real one.
+        """
+        fig, ax = fig_ax
+        ax.plot([0, 1, 2], [0, 1000, 2000])
+        apply_ticks(ax)
+
+        ax.ticklabel_format(style="plain", axis="y")  # must not raise
+        fig.canvas.draw()
+
+        assert self._blank_tick_locs(ax.yaxis) == {0.0}
 
     @pytest.mark.parametrize(
         ("outside", "expected_title"),

--- a/tests/plots/styles/test_styling_helper.py
+++ b/tests/plots/styles/test_styling_helper.py
@@ -8,6 +8,7 @@ from matplotlib.ticker import FixedFormatter
 from openretailscience.options import get_option, option_context
 from openretailscience.plots.styles.styling_helpers import (
     _auto_rotate_categorical_x_ticks,
+    _ZeroBlankingFormatter,
     apply_base_styling,
     apply_label,
     apply_legend,
@@ -65,49 +66,116 @@ class TestStylingHelpers:
         for label in tick_labels:
             assert label.get_fontsize() == get_option("plot.font.tick_size")
 
-    def test_apply_ticks_is_idempotent_when_zero_label_was_hidden(self, fig_ax):
-        """Re-applying ticks after the zero label was hidden must not raise.
+    @staticmethod
+    def _blank_tick_locs(axis) -> set[float]:
+        """Return the major-tick locations whose label renders blank after a draw.
 
-        The first call hides the zero tick's label, which makes
-        get_majorticklabels() one shorter than get_majorticklocs() (it filters
-        invisible labels). A second apply_ticks call would then crash on
-        strict-zip if the helper still paired locs against labels.
+        A tick counts as blank when its label artist is hidden or its rendered
+        text is empty, so the check catches a dropped label regardless of the
+        mechanism. Requires the figure to have been drawn so the label artists
+        carry their live text.
         """
-        _, ax = fig_ax
+        blank = set()
+        for tick, loc in zip(axis.get_major_ticks(), axis.get_majorticklocs(), strict=True):
+            if not tick.label1.get_visible() or tick.label1.get_text() == "":
+                blank.add(float(loc))
+        return blank
+
+    def test_apply_ticks_blanks_only_the_zero_label(self, fig_ax):
+        """On a numeric axis, apply_ticks renders the data-0 label blank and keeps every other."""
+        fig, ax = fig_ax
+        ax.plot([-2, -1, 0, 1, 2], [1, 2, 0, 2, 1])
+
+        apply_ticks(ax)
+        fig.canvas.draw()
+
+        for axis in (ax.xaxis, ax.yaxis):
+            assert self._blank_tick_locs(axis) == {0.0}
+
+    def test_zero_blank_tracks_value_after_caller_changes_ticks(self, fig_ax):
+        """Zero-blanking follows the value, not a tick index, when the caller re-ticks (issue #530).
+
+        The old implementation hid the zero label by flipping a persistent
+        visibility flag on the tick artist at zero's index. matplotlib reuses
+        those artists by index, so a later ``set_yticks`` left the flag on
+        whatever non-zero value moved into that index, silently blanking a real
+        label. Deriving the blank from the value keeps it on 0 only.
+        """
+        fig, ax = fig_ax
+        # Symmetric limits put 0 at index 1 of the default numeric ticks
+        # ([-80, 0, 80, 160, 240, 320]), reproducing the leak-prone layout.
+        ax.plot([0, 1, 2, 3], [-80, 100, 200, 320])
+        ax.set_ylim(-80, 320)
+        apply_ticks(ax)
+
+        ax.set_ylim(0, 320)
+        ax.set_yticks([0, 80, 160, 240])
+        fig.canvas.draw()
+
+        assert self._blank_tick_locs(ax.yaxis) == {0.0}
+
+    def test_apply_ticks_is_idempotent_for_zero_blanking(self, fig_ax):
+        """Re-applying ticks keeps a single zero-blanking wrapper and still blanks only 0.
+
+        Iterative replotting (Jupyter, parametrized tests) runs the styling path
+        repeatedly; the formatter wrapper must not stack on itself each time.
+        """
+        fig, ax = fig_ax
         ax.plot([-2, -1, 0, 1, 2], [1, 2, 0, 2, 1])
 
         apply_ticks(ax)
         apply_ticks(ax)
+        fig.canvas.draw()
 
         for axis in (ax.xaxis, ax.yaxis):
-            ticks = axis.get_major_ticks()
-            locs = axis.get_majorticklocs()
-            zero_ticks = [tick for tick, loc in zip(ticks, locs, strict=True) if loc == 0]
-            assert len(zero_ticks) == 1
-            for tick in zero_ticks:
-                assert not tick.label1.get_visible()
+            formatter = axis.get_major_formatter()
+            assert isinstance(formatter, _ZeroBlankingFormatter)
+            # A second wrap would nest the wrapper inside itself.
+            assert not isinstance(formatter._base, _ZeroBlankingFormatter)
+            assert self._blank_tick_locs(axis) == {0.0}
 
-    def test_apply_ticks_handles_labeltop_on_numeric_axis(self, fig_ax):
-        """tick_params(labeltop=True) doubles get_majorticklabels() length.
+    def test_apply_ticks_blanks_zero_on_both_label_rows(self, fig_ax):
+        """With labeltop enabled, the value-0 label is blank on both the bottom and top rows.
 
-        With both label1 and label2 visible on a numeric MaxNLocator/AutoLocator
-        axis, get_majorticklabels() returns 2N entries while get_majorticklocs()
-        returns N. apply_ticks must still complete without raising, and both
-        the bottom and top label artists at zero must be hidden.
+        Both label rows draw from the same major formatter, so blanking by value
+        drops the zero label wherever it is rendered while non-zero ticks keep
+        their labels on both rows.
         """
-        _, ax = fig_ax
+        fig, ax = fig_ax
         ax.plot([-2, -1, 0, 1, 2], [1, 2, 0, 2, 1])
         ax.tick_params(labeltop=True, labelbottom=True)
 
         apply_ticks(ax)
+        fig.canvas.draw()
 
         ticks = ax.xaxis.get_major_ticks()
         locs = ax.xaxis.get_majorticklocs()
         zero_ticks = [tick for tick, loc in zip(ticks, locs, strict=True) if loc == 0]
+        nonzero_ticks = [tick for tick, loc in zip(ticks, locs, strict=True) if loc != 0]
         assert len(zero_ticks) == 1
-        for tick in zero_ticks:
-            assert not tick.label1.get_visible()
-            assert not tick.label2.get_visible()
+        assert zero_ticks[0].label1.get_text() == ""
+        assert zero_ticks[0].label2.get_text() == ""
+        assert all(tick.label1.get_text() != "" for tick in nonzero_ticks)
+        assert all(tick.label2.get_text() != "" for tick in nonzero_ticks)
+
+    def test_zero_blanking_formatter_delegates_and_blanks_zero(self, fig_ax):
+        """_ZeroBlankingFormatter blanks value 0 and delegates formatting and offset to its base.
+
+        The offset delegation matters for large-magnitude axes: ScalarFormatter
+        renders a shared ``1e6``-style offset that a naive wrapper would drop.
+        """
+        fig, ax = fig_ax
+        ax.plot([0, 1, 2], [0, 1_500_000, 3_000_000])
+        fig.canvas.draw()
+        base = ax.yaxis.get_major_formatter()
+        base.set_locs(list(ax.yaxis.get_majorticklocs()))
+
+        formatter = _ZeroBlankingFormatter(base)
+
+        assert base.get_offset() != ""  # sanity: the base carries an offset to delegate
+        assert formatter.get_offset() == base.get_offset()
+        assert formatter(0) == ""
+        assert formatter(1_500_000) == base(1_500_000)
 
     @pytest.mark.parametrize(
         ("outside", "expected_title"),

--- a/tests/plots/styles/test_styling_helper.py
+++ b/tests/plots/styles/test_styling_helper.py
@@ -191,6 +191,17 @@ class TestStylingHelpers:
 
         assert self._blank_tick_locs(ax.yaxis) == {0.0}
 
+    def test_zero_blanking_formatter_getattr_raises_when_base_missing(self):
+        """Attribute access on a half-built wrapper raises AttributeError, not RecursionError.
+
+        The ``__getattr__`` ``_base`` guard matters when the wrapper is materialised
+        without ``__init__`` (e.g. a copy/unpickle of a figure): resolving any missing
+        attribute would otherwise recurse forever trying to read ``_base``.
+        """
+        formatter = _ZeroBlankingFormatter.__new__(_ZeroBlankingFormatter)
+        with pytest.raises(AttributeError):
+            _ = formatter.set_scientific
+
     @pytest.mark.parametrize(
         ("outside", "expected_title"),
         [


### PR DESCRIPTION
## Summary

Fixes issue #530 where the zero-label blanking mechanism was silently blanking non-zero tick labels when the caller re-ticked the axis. The root cause was that the old implementation hid labels by flipping a visibility flag on the tick artist at zero's index; matplotlib reuses tick artists by index, so a later `set_yticks` would leave that flag on whatever value moved into that position.

## Changes

- **Introduced `_ZeroBlankingFormatter`**: A new formatter wrapper that blanks the value `0` by returning an empty string from `__call__`, rather than manipulating tick artist visibility. This keeps the blank keyed to the data value, not a reused artist index.
  - Delegates all formatting and offset computation to the base formatter (preserving `ScalarFormatter`'s `1e6`-style offsets)
  - Implements `__getattr__` to transparently forward attribute access, so callers' `Axes.ticklabel_format` calls still reach the real `ScalarFormatter` underneath
  - Idempotent: repeated styling passes don't nest the wrapper

- **Refactored `_hide_zero_value_ticks`**: Now wraps the major formatter instead of manipulating tick artists directly. Checks for existing `_ZeroBlankingFormatter` to avoid stacking on repeated calls.

- **Updated tests**: Replaced brittle index-based assertions with a new helper `_blank_tick_locs()` that checks which tick values render blank after a draw. Added tests for:
  - Value-tracking behavior when the caller re-ticks
  - Idempotency of the wrapper
  - Blanking on both label rows when `labeltop=True`
  - Delegation of offset and formatter attributes
  - Compatibility with `ticklabel_format` calls

## Implementation Details

The formatter wrapper approach is simpler and more robust than the previous index-pinned visibility flag: it naturally survives axis re-ticking because the blank is computed fresh on every draw based on the actual data value, not a persistent flag on a reused artist. The delegation pattern (via `__getattr__` and explicit method forwarding) ensures the wrapper is transparent to callers who configure the axis via matplotlib's standard APIs.

https://claude.ai/code/session_01DtaNmaKdhz74Aux88MQnJ3