### PR TITLE
fix(skills): patch Path.symlink_to in copy-fallback tests for Python 3.10

### DIFF
--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -72,7 +72,7 @@ def _skill_import_statements() -> list[str]:
 
 
 def _raise_oserror(*_args: object, **_kwargs: object) -> None:
-    """Stand-in for os.symlink that reports symlinks are unsupported."""
+    """Raise OSError; a patched-call stand-in for a failing operation (unsupported symlink, cross-drive path)."""
     msg = "symlinks not supported"
     raise OSError(msg)
 
@@ -84,7 +84,7 @@ def _raise_value_error(*_args: object, **_kwargs: object) -> str:
 
 
 def _raise_not_implemented(*_args: object, **_kwargs: object) -> None:
-    """Stand-in for os.symlink on a platform without symlink support."""
+    """Raise NotImplementedError; a patched-call stand-in for an operation unsupported on the platform."""
     raise NotImplementedError
 
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -256,8 +256,10 @@ class TestCopyFallback:
     def test_copies_directory_when_symlink_unsupported(
         self, source_dir: Path, project_dir: Path, monkeypatch: pytest.MonkeyPatch, raiser: object
     ) -> None:
-        """When os.symlink raises OSError or NotImplementedError, the skill is copied instead."""
-        monkeypatch.setattr(os, "symlink", raiser)
+        """When creating the symlink raises OSError or NotImplementedError, the skill is copied instead."""
+        # Patch Path.symlink_to (what _try_symlink calls), not os.symlink: on Python 3.10 pathlib binds
+        # os.symlink at import time, so patching os.symlink would not reach the symlink call.
+        monkeypatch.setattr("pathlib.Path.symlink_to", raiser)
 
         install_skills()
 
@@ -277,7 +279,8 @@ class TestCopyFallback:
         own (byte-identical to the source) and report it up to date instead of
         skipping it as a name conflict.
         """
-        monkeypatch.setattr(os, "symlink", _raise_oserror)
+        # Patch the symlink call itself (see test_copies_directory_when_symlink_unsupported).
+        monkeypatch.setattr("pathlib.Path.symlink_to", _raise_oserror)
 
         install_skills()
         result = install_skills()


### PR DESCRIPTION
## Summary

Fixes the **Python 3.10** `Tests` matrix job on `main`, which has been red since
2026-07-11 (`docs(skill): trim verbose comments`). The failure is in the skills-installer
copy-fallback tests, not in any product code — it only reproduces on 3.10.

## Root cause

`TestCopyFallback` simulates "symlinks unsupported" by patching `os.symlink`, but the
installer's `_try_symlink` calls `Path.symlink_to(...)`:

- **Python 3.11+**: `Path.symlink_to` looks up `os.symlink` dynamically, so the patch is
  seen, `_try_symlink` raises → the installer falls back to copying → tests pass.
- **Python 3.10**: `Path.symlink_to` goes through `pathlib._NormalAccessor.symlink`, which
  is bound to the real `os.symlink` at import time. Patching `os.symlink` afterward never
  reaches the call, so a real symlink is created, the copy-fallback never triggers, and
  `assert not target.is_symlink()` fails.

## Fix

Patch `pathlib.Path.symlink_to` (the call the installer actually makes) instead of
`os.symlink`, in both `TestCopyFallback` tests. This exercises the copy-fallback path on
every supported Python version. The second test previously passed on 3.10 only by accident
(a symlink-mode rerun also reports "up to date"); it now genuinely tests the copy path.

## Verification

- `tests/test_skills.py` passes on Python 3.10 (86 passed) and 3.11 locally.
- Test-only change; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
