### PR TITLE
feat(experimental): CLVStats BTYD summary adapter for pymc-marketing

### DIFF
--- a/docs/api/experimental/clv.md
+++ b/docs/api/experimental/clv.md
@@ -1,0 +1,3 @@
+# CLV (BTYD Model Prep)
+
+::: openretailscience.experimental.clv

--- a/docs/experimental/clv.md
+++ b/docs/experimental/clv.md
@@ -12,18 +12,19 @@ social:
 ## CLVStats (BTYD model input)
 
 `CLVStats` turns transaction data into the per-customer summary that the "buy-till-you-die" (BTYD)
-models in [pymc-marketing](https://www.pymc-marketing.io/) consume — `ParetoNBDModel` (churn and
-purchase frequency) and `GammaGammaModel` (per-transaction spend). It prepares the model **input**;
-it does not fit the models and does not depend on pymc-marketing.
+models in [pymc-marketing](https://www.pymc-marketing.io/) consume: `ParetoNBDModel` (churn and
+purchase frequency) and `GammaGammaModel` (per-transaction spend). It does not fit the models and does
+not depend on pymc-marketing.
 
 Each customer is "born" at their first purchase in the data and observed until the
-`observation_period_end`. A purchase occasion is a distinct calendar day, so multiple baskets on the
-same day count once.
+`observation_period_end`. A purchase occasion is a distinct calendar day with positive net spend, so
+multiple baskets on the same day count once and a returns-only day (net spend zero or less) is not an
+occasion. Undated rows are also dropped, and a customer left with no occasion drops out entirely.
 
 | Column | Meaning |
 | --- | --- |
 | `customer_id` | Your configured customer id column. |
-| `frequency` | Number of *repeat* purchase occasions (distinct purchase days minus one). |
+| `frequency` | Number of *repeat* purchase occasions (distinct positive-spend days minus one). |
 | `recency` | Time from the first purchase to the last purchase, in `period` units. |
 | `T` | Customer age: time from the first purchase to `observation_period_end`, in `period` units. |
 | `monetary_value` | Mean spend across the *repeat* purchases; `NaN` for one-time buyers. |
@@ -38,10 +39,19 @@ T = \frac{\text{days}(\text{first purchase} \rightarrow \text{observation end})}
 \text{recency} = \frac{\text{days}(\text{first purchase} \rightarrow \text{last purchase})}{\text{days per period}}
 $$
 
+`period` may be `"day"`, `"week"`, or `"month"` (case-insensitive, with short forms like `"d"`/`"m"`
+accepted). A month is a fixed 365.25/12-day unit, not a calendar month, so continuous age stays well
+defined. Day, week, and month map to pymc-marketing's `"D"`/`"W"`/`"M"` time units.
+
 `monetary_value` excludes the first purchase, matching the Gamma-Gamma assumption. One-time buyers
 (`frequency` of 0) have no repeat spend, cannot be fit by the standard Gamma-Gamma model, and are
 excluded from it (their expected spend falls back to the population mean). They remain valid rows for
 the Pareto/NBD model.
+
+The `clv.repeat_buyers` property returns the Gamma-Gamma-ready subset: the `frequency > 0` rows.
+`monetary_value` is always positive here (an occasion is a positive-spend day), so no spend filter is
+needed. It warns if `frequency` and `monetary_value` correlate (`|Pearson r| > 0.15`), which breaks
+Gamma-Gamma's independence assumption and biases its spend estimates.
 
 `frequency`, `recency`, `T`, and `monetary_value` are pymc-marketing's required literal column names,
 so the frame can be passed straight to the models.
@@ -61,8 +71,8 @@ transactions = pd.DataFrame({
 })
 
 # .df rows are one-per-customer in engine order; sort for a stable view.
-summary = CLVStats(transactions, period="week", observation_period_end="2023-01-29").df
-print(summary.sort_values("customer_id").reset_index(drop=True))
+clv = CLVStats(transactions, period="week", observation_period_end="2023-01-29")
+print(clv.df.sort_values("customer_id").reset_index(drop=True))
 #    customer_id  frequency  recency         T  monetary_value
 # 0          101          2      2.0  4.000000            60.0
 # 1          102          0      0.0  4.000000             NaN
@@ -74,18 +84,84 @@ The summary feeds pymc-marketing directly (install it separately):
 ```python
 from pymc_marketing.clv import ParetoNBDModel, GammaGammaModel
 
-pareto = ParetoNBDModel(data=summary)                              # frequency, recency, T
+clv = CLVStats(transactions, period="week", observation_period_end="2023-01-29")
+pareto = ParetoNBDModel(data=clv.df) # frequency, recency, T
 pareto.fit()
 
-repeat_buyers = summary[summary["frequency"] > 0]
-gamma_gamma = GammaGammaModel(data=repeat_buyers)                  # frequency, monetary_value
+gamma_gamma = GammaGammaModel(data=clv.repeat_buyers) # frequency > 0
 gamma_gamma.fit()
 ```
+
+<!-- markdownlint-disable MD046 -->
+!!! warning "Finite-horizon CLV: pass `time_unit`, or it fails silently"
+    `GammaGammaModel.expected_customer_lifetime_value(future_t=12, time_unit=...)` reads `future_t` in
+    **months**. The default `time_unit="D"` is wrong for a weekly or monthly summary and scales the
+    horizon by ~7x (weekly) to ~30x (monthly) with **no error raised**. Pass `time_unit=clv.pymc_time_unit`:
+
+    ```python
+    clv_12mo = gamma_gamma.expected_customer_lifetime_value(
+        transaction_model=pareto, data=clv.df, future_t=12, time_unit=clv.pymc_time_unit,
+    )
+    ```
+
+    Want an undiscounted CLV over a fixed horizon set directly in the model's units (e.g. exactly the
+    next 52 weeks)?
+    `pareto.expected_purchases(data=clv.df, future_t=52) * gamma_gamma.expected_customer_spend(data=clv.repeat_buyers)`
+    computes it with no month conversion and no `time_unit`.
+<!-- markdownlint-enable MD046 -->
+
+## Extra columns and covariates
+
+`customer_attributes` attaches a caller-supplied per-customer table (one row per `customer_id`) to the
+summary via a left join: customer descriptors (signup channel, region) or pre-computed aggregates
+(stores shopped). Build it however you like, e.g. `SegTransactionStats` grouped on `customer_id`, or a
+plain `group_by`. `one_hot_col` names column(s) of that table to one-hot encode into `0`/`1` dummy
+columns suitable for `ParetoNBDModel` covariates, and the original column is removed.
+
+```python
+transactions = pd.DataFrame({...})  # customer_id, transaction_date, unit_spend
+
+# One row per customer: a pre-computed count joined as-is, plus a categorical to one-hot encode.
+customer_attributes = pd.DataFrame({
+    "customer_id": [101, 102, 103, 104],
+    "stores_shopped": [3, 1, 2, 1],
+    "signup_channel": ["email", "paid_search", "organic", None],  # None -> the dropped reference level
+})
+
+clv = CLVStats(
+    transactions, period="week", customer_attributes=customer_attributes, one_hot_col="signup_channel",
+)
+# adds: stores_shopped, signup_channel_email, signup_channel_organic, signup_channel_paid_search
+
+# covariate_cols lists the attached columns (stores_shopped + the one-hot dummies), no prefix matching.
+covariate_cols = clv.covariate_cols
+pareto = ParetoNBDModel(
+    data=clv.df,
+    model_config={"purchase_covariate_cols": covariate_cols, "dropout_covariate_cols": covariate_cols},
+)
+```
+
+`customer_attributes` must have one row per `customer_id`. When it is an Ibis table ensure it is on
+the same backend as the transactions data. A pandas frame also works, but do not mix live
+backends (e.g. BigQuery transactions with a separate DuckDB attributes file).
+
+Every customer needs a row in `customer_attributes`: a missing one leaves NULL covariates (one-hot
+dummies included) that silently break `ParetoNBDModel`'s fit. A NULL attribute *value* is a NULL
+covariate too, except in a one-hot source column, where NULL is just the reference level (all dummies 0).
+`CLVStats` rejects NULL covariates only on `.df`; feed `.table` to the model and you must check yourself.
+
+For each one-hot column, one level is dropped as the reference level, because a full set of
+dummies would be collinear with the model intercept: NULL when the column contains NULLs, otherwise
+the first value in sorted order. Values are used verbatim in the column names, so keep categorical
+values short and free of characters you would not want in a column name. A column producing more than 32
+dummies emits a `UserWarning` (one-hot is for low-cardinality categoricals, not IDs). A single-category
+column produces zero dummies and also warns, since it contributes no covariate. `GammaGammaModel` has no covariate
+support in pymc-marketing, so spend-by-channel needs a separate Gamma-Gamma fit per channel.
 
 !!! note "Truncated history"
     The first purchase is always the earliest transaction *in the supplied data*, exactly as
     `pymc_marketing.clv.rfm_summary` treats it. A customer who was already active before the data
     window is treated as born at the window's start, which understates their true age. This is a
-    limitation of a truncated observation period, not something `CLVStats` corrects — substituting an
+    limitation of a truncated observation period, not something `CLVStats` corrects. Substituting an
     earlier first-purchase date while the intervening transactions are missing would break the model's
     frequency/recency/T consistency and silently deflate the estimated purchase rate.

--- a/docs/experimental/clv.md
+++ b/docs/experimental/clv.md
@@ -1,0 +1,91 @@
+---
+title: Customer Lifetime Value
+social:
+  cards_layout_options:
+    title: OpenRetailScience | Customer Lifetime Value
+---
+
+!!! warning "Experimental"
+    CLV preparation is experimental. Its API and import path (under `openretailscience.experimental`)
+    may change without notice.
+
+## CLVStats (BTYD model input)
+
+`CLVStats` turns transaction data into the per-customer summary that the "buy-till-you-die" (BTYD)
+models in [pymc-marketing](https://www.pymc-marketing.io/) consume — `ParetoNBDModel` (churn and
+purchase frequency) and `GammaGammaModel` (per-transaction spend). It prepares the model **input**;
+it does not fit the models and does not depend on pymc-marketing.
+
+Each customer is "born" at their first purchase in the data and observed until the
+`observation_period_end`. A purchase occasion is a distinct calendar day, so multiple baskets on the
+same day count once.
+
+| Column | Meaning |
+| --- | --- |
+| `customer_id` | Your configured customer id column. |
+| `frequency` | Number of *repeat* purchase occasions (distinct purchase days minus one). |
+| `recency` | Time from the first purchase to the last purchase, in `period` units. |
+| `T` | Customer age: time from the first purchase to `observation_period_end`, in `period` units. |
+| `monetary_value` | Mean spend across the *repeat* purchases; `NaN` for one-time buyers. |
+
+`recency` and `T` are fractional (for example, 2.5 weeks). The elapsed time is measured in whole days
+and divided by the days-per-period, because some backends (notably Oracle) support only
+day-granularity date deltas:
+
+$$
+T = \frac{\text{days}(\text{first purchase} \rightarrow \text{observation end})}{\text{days per period}}
+\qquad
+\text{recency} = \frac{\text{days}(\text{first purchase} \rightarrow \text{last purchase})}{\text{days per period}}
+$$
+
+`monetary_value` excludes the first purchase, matching the Gamma-Gamma assumption. One-time buyers
+(`frequency` of 0) have no repeat spend, cannot be fit by the standard Gamma-Gamma model, and are
+excluded from it (their expected spend falls back to the population mean). They remain valid rows for
+the Pareto/NBD model.
+
+`frequency`, `recency`, `T`, and `monetary_value` are pymc-marketing's required literal column names,
+so the frame can be passed straight to the models.
+
+Example:
+
+```python
+import pandas as pd
+from openretailscience.experimental.clv import CLVStats
+
+transactions = pd.DataFrame({
+    "customer_id": [101, 101, 101, 102, 103, 103],
+    "transaction_date": pd.to_datetime(
+        ["2023-01-01", "2023-01-08", "2023-01-15", "2023-01-01", "2023-01-10", "2023-01-24"]
+    ),
+    "unit_spend": [100.0, 50.0, 70.0, 200.0, 50.0, 80.0],
+})
+
+# .df rows are one-per-customer in engine order; sort for a stable view.
+summary = CLVStats(transactions, period="week", observation_period_end="2023-01-29").df
+print(summary.sort_values("customer_id").reset_index(drop=True))
+#    customer_id  frequency  recency         T  monetary_value
+# 0          101          2      2.0  4.000000            60.0
+# 1          102          0      0.0  4.000000             NaN
+# 2          103          1      2.0  2.714286            80.0
+```
+
+The summary feeds pymc-marketing directly (install it separately):
+
+```python
+from pymc_marketing.clv import ParetoNBDModel, GammaGammaModel
+
+pareto = ParetoNBDModel(data=summary)                              # frequency, recency, T
+pareto.fit()
+
+repeat_buyers = summary[summary["frequency"] > 0]
+gamma_gamma = GammaGammaModel(data=repeat_buyers)                  # frequency, monetary_value
+gamma_gamma.fit()
+```
+
+!!! note "Truncated history"
+    The first purchase is always the earliest transaction *in the supplied data*, exactly as
+    `pymc_marketing.clv.rfm_summary` treats it. A customer who was already active before the data
+    window is treated as born at the window's start, which understates their true age. This is a
+    limitation of a truncated observation period, not something `CLVStats` corrects — substituting an
+    earlier first-purchase date while the intervening transactions are missing would break the model's
+    frequency/recency/T consistency and silently deflate the estimated purchase rate.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - analysis_modules.md
   - Experimental:
       - Metrics: experimental/metrics.md
+      - Customer Lifetime Value: experimental/clv.md
   - Plot Gallery:
       - Overview: gallery/index.md
       - Area Plot: gallery/plots/area.ipynb
@@ -84,6 +85,7 @@ nav:
       - Experimental:
           - Metrics:
               - Distribution: api/experimental/metrics/distribution.md
+          - CLV: api/experimental/clv.md
       - Utils:
           - Date Utils: api/utils/date.md
           - Filter & Label Utils: api/utils/filter_and_label.md

--- a/openretailscience/.agents/skills/using-openretailscience/SKILL.md
+++ b/openretailscience/.agents/skills/using-openretailscience/SKILL.md
@@ -6,7 +6,8 @@ description: >-
   or transaction data and mentions any openretailscience analysis (RFM / HML /
   NLR / threshold segmentation, cross-shop Venn overlap, gain-loss switching,
   cohort retention, product association / market-basket, revenue-tree KPI
-  decomposition, customer decision hierarchy, composite rank, haversine), any of
+  decomposition, customer decision hierarchy, composite rank, haversine,
+  customer-lifetime-value / Pareto-NBD / BTYD model-input prep), any of
   its plots (bar, line, area, scatter, histogram, waterfall, venn, heatmap,
   cohort, time, period-on-period, broken-timeline, price, index) or trendlines,
   its options/ColumnHelper configuration system, or connecting analyses to a
@@ -53,6 +54,9 @@ and examples — do not guess signatures:
 
 - **`references/analysis.md`** — every analysis and segmentation class, the
   `utils` labelling/date helpers, and the experimental metrics.
+- **`references/clv.md`** — `experimental.clv.CLVStats`, which prepares the
+  per-customer BTYD summary (frequency / recency / T / monetary_value) for the
+  pymc-marketing Pareto/NBD and Gamma-Gamma models.
 - **`references/plotting.md`** — every `plots.*` function, **trendlines**
   (`add_trend_line`), and the styling / color / font helpers.
 - **`references/configuration.md`** — the options system, `ColumnHelper`, the
@@ -82,6 +86,7 @@ Prefer reading the relevant script over assembling calls from signatures alone.
 | KPI decomposition tree (spend = customers × visits × ...) | `analysis.revenue_tree.RevenueTree` |
 | Substitutable-product dendrogram | `analysis.customer_decision_hierarchy.CustomerDecisionHierarchy` |
 | Per-customer purchase / recency / churn metrics | `analysis.customer` (Purchases/Days/Churn classes) |
+| BTYD summary (frequency/recency/T/monetary) for pymc-marketing CLV models | `experimental.clv.CLVStats` |
 | Rank items by several weighted metrics | `analysis.composite_rank.CompositeRank` |
 | Great-circle customer-to-store distance | `analysis.haversine.haversine_distance` |
 

--- a/openretailscience/.agents/skills/using-openretailscience/references/clv.md
+++ b/openretailscience/.agents/skills/using-openretailscience/references/clv.md
@@ -1,0 +1,68 @@
+# Customer lifetime value (BTYD) reference
+
+`openretailscience.experimental.clv.CLVStats` prepares the per-customer summary that the
+"buy-till-you-die" models in [pymc-marketing](https://www.pymc-marketing.io/) consume —
+`ParetoNBDModel` (churn + purchase frequency) and `GammaGammaModel` (per-transaction
+spend). It **prepares the input; it does not fit the models** and does not depend on
+pymc-marketing. Flagged experimental — the API may change.
+
+```python
+from openretailscience.experimental.clv import CLVStats
+
+summary = CLVStats(data, period="week", observation_period_end=None).df
+```
+
+- `CLVStats(data, period="week", observation_period_end=None)` — reads `customer_id`,
+  `transaction_date` (must be a date/datetime type), and `unit_spend` from the options
+  system. Read `.table` (Ibis) / `.df` (pandas). `help(CLVStats)` for full Args/Raises.
+
+## Output columns
+
+One row per customer, using pymc-marketing's **required literal** column names (not
+options.py names). Each customer is "born" at their first purchase in the data:
+
+| column | meaning |
+| --- | --- |
+| `customer_id` | your configured id column |
+| `frequency` | number of *repeat* purchase occasions (distinct purchase days minus one) |
+| `recency` | first-purchase → last-purchase, in `period` units |
+| `T` | customer age: first-purchase → `observation_period_end`, in `period` units |
+| `monetary_value` | mean spend across the *repeat* purchases; `NaN` for one-time buyers |
+
+`recency` and `T` are fractional (e.g. `2.5` weeks). Same-day baskets count as one
+occasion. `monetary_value` excludes the first purchase (the Gamma-Gamma convention), so
+one-time buyers (`frequency == 0`) have no value and are excluded from the Gamma-Gamma fit
+— filter `summary[summary["frequency"] > 0]` for that model.
+
+## Arguments
+
+- `period` — `"day"` or `"week"` only (the units for which a fractional age is well
+  defined). Fixes the model's time unit; keep it consistent when later converting a
+  business horizon (e.g. 12 months → 52 weeks).
+- `observation_period_end` — ISO-8601 string or `datetime.date`; defaults to the latest
+  transaction date in the data. Must be on or after every customer's last purchase.
+
+## Feeding pymc-marketing
+
+```python
+from pymc_marketing.clv import ParetoNBDModel, GammaGammaModel
+
+pareto = ParetoNBDModel(data=summary)                       # frequency, recency, T
+pareto.fit()
+
+gamma_gamma = GammaGammaModel(data=summary[summary["frequency"] > 0])   # frequency, monetary_value
+gamma_gamma.fit()
+```
+
+If you have overridden `column.customer_id`, give the downstream model the matching id
+column name.
+
+## Caveat: truncated history
+
+The first purchase is always the earliest transaction **in the supplied data**, exactly as
+`pymc_marketing.clv.rfm_summary` treats it. A customer who was already active before the
+data window is treated as born at the window's start, which understates their true age.
+This is a limitation of a truncated observation period, not something `CLVStats` corrects —
+substituting an earlier first-purchase date from a customer dimension while the intervening
+transactions are missing would break the model's frequency/recency/T consistency and
+silently deflate the estimated purchase rate.

--- a/openretailscience/.agents/skills/using-openretailscience/references/clv.md
+++ b/openretailscience/.agents/skills/using-openretailscience/references/clv.md
@@ -9,53 +9,113 @@ pymc-marketing. Flagged experimental — the API may change.
 ```python
 from openretailscience.experimental.clv import CLVStats
 
-summary = CLVStats(data, period="week", observation_period_end=None).df
+clv = CLVStats(data, period="week", observation_period_end=None)
 ```
 
-- `CLVStats(data, period="week", observation_period_end=None)` — reads `customer_id`,
-  `transaction_date` (must be a date/datetime type), and `unit_spend` from the options
-  system. Read `.table` (Ibis) / `.df` (pandas). `help(CLVStats)` for full Args/Raises.
+Reads `customer_id`, `transaction_date` (must be a date/datetime type), and `unit_spend`
+from the options system. Undated rows and returns-only days (net spend zero or less) are dropped
+(a customer left with none drops out). Read `.table` (Ibis) / `.df` (pandas); `.repeat_buyers` is the
+GammaGamma-ready subset (`frequency > 0`); `.covariate_cols`
+lists the attached customer_attributes / one-hot columns; `.pymc_time_unit` is the matching
+ pymc-marketing `time_unit`. `help(CLVStats)` for full Args/Raises.
 
 ## Output columns
 
-One row per customer, using pymc-marketing's **required literal** column names (not
-options.py names). Each customer is "born" at their first purchase in the data:
+One row per customer, using pymc-marketing's **required literal** column names (**not** your
+configured options.py names). Each customer is "born" at their first purchase in the data:
 
 | column | meaning |
 | --- | --- |
 | `customer_id` | your configured id column |
-| `frequency` | number of *repeat* purchase occasions (distinct purchase days minus one) |
+| `frequency` | number of *repeat* purchase occasions (distinct positive-spend days minus one) |
 | `recency` | first-purchase → last-purchase, in `period` units |
 | `T` | customer age: first-purchase → `observation_period_end`, in `period` units |
 | `monetary_value` | mean spend across the *repeat* purchases; `NaN` for one-time buyers |
 
-`recency` and `T` are fractional (e.g. `2.5` weeks). Same-day baskets count as one
-occasion. `monetary_value` excludes the first purchase (the Gamma-Gamma convention), so
-one-time buyers (`frequency == 0`) have no value and are excluded from the Gamma-Gamma fit
-— filter `summary[summary["frequency"] > 0]` for that model.
+`recency` and `T` are fractional (e.g. `2.5` weeks). Same-day baskets count as one occasion; a day
+whose net spend is zero or less (returns) is not an occasion. `monetary_value` excludes the first
+purchase (the Gamma-Gamma convention), so one-time buyers (`frequency == 0`) have no value. Use
+`clv.repeat_buyers` for the Gamma-Gamma fit: the `frequency > 0` rows (one-time buyers fall back to
+the population mean). It warns if `frequency` and `monetary_value` correlate (`|Pearson r| > 0.15`),
+which breaks GammaGamma's independence assumption.
 
 ## Arguments
 
-- `period` — `"day"` or `"week"` only (the units for which a fractional age is well
-  defined). Fixes the model's time unit; keep it consistent when later converting a
-  business horizon (e.g. 12 months → 52 weeks).
+- `period` — `"day"`, `"week"`, or `"month"` (case-insensitive; short forms like `"d"`/`"m"`
+  accepted). A month is a fixed 365.25/12-day unit, so continuous age stays well defined. Fixes the
+  model's time unit; pass `clv.pymc_time_unit` downstream (day/week/month map to `"D"`/`"W"`/`"M"`).
 - `observation_period_end` — ISO-8601 string or `datetime.date`; defaults to the latest
   transaction date in the data. Must be on or after every customer's last purchase.
+- `customer_attributes` — a pandas/Ibis table, one row per `customer_id`, of extra columns to
+  left-join onto the summary (covariates such as signup channel, region, or a pre-computed
+  `stores_shopped` count). Build it however you like (e.g. `SegTransactionStats` grouped on
+  `customer_id`). Must have a unique `customer_id` and a row per customer: a missing customer leaves NULL
+  covariates (one-hot dummies included) that silently break ParetoNBD. A NULL attribute *value* counts
+  too, except a one-hot source column (NULL = reference level, all dummies 0). Rejected on `.df` only;
+  check yourself if you consume `.table`. Joins in-database when it is an Ibis table on the same backend
+  as the transactions (a pandas frame also works, but don't mix live backends).
+- `one_hot_col` — `str` or list of columns **of `customer_attributes`** to one-hot encode into
+  `{col}_{value}` 0/1 dummy columns for `ParetoNBDModel` covariates. One level is dropped as the
+  reference (collinear with the intercept otherwise): NULL when the column has NULLs, else the first
+  value in sorted order. The original column is dropped. Warns if a column yields more than 32 dummies
+  (a likely high-cardinality mistake) or zero dummies (a single-category column, no covariate).
+
+## Extra columns and covariates
+
+```python
+# One row per customer_id: a numeric covariate joined as-is + a categorical to one-hot encode.
+customer_attributes = pd.DataFrame(
+    {"customer_id": [...], "stores_shopped": [...], "signup_channel": [...]},  # None -> dropped reference
+)
+clv = CLVStats(
+    data,
+    period="week",
+    customer_attributes=customer_attributes,
+    one_hot_col="signup_channel", # -> signup_channel_<value> dummy columns, original dropped
+)
+covariate_cols = clv.covariate_cols # attached columns (customer_attributes + one-hot dummies)
+
+from pymc_marketing.clv import ParetoNBDModel
+ParetoNBDModel(data=clv.df, model_config={
+    "purchase_covariate_cols": covariate_cols,
+    "dropout_covariate_cols": covariate_cols,
+})
+```
+
+Values are used verbatim in column names (same as ibis `pivot_wider`, no sanitisation).
+`GammaGammaModel` has **no** covariate support in pymc-marketing, so for spend-by-channel, fit a
+separate Gamma-Gamma per channel.
 
 ## Feeding pymc-marketing
 
 ```python
+from openretailscience.experimental.clv import CLVStats
 from pymc_marketing.clv import ParetoNBDModel, GammaGammaModel
 
-pareto = ParetoNBDModel(data=summary)                       # frequency, recency, T
+clv = CLVStats(data)
+
+pareto = ParetoNBDModel(data=clv.df) # frequency, recency, T
 pareto.fit()
 
-gamma_gamma = GammaGammaModel(data=summary[summary["frequency"] > 0])   # frequency, monetary_value
+gamma_gamma = GammaGammaModel(data=clv.repeat_buyers) # frequency > 0
 gamma_gamma.fit()
 ```
 
-If you have overridden `column.customer_id`, give the downstream model the matching id
-column name.
+**Finite-horizon CLV: pass `time_unit`, or it fails silently.**
+`GammaGammaModel.expected_customer_lifetime_value(future_t=12, time_unit=...)` reads `future_t` in
+**months**; its default `"D"` is wrong for a weekly/monthly summary and scales the horizon ~7x (weekly)
+to ~30x (monthly) with **no error**. Pass `time_unit=clv.pymc_time_unit`:
+
+```python
+clv_12mo = gamma_gamma.expected_customer_lifetime_value(
+    transaction_model=pareto, data=clv.df, future_t=12, time_unit=clv.pymc_time_unit,
+)
+```
+
+Want an undiscounted CLV over a fixed horizon set directly in the model's units (e.g. exactly the
+next 52 weeks)?
+`pareto.expected_purchases(data=clv.df, future_t=52) * gamma_gamma.expected_customer_spend(data=clv.repeat_buyers)`
+computes it with no month conversion and no `time_unit`.
 
 ## Caveat: truncated history
 

--- a/openretailscience/.agents/skills/using-openretailscience/scripts/example_clv_stats.py
+++ b/openretailscience/.agents/skills/using-openretailscience/scripts/example_clv_stats.py
@@ -26,31 +26,55 @@ first_day_per_txn = np.repeat(first_day, purchases_per_customer)
 days_after_first = (rng.random(customer_id.size) * 330).astype(int)
 day_offset = np.minimum(first_day_per_txn + days_after_first, last_day_offset)
 
+# A customer-constant acquisition channel (one value per customer, repeated across their rows) and a
+# per-transaction store. The channel is a candidate one-hot covariate; the store is aggregated per
+# customer into customer_attributes below.
+channels = np.array(["email", "paid_search", "organic", None], dtype=object)
+signup_channel = np.repeat(rng.choice(channels, size=n_customers), purchases_per_customer)
+
+# Each customer has a typical basket size; per-transaction spend varies mildly around it and is
+# independent of how often they shop (Gamma-Gamma assumes spend and frequency are uncorrelated).
+basket_size = rng.uniform(5, 250, size=n_customers)
+unit_spend = (np.repeat(basket_size, purchases_per_customer) * rng.uniform(0.8, 1.2, size=customer_id.size)).round(2)
+
 transactions = pd.DataFrame({
     "customer_id": customer_id,
     "transaction_date": pd.to_datetime(epoch + day_offset.astype("timedelta64[D]")),
-    "unit_spend": rng.uniform(5, 250, size=customer_id.size).round(2),
+    "unit_spend": unit_spend,
+    "store_id": rng.integers(1, 6, size=customer_id.size),
+    "signup_channel": signup_channel,
 })
 
-# Weekly summary: recency and T are in weeks; monetary_value is the mean spend across each
-# customer's repeat purchases (NaN for one-time buyers). Columns: customer_id, frequency,
-# recency, T, monetary_value.
-summary = CLVStats(transactions, period="week").df
+# Weekly BTYD summary: one row per customer (customer_id, frequency, recency, T, monetary_value).
+clv = CLVStats(transactions, period="week")
 
-# Pin the observation window to an explicit "as of" date rather than the default (the latest
-# transaction date). A wrong horizon unit later is a common silent bug, so keep the model's
-# time unit (here, weeks) fixed and known.
+# observation_period_end pins the window instead of defaulting to the latest transaction date.
 summary_asof = CLVStats(transactions, period="week", observation_period_end="2023-12-31").df
 
-# The repeat-buyer subset is what the Gamma-Gamma model is fit on.
-repeat_buyers = summary[summary["frequency"] > 0]
+# repeat_buyers (frequency > 0) is the GammaGammaModel input.
+repeat_buyers = clv.repeat_buyers
 
-# Feed these straight to pymc-marketing (install it separately; not imported here):
-#
-#     from pymc_marketing.clv import ParetoNBDModel, GammaGammaModel
-#
-#     pareto = ParetoNBDModel(data=summary)      # uses frequency, recency, T
-#     pareto.fit()
-#
-#     gamma_gamma = GammaGammaModel(data=repeat_buyers)   # uses frequency, monetary_value
-#     gamma_gamma.fit()
+# pymc_time_unit ("W" here) is the time_unit for expected_customer_lifetime_value; its default "D"
+# silently misreads a weekly/monthly horizon.
+time_unit = clv.pymc_time_unit
+
+# customer_attributes (one row per customer) is left-joined onto the summary; one_hot_col encodes one
+# of its columns into 0/1 ParetoNBDModel covariates. Build it with any per-customer aggregation.
+customer_attributes = (
+    transactions.groupby("customer_id")
+    .agg(stores_shopped=("store_id", "nunique"), signup_channel=("signup_channel", "first"))
+    .reset_index()
+)
+clv_covariates = CLVStats(
+    transactions,
+    period="week",
+    customer_attributes=customer_attributes,
+    one_hot_col="signup_channel",
+)
+summary_covariates = clv_covariates.df
+# covariate_cols = the attached columns (one-hot dummies + stores_shopped) to pass as covariates.
+covariate_cols = clv_covariates.covariate_cols
+
+# Feed to pymc-marketing (install separately): summary_covariates -> ParetoNBDModel, repeat_buyers ->
+# GammaGammaModel (pass time_unit for finite-horizon CLV), summary_covariates + covariate_cols ->
+# ParetoNBDModel covariates.

--- a/openretailscience/.agents/skills/using-openretailscience/scripts/example_clv_stats.py
+++ b/openretailscience/.agents/skills/using-openretailscience/scripts/example_clv_stats.py
@@ -1,0 +1,56 @@
+"""Example: build the BTYD summary for pymc-marketing CLV models with CLVStats.
+
+CLVStats turns transaction data into the per-customer frequency / recency / T /
+monetary_value frame that pymc-marketing's ParetoNBDModel and GammaGammaModel consume. It
+does not fit the models (and does not depend on pymc-marketing); it prepares their input.
+"""
+
+import numpy as np
+import pandas as pd
+
+from openretailscience.experimental.clv import CLVStats
+
+rng = np.random.default_rng(42)
+
+# ~200 customers shopping across 2023. Each starts on a random day in the first ~200 days
+# and makes 1-11 purchases; one-time buyers arise naturally and get frequency 0.
+n_customers = 200
+epoch = np.datetime64("2023-01-01")
+last_day_offset = 364  # 2023-12-31
+
+first_day = rng.integers(0, 200, size=n_customers)
+purchases_per_customer = rng.integers(1, 12, size=n_customers)
+
+customer_id = np.repeat(np.arange(1, n_customers + 1), purchases_per_customer)
+first_day_per_txn = np.repeat(first_day, purchases_per_customer)
+days_after_first = (rng.random(customer_id.size) * 330).astype(int)
+day_offset = np.minimum(first_day_per_txn + days_after_first, last_day_offset)
+
+transactions = pd.DataFrame({
+    "customer_id": customer_id,
+    "transaction_date": pd.to_datetime(epoch + day_offset.astype("timedelta64[D]")),
+    "unit_spend": rng.uniform(5, 250, size=customer_id.size).round(2),
+})
+
+# Weekly summary: recency and T are in weeks; monetary_value is the mean spend across each
+# customer's repeat purchases (NaN for one-time buyers). Columns: customer_id, frequency,
+# recency, T, monetary_value.
+summary = CLVStats(transactions, period="week").df
+
+# Pin the observation window to an explicit "as of" date rather than the default (the latest
+# transaction date). A wrong horizon unit later is a common silent bug, so keep the model's
+# time unit (here, weeks) fixed and known.
+summary_asof = CLVStats(transactions, period="week", observation_period_end="2023-12-31").df
+
+# The repeat-buyer subset is what the Gamma-Gamma model is fit on.
+repeat_buyers = summary[summary["frequency"] > 0]
+
+# Feed these straight to pymc-marketing (install it separately; not imported here):
+#
+#     from pymc_marketing.clv import ParetoNBDModel, GammaGammaModel
+#
+#     pareto = ParetoNBDModel(data=summary)      # uses frequency, recency, T
+#     pareto.fit()
+#
+#     gamma_gamma = GammaGammaModel(data=repeat_buyers)   # uses frequency, monetary_value
+#     gamma_gamma.fit()

--- a/openretailscience/analysis/cohort.py
+++ b/openretailscience/analysis/cohort.py
@@ -40,7 +40,7 @@ import ibis
 import numpy as np
 import pandas as pd
 
-from openretailscience.core.validation import ensure_data_has_columns, ensure_ibis_table, ensure_value_choice
+from openretailscience.core.validation import ensure_data_has_columns, ensure_ibis_table, ensure_period
 from openretailscience.options import ColumnHelper
 
 
@@ -105,7 +105,8 @@ class CohortAnalysis:
             df (pd.DataFrame | ibis.Table): The dataset containing transaction data.
             aggregation_column (str): The column to apply the aggregation function on (e.g., 'unit_spend').
             agg_func (str, optional): Aggregation function (e.g., "nunique", "sum", "mean"). Defaults to "nunique".
-            period (str): Period for cohort analysis (must be "year", "quarter", "month", "week", or "day").
+            period (str): Period for cohort analysis: "year", "quarter", "month", "week", or "day"
+                (case-insensitive; short forms like "m"/"d" accepted).
             percentage (bool): If True, converts cohort values into retention percentages relative to the first period.
 
         Raises:
@@ -115,7 +116,7 @@ class CohortAnalysis:
         """
         cols = ColumnHelper()
 
-        period = ensure_value_choice(period, self.VALID_PERIODS, "period")
+        period = ensure_period(period, self.VALID_PERIODS, "period")
 
         required_cols = [
             cols.customer_id,
@@ -176,7 +177,8 @@ class CohortAnalysis:
             df (pd.DataFrame | ibis.Table): The dataset containing transaction data.
             aggregation_column (str): The column to apply the aggregation function on (e.g., 'unit_spend').
             agg_func (str, optional): Aggregation function (e.g., "nunique", "sum", "mean"). Defaults to "nunique".
-            period (str): Period for cohort analysis (must be "year", "quarter", "month", "week", or "day").
+            period (str): Period for cohort analysis: "year", "quarter", "month", "week", or "day"
+                (case-insensitive; short forms like "m"/"d" accepted).
             percentage (bool): If True, converts cohort values into retention percentages relative to the first period.
 
         Returns:

--- a/openretailscience/core/validation.py
+++ b/openretailscience/core/validation.py
@@ -6,12 +6,37 @@ from typing import TYPE_CHECKING
 
 import ibis
 import pandas as pd
+from ibis.expr.types import Scalar
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
 
 VALID_SORT_ORDERS = ("asc", "ascending", "desc", "descending")
+_EXTRA_AGG_SPEC_LEN = 2  # each extra_aggs value is a (source_col, agg_func) pair
+
+#: Period aliases (case-insensitive, short and long forms) mapped to their canonical word.
+PERIOD_ALIASES: dict[str, str] = {
+    "d": "day",
+    "day": "day",
+    "days": "day",
+    "w": "week",
+    "wk": "week",
+    "week": "week",
+    "weeks": "week",
+    "m": "month",
+    "mo": "month",
+    "month": "month",
+    "months": "month",
+    "q": "quarter",
+    "qtr": "quarter",
+    "quarter": "quarter",
+    "quarters": "quarter",
+    "y": "year",
+    "yr": "year",
+    "year": "year",
+    "years": "year",
+}
 
 
 def ensure_ibis_table(df: pd.DataFrame | ibis.Table, param_name: str = "df") -> ibis.Table:
@@ -153,6 +178,40 @@ def ensure_value_choice(
     raise ValueError(msg)
 
 
+def ensure_period(value: str, choices: Iterable[str], param_name: str = "period") -> str:
+    """Validate a period parameter, accepting case-insensitive aliases and short forms.
+
+    Normalizes ``value`` through :data:`PERIOD_ALIASES` ("d"/"D"/"day"/"days" all resolve to "day"),
+    then matches the canonical word against ``choices`` (the caller's allowed periods). Use this for
+    any period/date-unit parameter so callers can pass any casing or abbreviation.
+
+    Args:
+        value (str): The period supplied by the caller (any alias or casing).
+        choices (Iterable[str]): The canonical period words this function allows, e.g. ``("day", "week")``.
+        param_name (str): The parameter name to surface in error messages. Defaults to ``"period"``.
+
+    Returns:
+        str: The entry from ``choices`` matching ``value`` (the caller's own spelling).
+
+    Raises:
+        TypeError: If ``value`` is not a string.
+        ValueError: If ``value`` does not resolve to one of ``choices``.
+    """
+    if not isinstance(value, str):
+        msg = f"{param_name} must be a string. Got {type(value).__name__}."
+        raise TypeError(msg)
+
+    canonical = PERIOD_ALIASES.get(value.strip().lower())
+    choices_list = list(choices)
+    if canonical is not None:
+        for choice in choices_list:
+            if choice.lower() == canonical:
+                return choice
+
+    msg = f"{param_name} must be one of {choices_list} (aliases like 'd'/'day' accepted). Got '{value}'."
+    raise ValueError(msg)
+
+
 def ensure_number(value: float, param_name: str) -> None:
     """Validate that a parameter is a real number — an int or float, but not a bool.
 
@@ -221,6 +280,44 @@ def ensure_integer(value: int, param_name: str) -> None:
     if isinstance(value, bool) or not isinstance(value, int):
         msg = f"{param_name} must be an integer. Got {type(value).__name__}."
         raise TypeError(msg)
+
+
+def ensure_valid_extra_aggs(data: ibis.Table, extra_aggs: dict[str, tuple[str, str]] | None) -> None:
+    """Validate an ``extra_aggs`` mapping of ``{output_col: (source_col, agg_func)}``.
+
+    Each entry names a source column that must exist in ``data`` and an Ibis aggregation
+    function (e.g. ``"sum"``, ``"nunique"``, ``"max"``) that must be available on that
+    column.
+
+    Args:
+        data (ibis.Table): The table the aggregations will run against.
+        extra_aggs (dict[str, tuple[str, str]] | None): The aggregation spec to validate.
+            ``None`` is a no-op.
+
+    Raises:
+        ValueError: If a spec value is not a ``(source_col, agg_func)`` tuple, if a source
+            column is absent from ``data``, or if ``agg_func`` is not a no-argument aggregation
+            that reduces that column to a scalar.
+    """
+    if extra_aggs is None:
+        return
+    for output_col, spec in extra_aggs.items():
+        if not (isinstance(spec, tuple) and len(spec) == _EXTRA_AGG_SPEC_LEN):
+            msg = f"extra_aggs['{output_col}'] must be a (source_col, agg_func) tuple, got {spec!r}"
+            raise ValueError(msg)
+        col, func = spec
+        if col not in data.columns:
+            msg = f"Column '{col}' specified in extra_aggs does not exist in the data"
+            raise ValueError(msg)
+        # A bare hasattr(func) passes for non-aggregations (e.g. "cast", "isnull") that build fine
+        # but crash later; require func to build a scalar reduction on the column.
+        try:
+            aggregation = getattr(data[col], func)()
+        except (AttributeError, TypeError):
+            aggregation = None
+        if not isinstance(aggregation, Scalar):
+            msg = f"Aggregation function '{func}' not available for column '{col}'"
+            raise ValueError(msg)  # noqa: TRY004 -- bad aggregation name is a value error, not a type error
 
 
 def ensure_tznaive_datetime(df: ibis.Table, column: str) -> None:

--- a/openretailscience/experimental/clv.py
+++ b/openretailscience/experimental/clv.py
@@ -1,0 +1,210 @@
+"""Customer-lifetime-value (BTYD) model input preparation.
+
+This module adapts OpenRetailScience transaction data into the per-customer summary
+frame consumed by the "buy-till-you-die" models in
+`pymc-marketing <https://www.pymc-marketing.io/>`_ — ``ParetoNBDModel`` (churn and
+purchase frequency) and ``GammaGammaModel`` (per-transaction spend).
+
+The summary follows the standard BTYD convention, where each customer is "born" at their
+first purchase and observed until ``observation_period_end``:
+
+- ``frequency`` — number of *repeat* purchase occasions (total occasions minus one). A
+  purchase occasion is a distinct calendar day, so multiple baskets on the same day count
+  once.
+- ``recency`` — time from the first purchase to the last purchase.
+- ``T`` — the customer's "age": time from the first purchase to ``observation_period_end``.
+- ``monetary_value`` — mean spend across the *repeat* purchases (the first purchase is
+  excluded, matching the Gamma-Gamma assumption). ``NaN`` for one-time buyers, who cannot
+  be fit by the standard Gamma-Gamma model and fall back to the population mean downstream.
+
+``recency`` and ``T`` are expressed in ``period`` units (``"day"`` or ``"week"``) and are
+fractional (e.g. 2.5 weeks). The elapsed time is measured in whole days and then divided
+by the days-per-period, because the Oracle backend supports only day-granularity date
+deltas (see ``openretailscience.analysis.cohort`` for the same constraint).
+
+The first purchase is always the earliest transaction *in the supplied data*, exactly as
+`pymc_marketing.clv.rfm_summary` treats it. A customer who was already active before the
+data window is therefore treated as born at the window's start — a known limitation of a
+truncated observation period, not something this adapter corrects.
+"""
+
+from __future__ import annotations
+
+import datetime
+import functools
+from typing import TYPE_CHECKING, ClassVar
+
+import ibis
+
+from openretailscience.core.validation import (
+    ensure_data_has_columns,
+    ensure_ibis_table,
+    ensure_tznaive_datetime,
+    ensure_value_choice,
+)
+from openretailscience.options import ColumnHelper
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+def _coerce_to_date(value: str | datetime.date) -> datetime.date:
+    """Normalize a date-like value to a ``datetime.date``.
+
+    Args:
+        value (str | datetime.date): An ISO-8601 date string, a ``datetime.date``, or a
+            ``datetime.datetime`` (its date part is used).
+
+    Returns:
+        datetime.date: The normalized date.
+
+    Raises:
+        TypeError: If ``value`` is not a string or ``datetime.date``.
+    """
+    if isinstance(value, str):
+        return datetime.date.fromisoformat(value)
+    # ``datetime.datetime`` is a ``datetime.date`` subclass; take its date part explicitly.
+    if isinstance(value, datetime.datetime):
+        return value.date()
+    if isinstance(value, datetime.date):
+        return value
+    msg = "observation_period_end must be an ISO-8601 date string, a datetime.date, or None."
+    raise TypeError(msg)
+
+
+class CLVStats:
+    """Prepares the per-customer BTYD summary for pymc-marketing CLV models.
+
+    Aggregates transaction data into the ``frequency`` / ``recency`` / ``T`` /
+    ``monetary_value`` summary that ``ParetoNBDModel`` and ``GammaGammaModel`` consume.
+    Results are accessible via the ``table`` attribute (ibis Table) or the ``df`` property
+    (materialized pandas DataFrame). See the module docstring for column definitions.
+
+    Constructing ``CLVStats`` runs one aggregate query against the backend to resolve and
+    validate the observation window; the full per-customer summary stays lazy and is
+    materialized only on first ``df`` access.
+
+    Args:
+        data (pd.DataFrame | ibis.Table): Transaction data containing the ``customer_id``,
+            ``transaction_date`` (a date/datetime type), and ``unit_spend`` columns.
+        period (str, optional): The time unit for ``recency`` and ``T``. One of ``"day"``
+            or ``"week"``. Defaults to ``"week"``.
+        observation_period_end (str | datetime.date | None, optional): The end of the
+            observation window, from which each customer's age ``T`` is measured. An
+            ISO-8601 string or a ``datetime.date``. Defaults to the latest transaction date
+            in ``data``.
+
+    Raises:
+        TypeError: If ``data`` is not a pandas DataFrame or an Ibis Table, if
+            ``transaction_date`` is not a date/datetime type, or if
+            ``observation_period_end`` is not a valid date-like value.
+        ValueError: If required columns are missing, if ``period`` is not ``"day"`` or
+            ``"week"``, or if ``observation_period_end`` is before the latest transaction.
+    """
+
+    #: Supported period values. Restricted to the units for which a fractional
+    #: (day-delta / days-per-period) age is well defined; month/quarter/year have
+    #: irregular day counts and are not meaningful for continuous BTYD time.
+    VALID_PERIODS: ClassVar[tuple[str, ...]] = ("day", "week")
+    _DAYS_PER_PERIOD: ClassVar[dict[str, int]] = {"day": 1, "week": 7}
+
+    def __init__(
+        self,
+        data: pd.DataFrame | ibis.Table,
+        *,
+        period: str = "week",
+        observation_period_end: str | datetime.date | None = None,
+    ) -> None:
+        """Initializes and computes the BTYD summary."""
+        self.table: ibis.Table
+
+        cols = ColumnHelper()
+        data = ensure_ibis_table(data, "data")
+        ensure_data_has_columns(data, [cols.customer_id, cols.transaction_date, cols.unit_spend])
+        ensure_tznaive_datetime(data, cols.transaction_date)
+        period = ensure_value_choice(period, self.VALID_PERIODS, "period")
+
+        # Cast the single max scalar to a date (not every row) — same idiom as segmentation/rfm.py.
+        latest_transaction = _coerce_to_date(data[cols.transaction_date].max().cast("date").execute())
+        if observation_period_end is None:
+            observation_period_end = latest_transaction
+        else:
+            observation_period_end = _coerce_to_date(observation_period_end)
+            if observation_period_end < latest_transaction:
+                msg = (
+                    f"observation_period_end ({observation_period_end}) must be on or after the latest "
+                    f"transaction date ({latest_transaction}); an earlier end would produce a negative age."
+                )
+                raise ValueError(msg)
+
+        self.table = self._compute_summary(data, cols, period, observation_period_end)
+
+    @classmethod
+    def _compute_summary(
+        cls,
+        data: ibis.Table,
+        cols: ColumnHelper,
+        period: str,
+        observation_period_end: datetime.date,
+    ) -> ibis.Table:
+        """Computes the BTYD summary table.
+
+        Args:
+            data (ibis.Table): The validated transaction data.
+            cols (ColumnHelper): Resolved column names.
+            period (str): The validated period unit (``"day"`` or ``"week"``).
+            observation_period_end (datetime.date): The resolved observation window end.
+
+        Returns:
+            ibis.Table: One row per customer with the BTYD summary columns.
+        """
+        # Collapse to one purchase occasion per customer per calendar day, summing spend
+        # within the day (same-day baskets are a single occasion under the BTYD convention).
+        day = data[cols.transaction_date].cast("date").name("_day")
+        daily = data.group_by([cols.customer_id, day]).aggregate(_day_spend=data[cols.unit_spend].sum())
+
+        # A repeat occasion is any purchase day after the customer's first purchase day.
+        first_day = daily["_day"].min().over(ibis.window(group_by=daily[cols.customer_id]))
+        daily = daily.mutate(_is_repeat=daily["_day"] > first_day)
+
+        summary = daily.group_by(cols.customer_id).aggregate(
+            _first_day=daily["_day"].min(),
+            _last_day=daily["_day"].max(),
+            _occasions=daily.count(),
+            _repeat_spend=daily._day_spend.sum(where=daily._is_repeat),
+        )
+
+        days_per_period = cls._DAYS_PER_PERIOD[period]
+        observation_end = ibis.literal(observation_period_end)
+        frequency = summary._occasions - 1
+
+        # frequency / recency / T / monetary_value are pymc-marketing's required literal
+        # column names (ParetoNBDModel / GammaGammaModel), deliberately not options.py names.
+        # The customer id keeps its configured column name; if column.customer_id has been
+        # overridden, the downstream model call must be given the matching id column.
+        return summary.mutate(
+            frequency=frequency.cast("int64"),
+            # Day-granularity delta (Oracle-safe) divided by days-per-period for a fractional age.
+            recency=summary._last_day.delta(summary._first_day, unit="day") / days_per_period,
+            T=observation_end.delta(summary._first_day, unit="day") / days_per_period,
+            monetary_value=summary._repeat_spend / frequency.nullif(0),
+        ).select(
+            cols.customer_id,
+            "frequency",
+            "recency",
+            "T",
+            "monetary_value",
+        )
+
+    @functools.cached_property
+    def df(self) -> pd.DataFrame:
+        """Returns the materialized BTYD summary as a pandas DataFrame.
+
+        The ``customer_id`` is a column (not the index) so the frame can be passed straight
+        to ``ParetoNBDModel`` / ``GammaGammaModel``, which expect it as a column.
+
+        Returns:
+            pd.DataFrame: One row per customer with columns ``customer_id``, ``frequency``,
+                ``recency``, ``T``, and ``monetary_value``.
+        """
+        return self.table.execute()

--- a/openretailscience/experimental/clv.py
+++ b/openretailscience/experimental/clv.py
@@ -8,19 +8,17 @@ purchase frequency) and ``GammaGammaModel`` (per-transaction spend).
 The summary follows the standard BTYD convention, where each customer is "born" at their
 first purchase and observed until ``observation_period_end``:
 
-- ``frequency`` — number of *repeat* purchase occasions (total occasions minus one). A
-  purchase occasion is a distinct calendar day, so multiple baskets on the same day count
-  once.
+- ``frequency`` — number of *repeat* purchase occasions (total occasions minus one). An
+  occasion is a distinct calendar day with positive net spend (returns-only days excluded).
 - ``recency`` — time from the first purchase to the last purchase.
 - ``T`` — the customer's "age": time from the first purchase to ``observation_period_end``.
-- ``monetary_value`` — mean spend across the *repeat* purchases (the first purchase is
-  excluded, matching the Gamma-Gamma assumption). ``NaN`` for one-time buyers, who cannot
-  be fit by the standard Gamma-Gamma model and fall back to the population mean downstream.
+- ``monetary_value`` — mean spend across the *repeat* purchases (excludes the first, per the
+  Gamma-Gamma assumption). ``NaN`` for one-time buyers, who fall back to the population mean.
 
-``recency`` and ``T`` are expressed in ``period`` units (``"day"`` or ``"week"``) and are
-fractional (e.g. 2.5 weeks). The elapsed time is measured in whole days and then divided
-by the days-per-period, because the Oracle backend supports only day-granularity date
-deltas (see ``openretailscience.analysis.cohort`` for the same constraint).
+``recency`` and ``T`` are expressed in ``period`` units (``"day"``, ``"week"``, or ``"month"``;
+a month is a fixed 365.25/12-day unit) and are fractional (e.g. 2.5 weeks). The elapsed time is
+measured in whole days and then divided by the days-per-period, because the Oracle backend supports
+only day-granularity date deltas (see ``openretailscience.analysis.cohort`` for the same constraint).
 
 The first purchase is always the earliest transaction *in the supplied data*, exactly as
 `pymc_marketing.clv.rfm_summary` treats it. A customer who was already active before the
@@ -32,20 +30,20 @@ from __future__ import annotations
 
 import datetime
 import functools
-from typing import TYPE_CHECKING, ClassVar
+import warnings
+from typing import ClassVar
 
 import ibis
+import pandas as pd
 
 from openretailscience.core.validation import (
+    ensure_columns,
     ensure_data_has_columns,
     ensure_ibis_table,
+    ensure_period,
     ensure_tznaive_datetime,
-    ensure_value_choice,
 )
 from openretailscience.options import ColumnHelper
-
-if TYPE_CHECKING:
-    import pandas as pd
 
 
 def _coerce_to_date(value: str | datetime.date) -> datetime.date:
@@ -72,6 +70,63 @@ def _coerce_to_date(value: str | datetime.date) -> datetime.date:
     raise TypeError(msg)
 
 
+#: Past this many dummies, a one_hot_col is almost certainly a high-cardinality column (product_id, a
+#: per-transaction field) encoded by mistake.
+_ONE_HOT_CARDINALITY_WARN = 32
+
+
+def _one_hot_encode(table: ibis.Table, cols_to_encode: list[str]) -> ibis.Table:
+    """One-hot encode customer-constant columns into 0/1 dummy columns.
+
+    Each distinct value ``v`` of a column becomes ``{col}_{v}`` (raw value verbatim in the name). Per
+    column, one level is dropped as the reference (dummies would otherwise be collinear with a model
+    intercept): NULL when the column has NULLs, else the first value in sorted order. Dropping NULL rather
+    than a NULL-indicator column is a pure reparameterization (identical fit) that needs no NULL name.
+
+    Categories are read from ``table`` itself in a single ``distinct`` query over all ``cols_to_encode``,
+    so N columns cost one execute, not N.
+
+    Args:
+        table (ibis.Table): The customer-level table containing every column in ``cols_to_encode`` (one
+            row per customer); distinct values, dtypes, and dummies are all computed from it.
+        cols_to_encode (list[str]): The columns to one-hot encode.
+
+    Returns:
+        ibis.Table: ``table`` with each encoded column replaced by its 0/1 dummy columns.
+    """
+    combos = table.select(cols_to_encode).distinct().execute()
+    dummies = {}
+    for col in cols_to_encode:
+        # combos holds distinct *combinations*, so each column repeats a value once per pairing; dedupe
+        # per column or the reference-level drop (values[1:]) would leave the reference value in place.
+        distinct = combos[col]
+        has_null = bool(distinct.isna().any())
+        non_null = distinct.dropna().drop_duplicates()
+        if table[col].type().is_integer():
+            # A nullable integer column executes to float64 in pandas; restore integer values so dummy
+            # columns are named `{col}_2` (not `{col}_2.0`) and the equality below is an exact int match.
+            non_null = non_null.astype("int64")
+        values = sorted(non_null.tolist())
+        emitted = values if has_null else values[1:]
+        if len(emitted) == 0:
+            warnings.warn(
+                f"one_hot_col '{col}' has a single distinct level (one category, or all NULL), so dropping the "
+                "reference level leaves zero dummy columns and no covariate. Drop it from one_hot_col, or check "
+                "the column has the categories you expect.",
+                stacklevel=2,
+            )
+        elif len(emitted) > _ONE_HOT_CARDINALITY_WARN:
+            warnings.warn(
+                f"one_hot_col '{col}' expands to {len(emitted)} dummy columns; high-cardinality one-hot "
+                "makes a large, sparse ParetoNBD covariate matrix. Group rare levels or use another encoding.",
+                stacklevel=2,
+            )
+        # ifelse -> portable CASE WHEN (`col == value` as a value is invalid SQL on Oracle/SQL Server);
+        # NULL or non-match -> 0. int8 (TINYINT) not int64: a 0/1 flag is one byte.
+        dummies.update({f"{col}_{value}": ibis.ifelse(table[col] == value, 1, 0).cast("int8") for value in emitted})
+    return table.mutate(**dummies).drop(*cols_to_encode)
+
+
 class CLVStats:
     """Prepares the per-customer BTYD summary for pymc-marketing CLV models.
 
@@ -81,32 +136,62 @@ class CLVStats:
     (materialized pandas DataFrame). See the module docstring for column definitions.
 
     Constructing ``CLVStats`` runs one aggregate query against the backend to resolve and
-    validate the observation window; the full per-customer summary stays lazy and is
-    materialized only on first ``df`` access.
+    validate the observation window (plus, when ``customer_attributes`` is given, one aggregate to
+    check its customer_id is unique and a single distinct-value query enumerating all ``one_hot_col``
+    categories); the full per-customer summary stays lazy and is materialized only on first
+    ``df`` access.
 
     Args:
-        data (pd.DataFrame | ibis.Table): Transaction data containing the ``customer_id``,
-            ``transaction_date`` (a date/datetime type), and ``unit_spend`` columns.
-        period (str, optional): The time unit for ``recency`` and ``T``. One of ``"day"``
-            or ``"week"``. Defaults to ``"week"``.
+        data (pd.DataFrame | ibis.Table): Transaction data with the ``customer_id``,
+            ``transaction_date`` (a date/datetime type), and ``unit_spend`` columns. Undated rows and
+            returns-only days (net spend <= 0) are excluded; a customer left with none drops out.
+        period (str, optional): The time unit for ``recency`` and ``T``. One of ``"day"``,
+            ``"week"``, or ``"month"`` (case-insensitive; short forms like ``"d"``/``"m"`` accepted).
+            A month is a fixed 365.25/12-day unit. Defaults to ``"week"``.
         observation_period_end (str | datetime.date | None, optional): The end of the
             observation window, from which each customer's age ``T`` is measured. An
             ISO-8601 string or a ``datetime.date``. Defaults to the latest transaction date
             in ``data``.
+        customer_attributes (pd.DataFrame | ibis.Table | None, optional): A per-customer table (one
+            row per ``customer_id``) of extra columns to attach to the summary via a left join —
+            covariates such as signup channel, region, or a pre-computed ``stores_shopped`` count.
+            Build it however you like (e.g. ``SegTransactionStats`` grouped on ``customer_id``). Must
+            cover every customer with a non-NULL value for each (non-one-hot) covariate; a missing
+            customer or NULL value is rejected on :attr:`df` access. Defaults to ``None``.
+        one_hot_col (str | list[str] | None, optional): Column(s) of ``customer_attributes`` to
+            one-hot encode into 0/1 dummy columns suitable for ``ParetoNBDModel`` covariates. For
+            each column one level is dropped as the reference level (dummies would otherwise be
+            collinear with the model intercept) — NULL when the column contains NULLs, otherwise the
+            first value in sorted order — and the original column is removed. Warns (``UserWarning``)
+            if a column yields more than 32 dummies (a likely high-cardinality mistake) or zero dummies
+            (a single-category column that contributes no covariate). Defaults to ``None``.
 
     Raises:
-        TypeError: If ``data`` is not a pandas DataFrame or an Ibis Table, if
-            ``transaction_date`` is not a date/datetime type, or if
-            ``observation_period_end`` is not a valid date-like value.
-        ValueError: If required columns are missing, if ``period`` is not ``"day"`` or
-            ``"week"``, or if ``observation_period_end`` is before the latest transaction.
+        TypeError: If ``data`` or ``customer_attributes`` is not a pandas DataFrame or an Ibis Table,
+            if ``transaction_date`` is not a date/datetime type, or if ``observation_period_end`` is
+            not a valid date-like value.
+        ValueError: If required columns are missing, if ``period`` is not ``"day"``, ``"week"``, or
+            ``"month"``, if ``observation_period_end`` is before the latest transaction, if
+            ``customer_attributes`` lacks the ``customer_id`` column or has a duplicate ``customer_id``,
+            if ``one_hot_col`` is given without ``customer_attributes`` or names a column absent from
+            it, if an attached column name collides with a reserved summary column, or if ``data``
+            contains no transactions.
     """
 
-    #: Supported period values. Restricted to the units for which a fractional
-    #: (day-delta / days-per-period) age is well defined; month/quarter/year have
-    #: irregular day counts and are not meaningful for continuous BTYD time.
-    VALID_PERIODS: ClassVar[tuple[str, ...]] = ("day", "week")
-    _DAYS_PER_PERIOD: ClassVar[dict[str, int]] = {"day": 1, "week": 7}
+    #: A "month" is a fixed 365.25/12-day unit (the average Gregorian month), not a calendar month, so
+    #: fractional age stays well defined and 12 months is exactly one year.
+    _DAYS_PER_MONTH: ClassVar[float] = 365.25 / 12
+    VALID_PERIODS: ClassVar[tuple[str, ...]] = ("day", "week", "month")
+    _DAYS_PER_PERIOD: ClassVar[dict[str, float]] = {"day": 1, "week": 7, "month": _DAYS_PER_MONTH}
+    #: Maps each period to pymc-marketing's ``time_unit`` code; exposed via ``pymc_time_unit``.
+    _PYMC_TIME_UNIT: ClassVar[dict[str, str]] = {"day": "D", "week": "W", "month": "M"}
+    #: |Pearson r| between frequency and monetary_value above which ``repeat_buyers`` warns: GammaGamma
+    #: assumes the two are independent, and a stronger correlation biases its spend estimates (0.10-0.15
+    #: is the practical "weak enough" band in BTYD guidance).
+    _MONETARY_FREQUENCY_CORR_WARN: ClassVar[float] = 0.15
+    #: The base BTYD output columns (literal pymc-marketing names); anything else on the summary is a
+    #: covariate attached via customer_attributes / one_hot_col. See ``covariate_cols``.
+    _BASE_SUMMARY_COLUMNS: ClassVar[tuple[str, ...]] = ("customer_id", "frequency", "recency", "T", "monetary_value")
 
     def __init__(
         self,
@@ -114,18 +199,26 @@ class CLVStats:
         *,
         period: str = "week",
         observation_period_end: str | datetime.date | None = None,
+        customer_attributes: pd.DataFrame | ibis.Table | None = None,
+        one_hot_col: str | list[str] | None = None,
     ) -> None:
         """Initializes and computes the BTYD summary."""
-        self.table: ibis.Table
-
         cols = ColumnHelper()
         data = ensure_ibis_table(data, "data")
         ensure_data_has_columns(data, [cols.customer_id, cols.transaction_date, cols.unit_spend])
         ensure_tznaive_datetime(data, cols.transaction_date)
-        period = ensure_value_choice(period, self.VALID_PERIODS, "period")
+        period = ensure_period(period, self.VALID_PERIODS, "period")
+        attributes = self._prepare_customer_attributes(customer_attributes)
+        one_hot_cols = self._resolve_one_hot_cols(attributes, one_hot_col)
 
+        # Drop undated rows: a NULL date forms its own occasion and skews recency/T.
+        data = data.filter(data[cols.transaction_date].notnull())  # noqa: PD004 (ibis API, not pandas)
         # Cast the single max scalar to a date (not every row) — same idiom as segmentation/rfm.py.
-        latest_transaction = _coerce_to_date(data[cols.transaction_date].max().cast("date").execute())
+        latest_raw = data[cols.transaction_date].max().cast("date").execute()
+        if pd.isna(latest_raw):  # None or NaT: the table has no transactions to summarize.
+            msg = "data contains no transactions; cannot build a CLV summary."
+            raise ValueError(msg)
+        latest_transaction = _coerce_to_date(latest_raw)
         if observation_period_end is None:
             observation_period_end = latest_transaction
         else:
@@ -137,13 +230,117 @@ class CLVStats:
                 )
                 raise ValueError(msg)
 
-        self.table = self._compute_summary(data, cols, period, observation_period_end)
+        summary = self._compute_summary(data, period, observation_period_end)
+        table = self._attach_customer_attributes(summary, attributes, one_hot_cols)
+        # pymc-marketing requires the id column named literally "customer_id" (no remap arg), like the
+        # other four. Rename so an overridden customer_id option still yields a model-ready summary.
+        if cols.customer_id != "customer_id":
+            table = table.rename({"customer_id": cols.customer_id})
+        self.period = period
+        self.table = table
+
+    @staticmethod
+    def _prepare_customer_attributes(customer_attributes: pd.DataFrame | ibis.Table | None) -> ibis.Table | None:
+        """Validate and normalize the customer_attributes table to an Ibis Table.
+
+        Args:
+            customer_attributes (pd.DataFrame | ibis.Table | None): The caller-supplied per-customer
+                attribute table (one row per ``customer_id``), or ``None``.
+
+        Returns:
+            ibis.Table | None: The attributes as an Ibis Table, or ``None`` if none were supplied.
+
+        Raises:
+            TypeError: If ``customer_attributes`` is neither a pandas DataFrame nor an Ibis Table.
+            ValueError: If it lacks the ``customer_id`` column, or has a duplicate ``customer_id``
+                (a left join on a non-unique key would fan out, i.e. duplicate, the summary rows).
+        """
+        if customer_attributes is None:
+            return None
+        cols = ColumnHelper()
+        attributes = ensure_ibis_table(customer_attributes, "customer_attributes")
+        if cols.customer_id not in attributes.columns:
+            msg = f"customer_attributes must contain the customer_id column '{cols.customer_id}'."
+            raise ValueError(msg)
+        counts = attributes.aggregate(
+            rows=attributes.count(),
+            customers=attributes[cols.customer_id].nunique(),
+        ).execute()
+        if counts["rows"].iloc[0] != counts["customers"].iloc[0]:
+            msg = "customer_attributes must have one row per customer_id; found duplicate customer ids."
+            raise ValueError(msg)
+        return attributes
+
+    @staticmethod
+    def _resolve_one_hot_cols(
+        attributes: ibis.Table | None,
+        one_hot_col: str | list[str] | None,
+    ) -> list[str]:
+        """Normalize ``one_hot_col`` to a de-duplicated list of columns present in ``attributes``.
+
+        Args:
+            attributes (ibis.Table | None): The prepared customer_attributes table, or ``None``.
+            one_hot_col (str | list[str] | None): The user-supplied one-hot column(s).
+
+        Returns:
+            list[str]: The normalized, de-duplicated one-hot column names (empty if ``one_hot_col`` is None).
+
+        Raises:
+            ValueError: If ``one_hot_col`` is given without ``customer_attributes``, or names a column
+                absent from ``customer_attributes``.
+        """
+        if one_hot_col is None:
+            return []
+        if attributes is None:
+            msg = "one_hot_col requires customer_attributes; there are no columns to encode."
+            raise ValueError(msg)
+        one_hot_cols = ensure_columns(attributes, one_hot_col, "one_hot_col")
+        # De-duplicate while preserving order: a repeated column would be encoded twice, and the first
+        # pass drops it, so the second would fail to find it.
+        return list(dict.fromkeys(one_hot_cols))
+
+    @staticmethod
+    def _attach_customer_attributes(
+        summary: ibis.Table,
+        attributes: ibis.Table | None,
+        one_hot_cols: list[str],
+    ) -> ibis.Table:
+        """Left-join the per-customer attributes onto the summary, one-hot encoding the requested columns.
+
+        Args:
+            summary (ibis.Table): The base BTYD summary (one row per customer).
+            attributes (ibis.Table | None): The prepared customer_attributes table, or ``None``.
+            one_hot_cols (list[str]): Normalized one-hot column names (a subset of the attribute columns).
+
+        Returns:
+            ibis.Table: The summary with the attribute and one-hot columns attached.
+
+        Raises:
+            ValueError: If an attached column name collides with a reserved BTYD summary column
+                (``customer_id``, ``frequency``, ``recency``, ``T``, ``monetary_value``).
+        """
+        if attributes is None:
+            return summary
+        cols = ColumnHelper()
+        if len(one_hot_cols) > 0:
+            attributes = _one_hot_encode(attributes, one_hot_cols)
+
+        attached = [col for col in attributes.columns if col != cols.customer_id]
+        # Reserve the literal "customer_id" too (the output id name __init__ renames to); else under an
+        # overridden customer_id option an attribute named "customer_id" silently collides.
+        collisions = sorted(set(attached) & (set(summary.columns) | {"customer_id"}))
+        if len(collisions) > 0:
+            msg = f"customer_attributes / one_hot_col columns collide with reserved BTYD summary columns: {collisions}"
+            raise ValueError(msg)
+
+        # Reselect the base columns plus the attached ones, dropping the duplicated join key ibis
+        # appends (e.g. customer_id_right); selecting by name avoids hardcoding the join suffix.
+        return summary.left_join(attributes, cols.customer_id)[[*summary.columns, *attached]]
 
     @classmethod
     def _compute_summary(
         cls,
         data: ibis.Table,
-        cols: ColumnHelper,
         period: str,
         observation_period_end: datetime.date,
     ) -> ibis.Table:
@@ -151,17 +348,20 @@ class CLVStats:
 
         Args:
             data (ibis.Table): The validated transaction data.
-            cols (ColumnHelper): Resolved column names.
-            period (str): The validated period unit (``"day"`` or ``"week"``).
+            period (str): The validated period unit (``"day"``, ``"week"``, or ``"month"``).
             observation_period_end (datetime.date): The resolved observation window end.
 
         Returns:
             ibis.Table: One row per customer with the BTYD summary columns.
         """
+        cols = ColumnHelper()
         # Collapse to one purchase occasion per customer per calendar day, summing spend
         # within the day (same-day baskets are a single occasion under the BTYD convention).
         day = data[cols.transaction_date].cast("date").name("_day")
         daily = data.group_by([cols.customer_id, day]).aggregate(_day_spend=data[cols.unit_spend].sum())
+
+        # A day is an occasion only if its net spend is positive; returns-only days are not purchases.
+        daily = daily.filter(daily._day_spend > 0)
 
         # A repeat occasion is any purchase day after the customer's first purchase day.
         first_day = daily["_day"].min().over(ibis.window(group_by=daily[cols.customer_id]))
@@ -178,10 +378,9 @@ class CLVStats:
         observation_end = ibis.literal(observation_period_end)
         frequency = summary._occasions - 1
 
-        # frequency / recency / T / monetary_value are pymc-marketing's required literal
-        # column names (ParetoNBDModel / GammaGammaModel), deliberately not options.py names.
-        # The customer id keeps its configured column name; if column.customer_id has been
-        # overridden, the downstream model call must be given the matching id column.
+        # frequency / recency / T / monetary_value are pymc-marketing's required literal names
+        # (deliberately not options.py names). The id keeps its configured name here for the join
+        # keys; __init__ renames the final column to the literal "customer_id" the models also need.
         return summary.mutate(
             frequency=frequency.cast("int64"),
             # Day-granularity delta (Oracle-safe) divided by days-per-period for a fractional age.
@@ -205,6 +404,77 @@ class CLVStats:
 
         Returns:
             pd.DataFrame: One row per customer with columns ``customer_id``, ``frequency``,
-                ``recency``, ``T``, and ``monetary_value``.
+                ``recency``, ``T``, and ``monetary_value``, followed by any ``customer_attributes``
+                and one-hot columns requested at construction.
+
+        Raises:
+            ValueError: If a covariate column is NULL for any customer (a customer missing from
+                ``customer_attributes``, or a NULL attribute value). NULL covariates silently break
+                ``ParetoNBDModel``'s fit, which does not validate for them.
         """
-        return self.table.execute()
+        result = self.table.execute()
+        # Checking one-hot dummies too is safe: a NULL *source* value became the reference level (0), so a
+        # dummy reads NULL only for a customer missing from the join -- exactly the case worth rejecting.
+        null_covariates = [col for col in self.covariate_cols if result[col].isna().any()]
+        if len(null_covariates) > 0:
+            msg = (
+                f"customer_attributes leaves NULL in covariate column(s) {null_covariates}: a customer is "
+                "missing from customer_attributes, or has a NULL attribute value. NULL covariates make "
+                "ParetoNBDModel's fit fail. Provide non-NULL covariates for every customer, or drop those "
+                "customers first."
+            )
+            raise ValueError(msg)
+        return result
+
+    @property
+    def repeat_buyers(self) -> pd.DataFrame:
+        """The GammaGamma-ready subset of :attr:`df` — the repeat buyers (``frequency > 0``, index reset).
+
+        One-time buyers (``NaN`` monetary_value) are excluded; ``GammaGammaModel`` cannot fit them. No
+        spend filter is needed because ``monetary_value`` is always positive here. Warns (``UserWarning``)
+        if ``|Pearson r|`` between ``frequency`` and ``monetary_value`` exceeds
+        ``_MONETARY_FREQUENCY_CORR_WARN``, breaking GammaGamma's independence assumption.
+
+        Returns:
+            pd.DataFrame: The ``frequency > 0`` rows of :attr:`df`, index reset.
+        """
+        summary = self.df
+        gg_ready = summary[summary["frequency"] > 0].reset_index(drop=True)
+        # Correlation is only defined when both columns vary; a constant column would divide by a zero
+        # standard deviation (NaN, plus a numpy warning), so skip the check in that degenerate case.
+        frequency, monetary_value = gg_ready["frequency"], gg_ready["monetary_value"]
+        both_vary = frequency.min() != frequency.max() and monetary_value.min() != monetary_value.max()
+        if both_vary:
+            corr = frequency.corr(monetary_value)
+            if abs(corr) > self._MONETARY_FREQUENCY_CORR_WARN:
+                warnings.warn(
+                    f"frequency and monetary_value are correlated (Pearson r={corr:.2f}); GammaGamma assumes "
+                    "they are independent, so its spend estimates may be biased.",
+                    stacklevel=2,
+                )
+        return gg_ready
+
+    @property
+    def covariate_cols(self) -> list[str]:
+        """The covariate columns attached to the summary (customer_attributes and one-hot dummies).
+
+        Every column beyond the base BTYD summary, ready to pass as ``purchase_covariate_cols`` /
+        ``dropout_covariate_cols`` to ``ParetoNBDModel``.
+
+        Returns:
+            list[str]: The covariate column names in summary order (empty if none were requested).
+        """
+        return [col for col in self.table.columns if col not in self._BASE_SUMMARY_COLUMNS]
+
+    @property
+    def pymc_time_unit(self) -> str:
+        """The pymc-marketing ``time_unit`` matching this summary's ``period`` (``"D"``/``"W"``/``"M"``).
+
+        Pass as the ``time_unit`` of ``GammaGammaModel.expected_customer_lifetime_value``, whose ``future_t``
+        is in months and defaults to ``"D"``, silently wrong for a weekly summary (horizon off ~7x) or a
+        monthly one (~30x).
+
+        Returns:
+            str: ``"D"`` for ``period="day"``, ``"W"`` for ``"week"``, ``"M"`` for ``"month"``.
+        """
+        return self._PYMC_TIME_UNIT[self.period]

--- a/openretailscience/experimental/clv.py
+++ b/openretailscience/experimental/clv.py
@@ -113,13 +113,13 @@ def _one_hot_encode(table: ibis.Table, cols_to_encode: list[str]) -> ibis.Table:
                 f"one_hot_col '{col}' has a single distinct level (one category, or all NULL), so dropping the "
                 "reference level leaves zero dummy columns and no covariate. Drop it from one_hot_col, or check "
                 "the column has the categories you expect.",
-                stacklevel=2,
+                stacklevel=4,  # user -> __init__ -> _attach_customer_attributes -> _one_hot_encode -> warn
             )
         elif len(emitted) > _ONE_HOT_CARDINALITY_WARN:
             warnings.warn(
                 f"one_hot_col '{col}' expands to {len(emitted)} dummy columns; high-cardinality one-hot "
                 "makes a large, sparse ParetoNBD covariate matrix. Group rare levels or use another encoding.",
-                stacklevel=2,
+                stacklevel=4,  # user -> __init__ -> _attach_customer_attributes -> _one_hot_encode -> warn
             )
         # ifelse -> portable CASE WHEN (`col == value` as a value is invalid SQL on Oracle/SQL Server);
         # NULL or non-match -> 0. int8 (TINYINT) not int64: a 0/1 flag is one byte.

--- a/openretailscience/experimental/clv.py
+++ b/openretailscience/experimental/clv.py
@@ -440,6 +440,8 @@ class CLVStats:
         """
         summary = self.df
         gg_ready = summary[summary["frequency"] > 0].reset_index(drop=True)
+        if len(gg_ready) == 0:  # no repeat buyers: nothing to correlate
+            return gg_ready
         # Correlation is only defined when both columns vary; a constant column would divide by a zero
         # standard deviation (NaN, plus a numpy warning), so skip the check in that degenerate case.
         frequency, monetary_value = gg_ready["frequency"], gg_ready["monetary_value"]

--- a/openretailscience/segmentation/segstats.py
+++ b/openretailscience/segmentation/segstats.py
@@ -56,7 +56,12 @@ import pandas as pd
 from ibis.backends.sql import compilers as sql_compilers
 from sqlglot import exp
 
-from openretailscience.core.validation import ensure_columns, ensure_data_has_columns, ensure_ibis_table
+from openretailscience.core.validation import (
+    ensure_columns,
+    ensure_data_has_columns,
+    ensure_ibis_table,
+    ensure_valid_extra_aggs,
+)
 from openretailscience.options import ColumnHelper, get_option
 
 __all__ = ["SegTransactionStats", "cube", "rollup"]
@@ -377,8 +382,7 @@ class SegTransactionStats:
             ],
         )
 
-        # Validate extra_aggs if provided
-        self._validate_extra_aggs(data, extra_aggs)
+        ensure_valid_extra_aggs(data, extra_aggs)
 
         self.segment_col = segment_col
         self.extra_aggs = {} if extra_aggs is None else extra_aggs
@@ -479,29 +483,6 @@ class SegTransactionStats:
             col_type = data[col].type()
             mutations[col] = ibis.literal(values[i], type=col_type)
         return mutations
-
-    @staticmethod
-    def _validate_extra_aggs(data: ibis.Table, extra_aggs: dict[str, tuple[str, str]] | None) -> None:
-        """Validate extra_aggs parameter.
-
-        Args:
-            data (ibis.Table): The data table to validate against
-            extra_aggs (dict[str, tuple[str, str]] | None): Extra aggregations to validate
-
-        Raises:
-            ValueError: If column doesn't exist or aggregation function is not available
-        """
-        if extra_aggs is None:
-            return
-
-        for col_tuple in extra_aggs.values():
-            col, func = col_tuple
-            if col not in data.columns:
-                msg = f"Column '{col}' specified in extra_aggs does not exist in the data"
-                raise ValueError(msg)
-            if not hasattr(data[col], func):
-                msg = f"Aggregation function '{func}' not available for column '{col}'"
-                raise ValueError(msg)
 
     @staticmethod
     def _validate_grouping_sets_params(

--- a/tests/analysis/test_cohort.py
+++ b/tests/analysis/test_cohort.py
@@ -113,19 +113,22 @@ class TestCohortAnalysis:
 
     def test_invalid_period(self, transactions_df):
         """Test if an invalid period raises an error."""
-        with pytest.raises(ValueError, match=r"period must be one of .*'m'"):
+        with pytest.raises(ValueError, match=r"period must be one of .*'fortnight'"):
             CohortAnalysis(
                 df=transactions_df,
                 aggregation_column="unit_spend",
-                period="m",
+                period="fortnight",
             )
 
-    @pytest.mark.parametrize("period", ["MONTH", "Month", "MoNtH"])
-    def test_period_case_insensitive_matches_lowercase(self, transactions_df, period):
-        """Mixed-case period values produce identical output to the lowercase form."""
-        lower = CohortAnalysis(df=transactions_df, aggregation_column="unit_spend", period=period.lower()).df
-        upper = CohortAnalysis(df=transactions_df, aggregation_column="unit_spend", period=period).df
-        pdt.assert_frame_equal(upper, lower)
+    def test_period_spelling_is_normalized_before_use(self, transactions_df):
+        """A non-canonical spelling is normalized (via ensure_period) before it drives truncate/_periods_between.
+
+        The full alias/case matrix is owned by tests/core/test_validation.py::TestEnsurePeriod; this only
+        checks CohortAnalysis threads the canonical word downstream rather than the raw input.
+        """
+        variant = CohortAnalysis(df=transactions_df, aggregation_column="unit_spend", period="MoNtH").df
+        expected = CohortAnalysis(df=transactions_df, aggregation_column="unit_spend", period="month").df
+        pdt.assert_frame_equal(variant, expected)
 
     def test_cohort_percentage_normalizes_each_cohort_to_own_period_zero(self, transactions_df):
         """Tests that percentage=True normalizes each cohort row by its own period-0 value.
@@ -199,8 +202,8 @@ class TestCohortAnalysis:
 
         pdt.assert_frame_equal(result, expected_df)
 
-    def test_with_custom_column_names(self, transactions_df):
-        """Test CohortAnalysis with custom column names to ensure column overrides work correctly."""
+    def test_with_custom_column_names(self, transactions_df, expected_results_df):
+        """Overriding the customer_id/transaction_date option names yields the same cohort as the defaults."""
         custom_transactions_df = transactions_df.rename(
             columns={
                 "customer_id": "cust_id",
@@ -210,16 +213,14 @@ class TestCohortAnalysis:
         )
 
         with option_context("column.customer_id", "cust_id", "column.transaction_date", "txn_date"):
-            cohort = CohortAnalysis(
+            result = CohortAnalysis(
                 df=custom_transactions_df,
                 aggregation_column="spend_amount",
                 agg_func="nunique",
                 period="month",
-            )
+            ).df
 
-            result = cohort.df
-            assert isinstance(result, pd.DataFrame), "Should return DataFrame with custom columns"
-            assert not result.empty, "Should produce results with custom column names"
+        pdt.assert_frame_equal(result, expected_results_df)
 
 
 class TestPeriodsBetween:

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -12,6 +12,7 @@ from openretailscience.core.validation import (
     ensure_ibis_table,
     ensure_integer,
     ensure_number,
+    ensure_period,
     ensure_positive,
     ensure_tznaive_datetime,
     ensure_unit_interval,
@@ -146,6 +147,50 @@ class TestEnsureValueChoice:
         """Materializing ``choices`` once means a generator's contents appear in the error too."""
         with pytest.raises(ValueError, match=r"\['asc', 'desc'\]"):
             ensure_value_choice("bogus", (c for c in ["asc", "desc"]), "sort_order")
+
+
+class TestEnsurePeriod:
+    """Tests for the ensure_period helper (alias-aware period validation)."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("d", "day"),
+            ("D", "day"),
+            ("day", "day"),
+            ("DAYS", "day"),
+            ("w", "week"),
+            ("Week", "week"),
+            ("weeks", "week"),
+            ("m", "month"),
+            ("MO", "month"),
+            ("months", "month"),
+        ],
+    )
+    def test_resolves_short_and_long_aliases_case_insensitively(self, value, expected):
+        """Short/long/mixed-case forms all resolve to the canonical period word in choices."""
+        assert ensure_period(value, ("day", "week", "month"), "period") == expected
+
+    def test_returns_the_callers_choice_spelling(self):
+        """The returned value is the caller's own choice spelling, ready for lookup."""
+        assert ensure_period("Q", ("Year", "Quarter", "Month"), "period") == "Quarter"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "year",  # a recognized period alias, but not among the caller's choices
+            "fortnight",  # not a recognized period at all
+        ],
+    )
+    def test_period_outside_choices_raises(self, value):
+        """A period outside the caller's choices is rejected, whether or not it is a recognized alias."""
+        with pytest.raises(ValueError, match=rf"period must be one of .*'{value}'"):
+            ensure_period(value, ("day", "week"), "period")
+
+    def test_non_string_raises_type_error(self):
+        """A non-string period raises TypeError."""
+        with pytest.raises(TypeError, match="period must be a string"):
+            ensure_period(7, ("day", "week"), "period")
 
 
 class TestEnsureIbisTable:

--- a/tests/experimental/test_clv.py
+++ b/tests/experimental/test_clv.py
@@ -1,6 +1,7 @@
 """Tests for openretailscience.experimental.clv."""
 
 import datetime
+import warnings
 
 import ibis
 import numpy as np
@@ -8,10 +9,17 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from openretailscience.experimental.clv import CLVStats
-from openretailscience.options import ColumnHelper
+from openretailscience.experimental.clv import _ONE_HOT_CARDINALITY_WARN, CLVStats
+from openretailscience.options import ColumnHelper, option_context
 
 cols = ColumnHelper()
+
+# The base BTYD output columns, in order. All five are pymc-marketing's fixed literals — the id is
+# always emitted as "customer_id", not the configured option — so they are not ColumnHelper-resolved.
+BASE_BTYD_COLS = ["customer_id", "frequency", "recency", "T", "monetary_value"]
+
+# A "month" period expresses recency/T as elapsed days / this fixed average-Gregorian-month length.
+DAYS_PER_MONTH = CLVStats._DAYS_PER_MONTH
 
 
 def _transactions() -> pd.DataFrame:
@@ -54,6 +62,14 @@ class TestCLVStats:
             pytest.param("day", datetime.date(2023, 1, 29), [14.0, 0.0, 14.0], [28.0, 28.0, 19.0], id="daily"),
             # Default end resolves to the global latest transaction, 2023-01-24 (101/102 age 23, 103 age 14).
             pytest.param("day", None, [14.0, 0.0, 14.0], [23.0, 23.0, 14.0], id="daily-default-obs-end"),
+            # Monthly: recency/T are elapsed days divided by the fixed average-Gregorian-month length.
+            pytest.param(
+                "month",
+                "2023-01-29",
+                [14 / DAYS_PER_MONTH, 0.0, 14 / DAYS_PER_MONTH],
+                [28 / DAYS_PER_MONTH, 28 / DAYS_PER_MONTH, 19 / DAYS_PER_MONTH],
+                id="monthly",
+            ),
         ],
     )
     def test_summary_matches_hand_computation(self, input_type, period, observation_period_end, recency, expected_t):
@@ -90,9 +106,74 @@ class TestCLVStats:
         with pytest.raises(TypeError, match="date or datetime"):
             CLVStats(data)
 
-    @pytest.mark.parametrize("bad_period", ["month", "fortnight", "W"])
+    def test_null_transaction_date_rows_are_dropped(self):
+        """Rows with a NULL transaction_date are dropped.
+
+        A partially-undated customer keeps only its real occasions; a fully-undated customer drops out.
+        """
+        data = pd.DataFrame(
+            {
+                cols.customer_id: [500, 500, 500, 600, 600],
+                cols.transaction_date: pd.to_datetime(["2023-01-01", "2023-01-08", None, None, None]),
+                cols.unit_spend: [10.0, 20.0, 5.0, 30.0, 40.0],
+            },
+        )
+        result = (
+            CLVStats(data, period="day", observation_period_end="2023-01-31")
+            .df.sort_values(cols.customer_id)
+            .reset_index(drop=True)
+        )
+        expected = pd.DataFrame(
+            {
+                cols.customer_id: [500],  # 600 (all-undated) drops out entirely
+                "frequency": np.array([1], dtype="int64"),  # Jan1 -> Jan8; the undated row is not an extra occasion
+                "recency": [7.0],
+                "T": [30.0],  # Jan1 -> Jan31
+                "monetary_value": [20.0],  # repeat spend is Jan8 only, undiluted by the undated row
+            },
+        )
+        assert_frame_equal(result, expected)
+
+    def test_net_nonpositive_days_are_not_occasions(self):
+        """A day with net spend <= 0 is not an occasion; a customer with no positive-spend day drops out."""
+        data = pd.DataFrame(
+            {
+                cols.customer_id: [801, 801, 801, 802, 802, 802, 803, 803],
+                cols.transaction_date: pd.to_datetime(
+                    [
+                        "2023-01-01",  # 801: purchase
+                        "2023-01-08",  # 801: net-negative return day -> dropped
+                        "2023-01-15",  # 801: purchase
+                        "2023-01-01",  # 802: purchase
+                        "2023-01-10",  # 802: buy 10 ...
+                        "2023-01-10",  # 802: ... and fully return it same day -> net zero, dropped
+                        "2023-01-01",  # 803: return only
+                        "2023-01-05",  # 803: return only
+                    ],
+                ),
+                cols.unit_spend: [100.0, -20.0, 60.0, 50.0, 10.0, -10.0, -30.0, -10.0],
+            },
+        )
+        result = (
+            CLVStats(data, period="day", observation_period_end="2023-01-31")
+            .df.sort_values(cols.customer_id)
+            .reset_index(drop=True)
+        )
+        expected = pd.DataFrame(
+            {
+                cols.customer_id: [801, 802],  # 803 (all returns, no positive day) drops out entirely
+                "frequency": np.array([1, 0], dtype="int64"),  # 801's return day is not a repeat occasion
+                # 801 Jan1 -> Jan15 (the Jan8 return does not become last_day); 802 is a one-time buyer
+                "recency": [14.0, 0.0],
+                "T": [30.0, 30.0],
+                "monetary_value": [60.0, np.nan],  # 801's repeat spend is Jan15 only, undiluted by the return
+            },
+        )
+        assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize("bad_period", ["fortnight", "year", "quarter"])
     def test_invalid_period_raises(self, bad_period):
-        """Only the canonical 'day'/'week' period values are accepted."""
+        """Periods outside day/week/month are rejected (year/quarter are real words but unsupported here)."""
         with pytest.raises(ValueError, match="period"):
             CLVStats(_transactions(), period=bad_period)
 
@@ -116,7 +197,503 @@ class TestCLVStats:
         with pytest.raises(TypeError, match="observation_period_end"):
             CLVStats(_transactions(), observation_period_end=20230129)
 
+    def test_repeat_buyers_keeps_only_repeat_buyers(self):
+        """repeat_buyers is the GammaGamma-ready subset: the repeat buyers (frequency > 0).
+
+        One-time buyers (frequency 0) are dropped. Customer 104's only repeat day nets negative
+        (unit_spend is a margin), so that day is not an occasion and 104 collapses to a one-time
+        buyer -- also dropped.
+        """
+        data = pd.DataFrame(
+            {
+                cols.customer_id: [101, 101, 102, 103, 103, 104, 104],
+                cols.transaction_date: pd.to_datetime(
+                    ["2023-01-01", "2023-01-15", "2023-01-01", "2023-01-01", "2023-01-15", "2023-01-01", "2023-01-15"],
+                ),
+                cols.unit_spend: [50.0, 40.0, 200.0, 30.0, 80.0, 20.0, -5.0],
+            },
+        )
+        result = CLVStats(data, period="day").repeat_buyers.sort_values(cols.customer_id).reset_index(drop=True)
+
+        expected = pd.DataFrame(
+            {
+                cols.customer_id: [101, 103],  # 102 (frequency 0) and 104 (collapses to frequency 0) dropped
+                "frequency": np.array([1, 1], dtype="int64"),
+                "recency": [14.0, 14.0],
+                "T": [14.0, 14.0],
+                "monetary_value": [40.0, 80.0],
+            },
+        )
+        assert_frame_equal(result, expected)
+
     @staticmethod
     def _as_input(pdf: pd.DataFrame, input_type: str) -> pd.DataFrame | ibis.Table:
         """Return the frame as a pandas DataFrame or an Ibis memtable."""
         return ibis.memtable(pdf) if input_type == "ibis" else pdf
+
+
+class TestCLVStatsCorrelationWarning:
+    """repeat_buyers warns when frequency and monetary_value break GammaGamma's independence assumption."""
+
+    @staticmethod
+    def _four_customers(unit_spend: list[float]) -> pd.DataFrame:
+        """Four repeat buyers with frequency 1/2/3/4; ``unit_spend`` sets each customer's per-day spend."""
+        return pd.DataFrame(
+            {
+                cols.customer_id: [201, 201, 202, 202, 202, 203, 203, 203, 203, 204, 204, 204, 204, 204],
+                cols.transaction_date: pd.to_datetime(
+                    [
+                        "2023-01-01",
+                        "2023-01-02",
+                        "2023-01-01",
+                        "2023-01-02",
+                        "2023-01-03",
+                        "2023-01-01",
+                        "2023-01-02",
+                        "2023-01-03",
+                        "2023-01-04",
+                        "2023-01-01",
+                        "2023-01-02",
+                        "2023-01-03",
+                        "2023-01-04",
+                        "2023-01-05",
+                    ],
+                ),
+                cols.unit_spend: unit_spend,
+            },
+        )
+
+    @pytest.mark.parametrize(
+        ("unit_spend", "expect_warn"),
+        [
+            # frequency [1,2,3,4] rising lockstep with monetary [10,20,30,40] -> Pearson r = 1.0.
+            pytest.param(
+                [100.0, 10.0, 100.0, 20.0, 20.0, 100.0, 30.0, 30.0, 30.0, 100.0, 40.0, 40.0, 40.0, 40.0],
+                True,
+                id="correlated",
+            ),
+            # frequency [1,2,3,4] against monetary [20,40,10,30] -> Pearson r = 0.0.
+            pytest.param(
+                [100.0, 20.0, 100.0, 40.0, 40.0, 100.0, 10.0, 10.0, 10.0, 100.0, 30.0, 30.0, 30.0, 30.0],
+                False,
+                id="uncorrelated",
+            ),
+        ],
+    )
+    def test_repeat_buyers_warns_iff_frequency_correlates_with_monetary(self, unit_spend, expect_warn):
+        """repeat_buyers warns exactly when |Pearson r(frequency, monetary_value)| exceeds the threshold."""
+        data = self._four_customers(unit_spend)
+        if expect_warn:
+            with pytest.warns(UserWarning, match="frequency and monetary_value are correlated"):
+                _ = CLVStats(data, period="day").repeat_buyers
+        else:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                result = CLVStats(data, period="day").repeat_buyers
+            assert not any("correlated" in str(w.message) for w in caught)
+            assert len(result) == data[cols.customer_id].nunique()  # all four are repeat buyers, none dropped
+
+
+class TestCLVStatsPymcTimeUnit:
+    """CLVStats exposes the pymc-marketing time_unit matching its period."""
+
+    @pytest.mark.parametrize(
+        ("period", "canonical", "time_unit"),
+        [
+            ("day", "day", "D"),
+            ("week", "week", "W"),
+            ("month", "month", "M"),
+            ("d", "day", "D"),
+            ("M", "month", "M"),
+        ],
+    )
+    def test_period_is_canonical_and_maps_to_pymc_time_unit(self, period, canonical, time_unit):
+        """The resolved period is stored canonically and maps to pymc-marketing's D/W/M time_unit."""
+        clv = CLVStats(_transactions(), period=period)
+        assert clv.period == canonical
+        assert clv.pymc_time_unit == time_unit
+
+
+def _dim_transactions() -> pd.DataFrame:
+    """Transactions for four customers (201-204) with distinct repeat-purchase histories."""
+    return pd.DataFrame(
+        {
+            cols.customer_id: [201, 201, 201, 202, 203, 203, 204, 204],
+            cols.transaction_date: pd.to_datetime(
+                [
+                    "2023-01-01",
+                    "2023-01-08",
+                    "2023-01-15",
+                    "2023-01-01",
+                    "2023-01-10",
+                    "2023-01-24",
+                    "2023-01-05",
+                    "2023-01-19",
+                ],
+            ),
+            cols.unit_spend: [100.0, 50.0, 70.0, 200.0, 30.0, 80.0, 40.0, 60.0],
+        },
+    )
+
+
+def _customer_attributes() -> pd.DataFrame:
+    """One row per customer (201-204): distinct stores shopped and signup channel.
+
+    The kind of table a caller builds upstream (e.g. SegTransactionStats grouped on customer_id).
+    203's channel is NULL (never signed up through a tracked channel), so it becomes the dropped
+    one-hot reference level.
+    """
+    return pd.DataFrame(
+        {
+            cols.customer_id: [201, 202, 203, 204],
+            "stores_shopped": np.array([2, 1, 1, 2], dtype="int64"),
+            "signup_channel": ["email", "referral", None, "search"],
+        },
+    )
+
+
+class TestCLVStatsCustomerAttributes:
+    """Tests for attaching a caller-supplied per-customer attributes table (join + one-hot)."""
+
+    @staticmethod
+    def _summary(**kwargs) -> pd.DataFrame:
+        """Build the CLVStats summary from the dim transactions, sorted by customer_id."""
+        return (
+            CLVStats(_dim_transactions(), period="day", **kwargs)
+            .df.sort_values(cols.customer_id)
+            .reset_index(drop=True)
+        )
+
+    @pytest.mark.parametrize("attr_type", ["pandas", "ibis"])
+    def test_customer_attributes_joined_as_is(self, attr_type):
+        """A per-customer attribute column joins onto the summary unchanged (pandas or ibis input)."""
+        attributes = _customer_attributes()[[cols.customer_id, "stores_shopped"]]
+        attributes = ibis.memtable(attributes) if attr_type == "ibis" else attributes
+        result = self._summary(customer_attributes=attributes)
+        expected = pd.DataFrame(
+            {cols.customer_id: [201, 202, 203, 204], "stores_shopped": np.array([2, 1, 1, 2], dtype="int64")},
+        )
+        assert_frame_equal(result[[cols.customer_id, "stores_shopped"]], expected)
+        # Exact schema: base BTYD columns then the attribute, with no stray join-key column.
+        assert list(result.columns) == [*BASE_BTYD_COLS, "stores_shopped"]
+
+    def test_customer_attributes_preserves_btyd_columns(self):
+        """Attaching attributes does not disturb the frequency/monetary_value computation."""
+        base = self._summary()
+        # one-hot signup_channel so its NULL (203) is the reference level, not a NULL covariate that raises.
+        with_attrs = self._summary(customer_attributes=_customer_attributes(), one_hot_col="signup_channel")
+        assert_frame_equal(with_attrs[base.columns.tolist()], base)
+
+    @pytest.mark.parametrize(
+        "attributes",
+        [
+            # A customer present in transactions but absent from customer_attributes: the left join leaves
+            # 204's stores_shopped covariate NULL, which breaks ParetoNBD.
+            pytest.param(_customer_attributes()[[cols.customer_id, "stores_shopped"]].iloc[:3], id="missing-customer"),
+            # Full customer coverage, but 202's loyalty_points is itself NULL; joined as-is it is a NULL covariate.
+            pytest.param(
+                pd.DataFrame({cols.customer_id: [201, 202, 203, 204], "loyalty_points": [10.0, None, 30.0, 40.0]}),
+                id="null-value",
+            ),
+        ],
+    )
+    def test_null_covariate_raises(self, attributes):
+        """A NULL covariate (a customer missing from attributes, or an explicit NULL attribute value) is rejected."""
+        with pytest.raises(ValueError, match="NULL"):
+            self._summary(customer_attributes=attributes)
+
+    @pytest.mark.parametrize("one_hot_col", ["signup_channel", ["signup_channel"]])
+    def test_one_hot_encodes_and_drops_original(self, one_hot_col):
+        """one_hot_col on an attribute column emits dummies and drops the source (str or list form)."""
+        result = self._summary(customer_attributes=_customer_attributes(), one_hot_col=one_hot_col)
+        expected = pd.DataFrame(
+            {
+                cols.customer_id: [201, 202, 203, 204],
+                "signup_channel_email": np.array([1, 0, 0, 0], dtype="int8"),
+                "signup_channel_referral": np.array([0, 1, 0, 0], dtype="int8"),
+                "signup_channel_search": np.array([0, 0, 0, 1], dtype="int8"),
+            },
+        )
+        dummy_cols = [c for c in result.columns if c.startswith("signup_channel_")]
+        assert_frame_equal(result[[cols.customer_id, *dummy_cols]], expected)
+        assert "signup_channel" not in result.columns
+        # The column has NULLs (customer 203), so NULL is the dropped reference: every real value
+        # emits a dummy and the NULL customer is 0 across all of them, with no dedicated NULL column.
+        assert "signup_channel_null" not in result.columns
+
+    def test_one_hot_integer_attribute_column(self):
+        """one_hot_col can encode an integer attribute column (drops the sorted-first level)."""
+        attributes = _customer_attributes()[[cols.customer_id, "stores_shopped"]]
+        result = self._summary(customer_attributes=attributes, one_hot_col="stores_shopped")
+        expected = pd.DataFrame(
+            {cols.customer_id: [201, 202, 203, 204], "stores_shopped_2": np.array([1, 0, 0, 1], dtype="int8")},
+        )
+        dummy_cols = [c for c in result.columns if c.startswith("stores_shopped_")]
+        assert_frame_equal(result[[cols.customer_id, *dummy_cols]], expected)
+        assert "stores_shopped" not in result.columns
+
+    def test_one_hot_multiple_columns(self):
+        """A list one_hot_col encodes every named attribute column."""
+        result = self._summary(
+            customer_attributes=_customer_attributes(),
+            one_hot_col=["signup_channel", "stores_shopped"],
+        )
+        expected = pd.DataFrame(
+            {
+                cols.customer_id: [201, 202, 203, 204],
+                "signup_channel_email": np.array([1, 0, 0, 0], dtype="int8"),
+                "signup_channel_referral": np.array([0, 1, 0, 0], dtype="int8"),
+                "signup_channel_search": np.array([0, 0, 0, 1], dtype="int8"),
+                "stores_shopped_2": np.array([1, 0, 0, 1], dtype="int8"),
+            },
+        )
+        dummy_cols = [c for c in result.columns if c not in BASE_BTYD_COLS]
+        assert_frame_equal(result[[cols.customer_id, *dummy_cols]], expected)
+        assert "signup_channel" not in result.columns
+        assert "stores_shopped" not in result.columns
+
+    @pytest.mark.parametrize(
+        ("n_categories", "expect_warn"),
+        [
+            # Each customer gets a distinct region and there are no NULLs, so one level is dropped as the
+            # reference and emitted dummies == n_categories - 1. Pin the strict-`>` threshold exactly:
+            # n = WARN + 1 emits WARN dummies (no warning); n = WARN + 2 emits WARN + 1 (warning).
+            pytest.param(_ONE_HOT_CARDINALITY_WARN + 1, False, id="at-threshold"),
+            pytest.param(_ONE_HOT_CARDINALITY_WARN + 2, True, id="over-threshold"),
+        ],
+    )
+    def test_one_hot_warns_on_high_cardinality(self, n_categories, expect_warn):
+        """One-hot encoding warns exactly when emitted dummies exceed _ONE_HOT_CARDINALITY_WARN (strict >)."""
+        customer_ids = list(range(1, n_categories + 1))
+        transactions = pd.DataFrame(
+            {
+                cols.customer_id: customer_ids,
+                cols.transaction_date: pd.to_datetime(["2023-01-01"] * n_categories),
+                cols.unit_spend: [10.0] * n_categories,
+            },
+        )
+        attributes = pd.DataFrame(
+            {cols.customer_id: customer_ids, "region": [f"r{i:03d}" for i in range(n_categories)]}
+        )
+        if expect_warn:
+            with pytest.warns(UserWarning, match="dummy columns"):
+                CLVStats(transactions, period="day", customer_attributes=attributes, one_hot_col="region")
+        else:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", UserWarning)  # any one-hot warning here would fail the test
+                clv = CLVStats(transactions, period="day", customer_attributes=attributes, one_hot_col="region")
+            assert len(clv.covariate_cols) == n_categories - 1  # encode still happens; one reference level dropped
+
+    def test_one_hot_constant_column_warns_and_emits_no_covariate(self):
+        """A constant, no-NULL one_hot column emits zero dummies and warns instead of failing silently."""
+        transactions = pd.DataFrame(
+            {
+                cols.customer_id: [201, 202, 203],
+                cols.transaction_date: pd.to_datetime(["2023-01-01", "2023-01-02", "2023-01-03"]),
+                cols.unit_spend: [10.0, 20.0, 30.0],
+            },
+        )
+        # Every customer shares one region, no NULLs: the sole level is the dropped reference, so no dummy remains.
+        attributes = pd.DataFrame({cols.customer_id: [201, 202, 203], "region": ["north", "north", "north"]})
+        with pytest.warns(UserWarning, match="zero dummy columns"):
+            clv = CLVStats(transactions, period="day", customer_attributes=attributes, one_hot_col="region")
+        assert clv.covariate_cols == []
+        assert "region" not in clv.df.columns
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [
+            (
+                {
+                    "customer_attributes": _customer_attributes(),
+                    "one_hot_col": ["signup_channel", "stores_shopped"],
+                },
+                ["signup_channel_email", "signup_channel_referral", "signup_channel_search", "stores_shopped_2"],
+            ),
+            ({}, []),
+        ],
+    )
+    def test_covariate_cols_lists_only_attached_columns(self, kwargs, expected):
+        """covariate_cols returns the attached attribute / one-hot columns, excluding base BTYD columns."""
+        summary = CLVStats(_dim_transactions(), period="day", **kwargs)
+        assert summary.covariate_cols == expected
+
+    def test_one_hot_integer_column_with_nulls_names_without_decimal(self):
+        """A nullable-integer one-hot column names dummies {col}_2, not the float64 {col}_2.0."""
+        transactions = pd.DataFrame(
+            {
+                cols.customer_id: [401, 401, 402, 403],
+                cols.transaction_date: pd.to_datetime(["2023-01-01", "2023-01-08", "2023-01-01", "2023-01-02"]),
+                cols.unit_spend: [10.0, 20.0, 30.0, 40.0],
+            },
+        )
+        attributes = pd.DataFrame(
+            {
+                cols.customer_id: [401, 402, 403],
+                "loyalty_tier": pd.array([2, 3, None], dtype="Int64"),  # nullable int, as a DB source gives
+            },
+        )
+        result = CLVStats(transactions, period="day", customer_attributes=attributes, one_hot_col="loyalty_tier").df
+        tier_cols = {c for c in result.columns if c.startswith("loyalty_tier")}
+        # 3 categories (2, 3, NULL); NULL is the dropped reference, so both real tiers emit dummies
+        # named {col}_2 / {col}_3 (not the float64 {col}_2.0 / {col}_3.0).
+        assert tier_cols == {"loyalty_tier_2", "loyalty_tier_3"}
+        # The int-cast path must also produce the right 0/1 values, not just the right names: tier-2
+        # customer 401 flags loyalty_tier_2, tier-3 customer 402 flags loyalty_tier_3, NULL customer
+        # 403 (the reference) flags neither.
+        dummies = result.set_index(cols.customer_id)[["loyalty_tier_2", "loyalty_tier_3"]].sort_index()
+        expected_dummies = pd.DataFrame(
+            {
+                "loyalty_tier_2": np.array([1, 0, 0], dtype="int8"),
+                "loyalty_tier_3": np.array([0, 1, 0], dtype="int8"),
+            },
+            index=pd.Index([401, 402, 403], name=cols.customer_id),
+        )
+        assert_frame_equal(dummies, expected_dummies)
+
+    def test_empty_data_raises_clear_error(self):
+        """Empty transaction data raises a clear ValueError, not a misleading date-coercion TypeError."""
+        empty = pd.DataFrame(
+            {
+                cols.customer_id: pd.Series([], dtype="int64"),
+                cols.transaction_date: pd.Series([], dtype="datetime64[ns]"),
+                cols.unit_spend: pd.Series([], dtype="float64"),
+            },
+        )
+        with pytest.raises(ValueError, match="no transactions"):
+            CLVStats(empty)
+
+    def test_duplicate_one_hot_col_is_deduplicated(self):
+        """A repeated one_hot_col is de-duplicated, not encoded twice (which would drop-then-not-find it)."""
+        transactions = pd.DataFrame(
+            {
+                cols.customer_id: [1, 1, 2, 3],
+                cols.transaction_date: pd.to_datetime(["2023-01-01", "2023-01-08", "2023-01-01", "2023-01-02"]),
+                cols.unit_spend: [10.0, 20.0, 30.0, 40.0],
+            },
+        )
+        attributes = pd.DataFrame({cols.customer_id: [1, 2, 3], "channel": ["email", "web", "email"]})
+        result = CLVStats(
+            transactions,
+            period="day",
+            customer_attributes=attributes,
+            one_hot_col=["channel", "channel"],
+        ).df
+        # Two categories (email, web); email sorts first and is the dropped reference, leaving one dummy.
+        assert sorted(c for c in result.columns if c.startswith("channel")) == ["channel_web"]
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            # customer_attributes missing the customer_id column.
+            pytest.param(
+                {"customer_attributes": pd.DataFrame({"stores_shopped": [2, 1, 1, 2]})},
+                "customer_id",
+                id="missing-customer-id",
+            ),
+            # Duplicate customer_id: a left join on a non-unique key would fan out the summary rows.
+            pytest.param(
+                {
+                    "customer_attributes": pd.DataFrame(
+                        {
+                            cols.customer_id: [201, 201, 202, 203, 204],
+                            "stores_shopped": np.array([2, 2, 1, 1, 2], dtype="int64"),
+                        },
+                    ),
+                },
+                "one row per",
+                id="duplicate-customer-id",
+            ),
+            # one_hot_col with no customer_attributes to encode.
+            pytest.param({"one_hot_col": "signup_channel"}, "requires customer_attributes", id="one-hot-without-attrs"),
+            # one_hot_col naming a column absent from customer_attributes.
+            pytest.param(
+                {"customer_attributes": _customer_attributes(), "one_hot_col": "loyalty_tier"},
+                "loyalty_tier",
+                id="one-hot-missing-column",
+            ),
+            # An attribute column named like a reserved BTYD column would mangle the summary.
+            pytest.param(
+                {
+                    "customer_attributes": pd.DataFrame(
+                        {cols.customer_id: [201, 202, 203, 204], "frequency": np.array([1, 2, 3, 4], dtype="int64")},
+                    ),
+                },
+                "reserved BTYD",
+                id="reserved-column-collision",
+            ),
+        ],
+    )
+    def test_invalid_attributes_or_one_hot_config_raises(self, kwargs, match):
+        """A malformed customer_attributes / one_hot_col config is rejected with a clear ValueError."""
+        with pytest.raises(ValueError, match=match):
+            self._summary(**kwargs)
+
+
+class TestCLVStatsOneHotNull:
+    """NULL handling for one_hot_col: genuine NULLs are the dropped reference level."""
+
+    def test_literal_null_string_coexists_with_genuine_nulls(self):
+        """A literal "null" string is an ordinary value dummy; the genuine NULL is the dropped reference."""
+        transactions = pd.DataFrame(
+            {
+                cols.customer_id: [301, 302, 303, 304],
+                cols.transaction_date: pd.to_datetime(["2023-01-01", "2023-01-02", "2023-01-03", "2023-01-04"]),
+                cols.unit_spend: [10.0, 20.0, 30.0, 40.0],
+            },
+        )
+        attributes = pd.DataFrame(
+            {cols.customer_id: [301, 302, 303, 304], "signup_channel": ["null", "web", None, "app"]},
+        )
+        result = CLVStats(
+            transactions,
+            period="day",
+            customer_attributes=attributes,
+            one_hot_col="signup_channel",
+        ).df.set_index(cols.customer_id)
+        # Every real value emits a dummy (including the literal "null" string); the genuine NULL (303)
+        # is the dropped reference, so it has no column of its own and is 0 across all dummies.
+        dummy_cols = sorted(c for c in result.columns if c.startswith("signup_channel_"))
+        assert dummy_cols == ["signup_channel_app", "signup_channel_null", "signup_channel_web"]
+        expected = pd.DataFrame(
+            {
+                "signup_channel_app": np.array([0, 0, 0, 1], dtype="int8"),
+                "signup_channel_null": np.array([1, 0, 0, 0], dtype="int8"),  # literal "null" string, 301
+                "signup_channel_web": np.array([0, 1, 0, 0], dtype="int8"),
+            },
+            index=pd.Index([301, 302, 303, 304], name=cols.customer_id),
+        )
+        assert_frame_equal(result[dummy_cols].sort_index(), expected)
+
+
+class TestCLVStatsCustomerIdColumn:
+    """The output id column is always the pymc-marketing literal "customer_id", not the option name."""
+
+    @staticmethod
+    def _txns(id_col: str) -> pd.DataFrame:
+        """Transactions whose customer key lives in ``id_col`` (the configured customer_id column)."""
+        return pd.DataFrame(
+            {
+                id_col: [701, 701, 702, 703],
+                cols.transaction_date: pd.to_datetime(["2023-01-01", "2023-01-08", "2023-01-01", "2023-01-02"]),
+                cols.unit_spend: [100.0, 50.0, 200.0, 40.0],
+            },
+        )
+
+    def test_overridden_customer_id_option_still_emits_literal_customer_id(self):
+        """Input keyed on a remapped "shopper_id" still yields the literal "customer_id" output id."""
+        with option_context("column.customer_id", "shopper_id"):
+            result = CLVStats(self._txns("shopper_id"), period="day").df
+        assert list(result.columns) == BASE_BTYD_COLS  # id is "customer_id", not the "shopper_id" option
+        assert "shopper_id" not in result.columns
+        # The renamed column carries the real customer keys, not an emptied/mangled column.
+        assert sorted(result["customer_id"].tolist()) == [701, 702, 703]
+
+    def test_overridden_option_attribute_named_customer_id_raises(self):
+        """Under a remapped option, a customer_attributes column literally named "customer_id" collides."""
+        with option_context("column.customer_id", "shopper_id"):
+            attributes = pd.DataFrame(
+                {"shopper_id": [701, 702, 703], "customer_id": np.array([1, 2, 3], dtype="int64")},
+            )
+            with pytest.raises(ValueError, match="reserved BTYD"):
+                CLVStats(self._txns("shopper_id"), period="day", customer_attributes=attributes)

--- a/tests/experimental/test_clv.py
+++ b/tests/experimental/test_clv.py
@@ -293,6 +293,25 @@ class TestCLVStatsCorrelationWarning:
             assert not any("correlated" in str(w.message) for w in caught)
             assert len(result) == data[cols.customer_id].nunique()  # all four are repeat buyers, none dropped
 
+    def test_repeat_buyers_all_one_time_buyers_is_empty_without_warning(self):
+        """When every customer is a one-time buyer, repeat_buyers is empty and no correlation check fires.
+
+        The correlation guard runs on an empty frame (min/max are NaN); it must not raise a spurious warning.
+        """
+        data = pd.DataFrame(
+            {
+                cols.customer_id: [101, 102, 103],
+                cols.transaction_date: pd.to_datetime(["2023-01-01", "2023-01-02", "2023-01-03"]),
+                cols.unit_spend: [100.0, 200.0, 300.0],
+            },
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = CLVStats(data, period="day").repeat_buyers
+        assert not any("correlated" in str(w.message) for w in caught)
+        assert len(result) == 0
+        assert list(result.columns) == BASE_BTYD_COLS
+
 
 class TestCLVStatsPymcTimeUnit:
     """CLVStats exposes the pymc-marketing time_unit matching its period."""
@@ -495,10 +514,12 @@ class TestCLVStatsCustomerAttributes:
         )
         # Every customer shares one region, no NULLs: the sole level is the dropped reference, so no dummy remains.
         attributes = pd.DataFrame({cols.customer_id: [201, 202, 203], "region": ["north", "north", "north"]})
-        with pytest.warns(UserWarning, match="zero dummy columns"):
+        with pytest.warns(UserWarning, match="zero dummy columns") as record:
             clv = CLVStats(transactions, period="day", customer_attributes=attributes, one_hot_col="region")
         assert clv.covariate_cols == []
         assert "region" not in clv.df.columns
+        # The warning is attributed to the caller's CLVStats(...) frame, not the internal encode helper.
+        assert record[0].filename.endswith("test_clv.py")
 
     @pytest.mark.parametrize(
         ("kwargs", "expected"),

--- a/tests/experimental/test_clv.py
+++ b/tests/experimental/test_clv.py
@@ -1,0 +1,122 @@
+"""Tests for openretailscience.experimental.clv."""
+
+import datetime
+
+import ibis
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from openretailscience.experimental.clv import CLVStats
+from openretailscience.options import ColumnHelper
+
+cols = ColumnHelper()
+
+
+def _transactions() -> pd.DataFrame:
+    """Realistic multi-customer transaction data with a known BTYD summary.
+
+    - Customer 101: three purchase days (two repeats), one basket per day.
+    - Customer 102: a single purchase (one-time buyer -> frequency 0).
+    - Customer 103: two purchase days, the first day split across two baskets
+      (same-day collapse) so the first-day spend is excluded from monetary_value.
+    """
+    return pd.DataFrame(
+        {
+            cols.customer_id: [101, 101, 101, 102, 103, 103, 103],
+            cols.transaction_date: pd.to_datetime(
+                [
+                    "2023-01-01",
+                    "2023-01-08",
+                    "2023-01-15",
+                    "2023-01-01",
+                    "2023-01-10",
+                    "2023-01-10",
+                    "2023-01-24",
+                ],
+            ),
+            cols.unit_spend: [100.0, 50.0, 70.0, 200.0, 30.0, 20.0, 80.0],
+        },
+    )
+
+
+class TestCLVStats:
+    """Tests for the CLVStats BTYD-summary adapter."""
+
+    @pytest.mark.parametrize("input_type", ["pandas", "ibis"])
+    @pytest.mark.parametrize(
+        ("period", "observation_period_end", "recency", "expected_t"),
+        [
+            # Weekly: recency/T are fractional weeks (elapsed days / 7). End given as an ISO string.
+            pytest.param("week", "2023-01-29", [14 / 7, 0.0, 14 / 7], [28 / 7, 28 / 7, 19 / 7], id="weekly"),
+            # Daily: recency/T are whole days. End given as a datetime.date object.
+            pytest.param("day", datetime.date(2023, 1, 29), [14.0, 0.0, 14.0], [28.0, 28.0, 19.0], id="daily"),
+            # Default end resolves to the global latest transaction, 2023-01-24 (101/102 age 23, 103 age 14).
+            pytest.param("day", None, [14.0, 0.0, 14.0], [23.0, 23.0, 14.0], id="daily-default-obs-end"),
+        ],
+    )
+    def test_summary_matches_hand_computation(self, input_type, period, observation_period_end, recency, expected_t):
+        """frequency/recency/T/monetary_value match a hand-computed summary across periods and observation ends."""
+        data = self._as_input(_transactions(), input_type)
+
+        result = (
+            CLVStats(data, period=period, observation_period_end=observation_period_end)
+            .df.sort_values(cols.customer_id)
+            .reset_index(drop=True)
+        )
+
+        expected = pd.DataFrame(
+            {
+                cols.customer_id: [101, 102, 103],
+                "frequency": np.array([2, 0, 1], dtype="int64"),
+                "recency": recency,
+                "T": expected_t,
+                "monetary_value": [60.0, np.nan, 80.0],
+            },
+        )
+        assert_frame_equal(result, expected)
+
+    def test_missing_column_raises(self):
+        """A dataset without unit_spend raises ValueError."""
+        data = _transactions().drop(columns=[cols.unit_spend])
+        with pytest.raises(ValueError, match="missing required columns"):
+            CLVStats(data)
+
+    def test_non_temporal_transaction_date_raises(self):
+        """A string transaction_date column is rejected (day math needs a temporal type)."""
+        data = _transactions()
+        data[cols.transaction_date] = data[cols.transaction_date].astype(str)
+        with pytest.raises(TypeError, match="date or datetime"):
+            CLVStats(data)
+
+    @pytest.mark.parametrize("bad_period", ["month", "fortnight", "W"])
+    def test_invalid_period_raises(self, bad_period):
+        """Only the canonical 'day'/'week' period values are accepted."""
+        with pytest.raises(ValueError, match="period"):
+            CLVStats(_transactions(), period=bad_period)
+
+    def test_observation_period_end_before_last_purchase_raises(self):
+        """An observation_period_end earlier than a customer's last purchase is rejected."""
+        with pytest.raises(ValueError, match="observation_period_end"):
+            CLVStats(_transactions(), observation_period_end="2023-01-10")
+
+    def test_observation_period_end_equal_to_latest_is_allowed(self):
+        """An observation_period_end exactly on the latest transaction is accepted (guard is strict <)."""
+        # 2023-01-24 is the global latest transaction; an explicit end there must match the default.
+        explicit = CLVStats(_transactions(), period="day", observation_period_end="2023-01-24").df
+        default = CLVStats(_transactions(), period="day").df
+        assert_frame_equal(
+            explicit.sort_values(cols.customer_id).reset_index(drop=True),
+            default.sort_values(cols.customer_id).reset_index(drop=True),
+        )
+
+    def test_observation_period_end_invalid_type_raises(self):
+        """A non-date observation_period_end (e.g. an int) is rejected with TypeError."""
+        with pytest.raises(TypeError, match="observation_period_end"):
+            CLVStats(_transactions(), observation_period_end=20230129)
+
+    @staticmethod
+    def _as_input(pdf: pd.DataFrame, input_type: str) -> pd.DataFrame | ibis.Table:
+        """Return the frame as a pandas DataFrame or an Ibis memtable."""
+        return ibis.memtable(pdf) if input_type == "ibis" else pdf

--- a/tests/integration/test_clv_stats.py
+++ b/tests/integration/test_clv_stats.py
@@ -1,0 +1,57 @@
+"""Unified integration tests for CLVStats across multiple database backends.
+
+These exercise the date arithmetic in CLVStats (day-granularity ``delta``, ``cast('date')``
+and same-day collapse) on real backends, since date/time handling is where portable SQL
+most often diverges between engines (Oracle, SQL Server, BigQuery, Snowflake, PySpark).
+"""
+
+import pandas as pd
+
+from openretailscience.experimental.clv import CLVStats
+from openretailscience.options import ColumnHelper
+
+cols = ColumnHelper()
+
+_SUBSET_CUSTOMERS = 25
+
+
+def test_clv_stats_integration(transactions_table):
+    """CLVStats produces a correct BTYD summary on each parameterized backend.
+
+    The seeded ``transaction_date`` is a string, so it is cast to a date first. The summary
+    is checked against an independent distinct-purchase-days query and the BTYD invariants
+    that would break if the date delta ran wrong on a given backend.
+
+    Args:
+        transactions_table: Parameterized fixture providing the transactions table on each
+            configured database backend.
+    """
+    table = transactions_table.mutate(**{cols.transaction_date: transactions_table[cols.transaction_date].cast("date")})
+
+    # Restrict to a handful of customers so every customer's history stays complete (a plain
+    # row limit could split a customer) while keeping the cross-backend run cheap.
+    subset_ids = table.select(cols.customer_id).distinct().order_by(cols.customer_id).limit(_SUBSET_CUSTOMERS)
+    subset = table.filter(table[cols.customer_id].isin(subset_ids[cols.customer_id]))
+
+    result = CLVStats(subset, period="week").df.set_index(cols.customer_id).sort_index()
+
+    # Independent expected frequency: distinct purchase days per customer minus the birth day.
+    expected_frequency = (
+        (
+            subset.group_by(cols.customer_id)
+            .aggregate(purchase_days=subset[cols.transaction_date].nunique())
+            .execute()
+            .set_index(cols.customer_id)["purchase_days"]
+            - 1
+        )
+        .astype("int64")
+        .sort_index()
+    )
+
+    assert len(result) == _SUBSET_CUSTOMERS
+    pd.testing.assert_series_equal(result["frequency"], expected_frequency, check_names=False)
+    # Age reaches at least to the last purchase, and recency is a real elapsed time.
+    assert (result["T"] >= result["recency"]).all()
+    assert (result["recency"] >= 0).all()
+    # monetary_value is defined exactly for repeat buyers.
+    assert (result["monetary_value"].isna() == (result["frequency"] == 0)).all()

--- a/tests/integration/test_clv_stats.py
+++ b/tests/integration/test_clv_stats.py
@@ -5,14 +5,32 @@ and same-day collapse) on real backends, since date/time handling is where porta
 most often diverges between engines (Oracle, SQL Server, BigQuery, Snowflake, PySpark).
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pandas as pd
 
 from openretailscience.experimental.clv import CLVStats
 from openretailscience.options import ColumnHelper
 
+if TYPE_CHECKING:
+    from ibis.expr.types import Table
+
 cols = ColumnHelper()
 
 _SUBSET_CUSTOMERS = 25
+
+
+def _subset(transactions_table: Table) -> Table:
+    """Cast transaction_date to a date and restrict to a handful of complete customer histories.
+
+    A plain row limit could split a customer mid-history, so filter on a distinct-customer subset to
+    keep each selected customer whole while keeping the cross-backend run cheap.
+    """
+    table = transactions_table.mutate(**{cols.transaction_date: transactions_table[cols.transaction_date].cast("date")})
+    subset_ids = table.select(cols.customer_id).distinct().order_by(cols.customer_id).limit(_SUBSET_CUSTOMERS)
+    return table.filter(table[cols.customer_id].isin(subset_ids[cols.customer_id]))
 
 
 def test_clv_stats_integration(transactions_table):
@@ -26,12 +44,7 @@ def test_clv_stats_integration(transactions_table):
         transactions_table: Parameterized fixture providing the transactions table on each
             configured database backend.
     """
-    table = transactions_table.mutate(**{cols.transaction_date: transactions_table[cols.transaction_date].cast("date")})
-
-    # Restrict to a handful of customers so every customer's history stays complete (a plain
-    # row limit could split a customer) while keeping the cross-backend run cheap.
-    subset_ids = table.select(cols.customer_id).distinct().order_by(cols.customer_id).limit(_SUBSET_CUSTOMERS)
-    subset = table.filter(table[cols.customer_id].isin(subset_ids[cols.customer_id]))
+    subset = _subset(transactions_table)
 
     result = CLVStats(subset, period="week").df.set_index(cols.customer_id).sort_index()
 
@@ -50,8 +63,71 @@ def test_clv_stats_integration(transactions_table):
 
     assert len(result) == _SUBSET_CUSTOMERS
     pd.testing.assert_series_equal(result["frequency"], expected_frequency, check_names=False)
-    # Age reaches at least to the last purchase, and recency is a real elapsed time.
-    assert (result["T"] >= result["recency"]).all()
-    assert (result["recency"] >= 0).all()
+
+    # Independent recency/T in weeks. A wrong-unit, wrong-anchor, or wrong-sign date delta on a backend
+    # would diverge from these exact expected values.
+    span = (
+        subset.group_by(cols.customer_id)
+        .aggregate(first=subset[cols.transaction_date].min(), last=subset[cols.transaction_date].max())
+        .execute()
+        .set_index(cols.customer_id)
+        .sort_index()
+    )
+    first_day = pd.to_datetime(span["first"])
+    observation_end = pd.Timestamp(subset[cols.transaction_date].max().execute())
+    expected_recency = ((pd.to_datetime(span["last"]) - first_day).dt.days / 7).astype("float64")
+    expected_t = ((observation_end - first_day).dt.days / 7).astype("float64")
+    pd.testing.assert_series_equal(result["recency"], expected_recency, check_names=False)
+    pd.testing.assert_series_equal(result["T"], expected_t, check_names=False)
     # monetary_value is defined exactly for repeat buyers.
     assert (result["monetary_value"].isna() == (result["frequency"] == 0)).all()
+
+
+def test_clv_stats_customer_attributes_and_one_hot_integration(transactions_table):
+    """A customer_attributes join and one_hot_col produce correct per-customer covariates on each backend.
+
+    one_hot emits a ``CASE WHEN`` per dummy; a boolean-as-value form (``COALESCE(col = v, ...)``) is
+    invalid SQL on Oracle and SQL Server, so this guards that the encoding stays portable. The attributes
+    table is built on the same backend so the left join runs in-database.
+
+    Args:
+        transactions_table: Parameterized fixture providing the transactions table on each backend.
+    """
+    subset = _subset(transactions_table)
+
+    # Build the per-customer attributes on the same backend (one row per customer): a numeric covariate
+    # joined as-is, plus a categorical reduced to its per-customer max for one-hot encoding.
+    customer_attributes = subset.group_by(cols.customer_id).aggregate(
+        distinct_stores=subset[cols.store_id].nunique(),
+        store_id=subset[cols.store_id].max(),
+    )
+    clv = CLVStats(subset, period="week", customer_attributes=customer_attributes, one_hot_col=cols.store_id)
+    result = clv.df.set_index(cols.customer_id).sort_index()
+
+    # customer_attributes join: distinct stores per customer, computed independently on the backend.
+    expected_stores = (
+        subset.group_by(cols.customer_id)
+        .aggregate(n=subset[cols.store_id].nunique())
+        .execute()
+        .set_index(cols.customer_id)["n"]
+        .astype("int64")
+        .sort_index()
+    )
+    pd.testing.assert_series_equal(result["distinct_stores"], expected_stores, check_names=False)
+
+    # one_hot: the store_id attribute (its per-customer max) is encoded. Each store_id_<v> dummy must
+    # equal (max_store == v) as 0/1 int8, with exactly one level dropped as the reference.
+    max_store = (
+        subset.group_by(cols.customer_id)
+        .aggregate(m=subset[cols.store_id].max())
+        .execute()
+        .set_index(cols.customer_id)["m"]
+        .sort_index()
+    )
+    store_dummies = [c for c in clv.covariate_cols if c.startswith(f"{cols.store_id}_")]
+    assert len(store_dummies) == max_store.nunique() - 1  # one reference level dropped
+    for dummy in store_dummies:
+        value = int(dummy[len(cols.store_id) + 1 :])
+        pd.testing.assert_series_equal(result[dummy], (max_store == value).astype("int8"), check_names=False)
+    # A row flags at most one dummy (its max store); reference-level customers flag none.
+    assert (result[store_dummies].sum(axis=1) <= 1).all()

--- a/tests/segmentation/test_segstats.py
+++ b/tests/segmentation/test_segstats.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 from sqlglot import exp
 
+from openretailscience.core.validation import ensure_valid_extra_aggs
 from openretailscience.options import ColumnHelper, get_option, option_context
 from openretailscience.segmentation.segstats import SegTransactionStats, _resolve_group_key, cube, rollup
 
@@ -452,8 +453,12 @@ class TestSegTransactionStats:
             total_product_count,
         ]
 
-    def test_extra_aggs_with_invalid_column(self):
-        """Test that an error is raised when an invalid column is specified in extra_aggs."""
+    def test_extra_aggs_invalid_spec_rejected_by_constructor(self):
+        """The constructor routes extra_aggs through ensure_valid_extra_aggs.
+
+        Exhaustive spec/column/function cases live in
+        TestGroupingSetsRollupMode.test_validate_extra_aggs_rejects_invalid_spec; this only pins the wiring.
+        """
         df = pd.DataFrame(
             {
                 cols.customer_id: [1, 2, 3],
@@ -463,26 +468,8 @@ class TestSegTransactionStats:
             },
         )
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError, match="does not exist in the data"):
             SegTransactionStats(df, "segment_name", extra_aggs={"invalid_agg": ("nonexistent_column", "nunique")})
-
-        assert "does not exist in the data" in str(excinfo.value)
-
-    def test_extra_aggs_with_invalid_function(self):
-        """Test that an error is raised when an invalid function is specified in extra_aggs."""
-        df = pd.DataFrame(
-            {
-                cols.customer_id: [1, 2, 3],
-                cols.unit_spend: [100.0, 200.0, 300.0],
-                cols.transaction_id: [101, 102, 103],
-                "segment_name": ["Premium", "Standard", "Premium"],
-            },
-        )
-
-        with pytest.raises(ValueError) as excinfo:
-            SegTransactionStats(df, "segment_name", extra_aggs={"invalid_agg": (cols.customer_id, "invalid_function")})
-
-        assert "not available for column" in str(excinfo.value)
 
     def test_with_custom_column_names(self):
         """Test SegTransactionStats with custom column names."""
@@ -742,6 +729,7 @@ class TestUnknownCustomerTracking:
         [
             (-1, [1, 2, -1, 3]),  # int value
             ("UNKNOWN", ["C1", "C2", "UNKNOWN", "C3"]),  # string value
+            (ibis.literal(-1), [1, 2, -1, 3]),  # ibis literal expression
         ],
     )
     def test_unknown_customer_input_types(self, unknown_value, customer_ids):
@@ -756,40 +744,6 @@ class TestUnknownCustomerTracking:
         )
 
         seg_stats = SegTransactionStats(df, "segment_name", unknown_customer_value=unknown_value)
-        result_df = seg_stats.df.sort_values("segment_name").reset_index(drop=True)
-
-        expected_output = pd.DataFrame(
-            {
-                "segment_name": ["Premium", "Standard", "Total"],
-                cols.agg.unit_spend: [300.0, 300.0, 600.0],
-                cols.agg.transaction_id: [2, 1, 3],
-                cols.agg.customer_id: [2, 1, 3],
-                cols.calc.spend_per_cust: [150.0, 300.0, 200.0],
-                cols.calc.spend_per_trans: [150.0, 300.0, 200.0],
-                cols.calc.trans_per_cust: [1.0, 1.0, 1.0],
-                cols.agg.unit_spend_unknown: [150.0, 0.0, 150.0],
-                cols.agg.transaction_id_unknown: [1, 0, 1],
-                cols.calc.spend_per_trans_unknown: [150.0, np.nan, 150.0],
-                cols.agg.unit_spend_total: [450.0, 300.0, 750.0],
-                cols.agg.transaction_id_total: [3, 1, 4],
-                cols.calc.spend_per_trans_total: [150.0, 300.0, 187.5],
-            },
-        )
-
-        pd.testing.assert_frame_equal(result_df, expected_output)
-
-    def test_unknown_customer_with_ibis_literal(self):
-        """Test unknown customer tracking with ibis literal."""
-        df = pd.DataFrame(
-            {
-                cols.customer_id: [1, 2, -1, 3],
-                cols.unit_spend: [100.0, 200.0, 150.0, 300.0],
-                cols.transaction_id: [101, 102, 103, 104],
-                "segment_name": ["Premium", "Premium", "Premium", "Standard"],
-            },
-        )
-
-        seg_stats = SegTransactionStats(df, "segment_name", unknown_customer_value=ibis.literal(-1))
         result_df = seg_stats.df.sort_values("segment_name").reset_index(drop=True)
 
         expected_output = pd.DataFrame(
@@ -1247,75 +1201,50 @@ class TestGroupingSetsRollupMode:
         # Compare using pandas assert_frame_equal
         pd.testing.assert_frame_equal(result_subset, expected_sorted)
 
-    def test_validate_extra_aggs_invalid_column(self):
-        """Test that _validate_extra_aggs raises ValueError for invalid column name."""
-        data = pd.DataFrame({"region": ["North", "South"], cols.unit_spend: [100, 200]})
-        table = ibis.memtable(data)
-        extra_aggs = {"total_sales": ("invalid_column", "sum")}
+    @pytest.mark.parametrize(
+        ("extra_aggs", "match"),
+        [
+            ({"total_sales": ("invalid_column", "sum")}, "Column 'invalid_column' specified in extra_aggs"),
+            ({"total_sales": (cols.unit_spend, "invalid_func")}, "Aggregation function 'invalid_func' not available"),
+            # "isnull" is a real ibis method but a column->column op, not a scalar reduction: it passes the
+            # old hasattr check yet must be rejected by the (source_col, agg_func) -> Scalar validation.
+            ({"total_sales": (cols.unit_spend, "isnull")}, "Aggregation function 'isnull' not available"),
+            # A spec that is not a 2-tuple is rejected before the column/function checks.
+            ({"total_sales": (cols.unit_spend,)}, r"must be a \(source_col, agg_func\) tuple"),
+        ],
+    )
+    def test_validate_extra_aggs_rejects_invalid_spec(self, extra_aggs, match):
+        """extra_aggs validation raises ValueError for a bad spec shape, unknown column, or non-reduction func."""
+        table = ibis.memtable(pd.DataFrame({"region": ["North", "South"], cols.unit_spend: [100, 200]}))
+        with pytest.raises(ValueError, match=match):
+            ensure_valid_extra_aggs(table, extra_aggs)
 
-        with pytest.raises(ValueError, match="Column 'invalid_column' specified in extra_aggs does not exist"):
-            SegTransactionStats._validate_extra_aggs(table, extra_aggs)
-
-    def test_validate_extra_aggs_invalid_function(self):
-        """Test that _validate_extra_aggs raises ValueError for invalid aggregation function."""
-        data = pd.DataFrame({"region": ["North", "South"], cols.unit_spend: [100, 200]})
-        table = ibis.memtable(data)
-        extra_aggs = {"total_sales": (cols.unit_spend, "invalid_func")}
-
-        with pytest.raises(ValueError, match="Aggregation function 'invalid_func' not available"):
-            SegTransactionStats._validate_extra_aggs(table, extra_aggs)
-
-    def test_generate_grouping_sets_cube_two_columns(self):
-        """Test CUBE mode generates all 2^n combinations for two columns."""
-        result = SegTransactionStats._generate_grouping_sets(
-            segment_col=["region", "store"],
-            grouping_sets="cube",
-        )
-        expected = [
-            ("region", "store"),  # full detail
-            ("region",),  # region only
-            ("store",),  # store only
-            (),  # grand total
-        ]
-        expected_count_two_columns = 4  # 2^2 = 4
-        # Convert to sets for order-independent comparison
+    @pytest.mark.parametrize(
+        ("segment_col", "expected"),
+        [
+            (["region"], [("region",), ()]),  # 2^1 = 2
+            (["region", "store"], [("region", "store"), ("region",), ("store",), ()]),  # 2^2 = 4
+            (
+                ["region", "store", "product"],  # 2^3 = 8
+                [
+                    ("region", "store", "product"),
+                    ("region", "store"),
+                    ("region", "product"),
+                    ("region",),
+                    ("store", "product"),
+                    ("store",),
+                    ("product",),
+                    (),
+                ],
+            ),
+        ],
+        ids=["single-column", "two-columns", "three-columns"],
+    )
+    def test_generate_grouping_sets_cube_emits_all_subsets(self, segment_col, expected):
+        """CUBE mode generates all 2^n subsets of the segment columns."""
+        result = SegTransactionStats._generate_grouping_sets(segment_col=segment_col, grouping_sets="cube")
         assert set(result) == set(expected)
-        assert len(result) == expected_count_two_columns
-
-    def test_generate_grouping_sets_cube_three_columns(self):
-        """Test CUBE mode generates all 2^n combinations for three columns."""
-        result = SegTransactionStats._generate_grouping_sets(
-            segment_col=["region", "store", "product"],
-            grouping_sets="cube",
-        )
-        expected = [
-            ("region", "store", "product"),  # full detail
-            ("region", "store"),  # region + store
-            ("region", "product"),  # region + product
-            ("region",),  # region only
-            ("store", "product"),  # store + product
-            ("store",),  # store only
-            ("product",),  # product only
-            (),  # grand total
-        ]
-        expected_count_three_columns = 8  # 2^3 = 8
-        # Convert to sets for order-independent comparison
-        assert set(result) == set(expected)
-        assert len(result) == expected_count_three_columns
-
-    def test_generate_grouping_sets_cube_single_column(self):
-        """Test CUBE mode with single segment column."""
-        result = SegTransactionStats._generate_grouping_sets(
-            segment_col=["region"],
-            grouping_sets="cube",
-        )
-        expected = [
-            ("region",),  # detail
-            (),  # grand total
-        ]
-        expected_count_single_column = 2  # 2^1 = 2
-        assert set(result) == set(expected)
-        assert len(result) == expected_count_single_column
+        assert len(result) == len(expected)  # all subsets distinct, so count == 2^n
 
     def test_cube_mode_integration(self):
         """Test CUBE mode produces correct aggregations across all dimension combinations."""


### PR DESCRIPTION
## Summary

Adds `openretailscience.experimental.clv.CLVStats`, an adapter that turns transaction data into the
per-customer "buy-till-you-die" (BTYD) summary consumed by [pymc-marketing](https://www.pymc-marketing.io/)'s
`ParetoNBDModel` (churn + purchase frequency) and `GammaGammaModel` (per-transaction spend). It prepares the
model input; it does not fit the models and does not depend on pymc-marketing.

The output uses pymc-marketing's required literal column names (`frequency`/`recency`/`T`/`monetary_value`),
so the frame can be passed straight to the models.

## What's included

**`CLVStats` (`openretailscience/experimental/clv.py`)**
- A purchase occasion is a distinct calendar day with **positive net spend**, so same-day baskets count once
  and returns-only days are excluded. Undated rows are dropped; a customer left with no occasion drops out.
- `recency`/`T` in `day`/`week`/`month` units (a month is a fixed 365.25/12-day unit); day-granularity date
  deltas for Oracle compatibility.
- `customer_attributes` left-join and `one_hot_col` → 0/1 `ParetoNBDModel` covariates (reference level dropped;
  high-cardinality and single-category columns warn).
- NULL-covariate rejection on `.df` access only (the lazy `.table` skips it); `pymc_time_unit` accessor for the
  finite-horizon `time_unit` footgun in `expected_customer_lifetime_value`.

**Shared validation (`openretailscience/core/validation.py`)**
- New `ensure_period` (alias/case-aware period resolution) and `ensure_valid_extra_aggs` (extracted from
  `SegTransactionStats`), now adopted by both `CohortAnalysis` and `SegTransactionStats`.

**Docs & agent skill**
- User docs (`docs/experimental/clv.md`), skill reference, and a runnable example script.

## Testing

- Unit tests for the summary math, occasions/returns handling, covariates/one-hot, and the shared validators;
  cross-backend integration tests for the date arithmetic and portable `CASE WHEN` one-hot.
- Overlapping tests consolidated (period alias resolution is owned by `TestEnsurePeriod`; consumer tests keep
  only delegation checks) and weak assertions strengthened to `assert_frame_equal` / pinned counts.
- Full suite green locally (1393 passed); pre-commit hooks (ruff, markdownlint, pytest, conventional-commit) pass.

## Notes

- Experimental: the API and import path under `openretailscience.experimental` may change without notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
