### PR TITLE
fix(ci): truncate commit message in Slack failure notification

### DIFF
--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -42,6 +42,13 @@ jobs:
           AUTHOR_NAME: ${{ github.event.workflow_run.head_commit.author.name }}
           COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
         run: |
+          # Slack caps a Block Kit section's text at 3000 characters and rejects the whole
+          # payload with HTTP 400 otherwise. Grouped dependabot commits blow past that, so
+          # trim the message well short of the limit to leave room for the surrounding markup.
+          message=${COMMIT_MESSAGE:0:2000}
+          if [ "$message" != "$COMMIT_MESSAGE" ]; then
+            message="$message"$'\n…(truncated)'
+          fi
           payload=$(jq -n \
             --arg repo "$REPO_FULL_NAME" \
             --arg repo_url "$REPO_URL" \
@@ -51,7 +58,7 @@ jobs:
             --arg sha "$HEAD_SHA" \
             --arg event "$EVENT_NAME" \
             --arg author "$AUTHOR_NAME" \
-            --arg message "$COMMIT_MESSAGE" \
+            --arg message "$message" \
             '{
               attachments: [{
                 color: "danger",

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -42,13 +42,6 @@ jobs:
           AUTHOR_NAME: ${{ github.event.workflow_run.head_commit.author.name }}
           COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
         run: |
-          # Slack caps a Block Kit section's text at 3000 characters and rejects the whole
-          # payload with HTTP 400 otherwise. Grouped dependabot commits blow past that, so
-          # trim the message well short of the limit to leave room for the surrounding markup.
-          message=${COMMIT_MESSAGE:0:2000}
-          if [ "$message" != "$COMMIT_MESSAGE" ]; then
-            message="$message"$'\n…(truncated)'
-          fi
           payload=$(jq -n \
             --arg repo "$REPO_FULL_NAME" \
             --arg repo_url "$REPO_URL" \
@@ -58,8 +51,13 @@ jobs:
             --arg sha "$HEAD_SHA" \
             --arg event "$EVENT_NAME" \
             --arg author "$AUTHOR_NAME" \
-            --arg message "$message" \
-            '{
+            --arg message "$COMMIT_MESSAGE" \
+            '# Slack caps a Block Kit section text at 3000 characters and rejects the whole
+             # payload with HTTP 400 otherwise; grouped dependabot commits blow past that.
+             # Slicing here rather than in bash keeps the cut on codepoint boundaries
+             # regardless of the runner locale.
+             ($message | if length > 2000 then .[0:2000] + "\n…(truncated)" else . end) as $commit_message
+             | {
               attachments: [{
                 color: "danger",
                 fallback: "Workflow failure notification",
@@ -86,7 +84,7 @@ jobs:
                   },
                   {
                     type: "section",
-                    text: {type: "mrkdwn", text: ("*Commit Message:*\n```" + $message + "```")}
+                    text: {type: "mrkdwn", text: ("*Commit Message:*\n```" + $commit_message + "```")}
                   },
                   {
                     type: "actions",

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -52,10 +52,8 @@ jobs:
             --arg event "$EVENT_NAME" \
             --arg author "$AUTHOR_NAME" \
             --arg message "$COMMIT_MESSAGE" \
-            '# Slack caps a Block Kit section text at 3000 characters and rejects the whole
-             # payload with HTTP 400 otherwise; grouped dependabot commits blow past that.
-             # Slicing here rather than in bash keeps the cut on codepoint boundaries
-             # regardless of the runner locale.
+            '# Slack 400s if a section text exceeds 3000 chars. Slice in jq, not bash:
+             # bash slices bytes under a C locale and can split a codepoint.
              ($message | if length > 2000 then .[0:2000] + "\n…(truncated)" else . end) as $commit_message
              | {
               attachments: [{

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ dependencies are used.
 
 - Follow Google Python Style Guide
 - Use Google-style docstrings with Args, Returns, and Raises sections
+- Comments, docstrings, and docs must be concise and load-bearing: say only what the reader cannot get from the
+  code. Cut restatements of the code, change history (it belongs in the commit message), and self-justification.
 - Import order: standard library → third-party → internal packages
 - Use explicit type annotations for all functions and parameters
 - Class names use CamelCase; functions, methods, variables use snake_case


### PR DESCRIPTION
## Problem

The `notify-failure` job fails with `curl: (22) The requested URL returned error: 400` whenever the head commit message is long — most recently on [run 30612586618](https://github.com/Data-Simply/openretailscience/actions/runs/30612586618), reporting a Security Audit failure on dependabot commit `ae2ae09`.

Slack caps a Block Kit section's `text` at **3000 characters** and rejects the whole payload with HTTP 400 when that is exceeded. `slack-notifications.yml` embeds the raw commit message in a section:

```jq
{type: "section",
 text: {type: "mrkdwn", text: ("*Commit Message:*\n```" + $message + "```")}}
```

Grouped dependabot commits carry a markdown table, a "Updates X from A to B" stanza with release/changelog/compare links per dependency, and the full `updated-dependencies:` YAML block. `ae2ae09`'s message is 3351 characters; with the 24 characters of surrounding markup the block is invalid, Slack returns 400, and `curl --fail` exits 22.

This is not a webhook credential problem — a bad or revoked URL returns 403/404, not 400. It recurs on every grouped dependabot commit that clears the cap.

## Change

Trim the message to 2000 characters before building the payload, appending a `…(truncated)` marker only when it was actually shortened. The 1000 characters of headroom cover the wrapper markup and any difference between bash's character count and Slack's.

The "View Commit" button in the same notification already links to the full message, so nothing is lost.

## Verification

Extracted the step's `run` script from the workflow with the curl stubbed out, and built the payload against real commit messages from this repo:

| commit | raw message | resulting section text | valid |
| --- | --- | --- | --- |
| `ae2ae09` (grouped dependabot bump) | 3351 chars | 2037 chars, ends `…(truncated)` | ✅ under 3000 |
| `c07fc29` (ordinary commit) | 812 chars | 834 chars, unmodified | ✅ under 3000 |

Both payloads parse as JSON. The workflow file still parses as YAML (`check-yaml`). The change touches no Python, so the pytest pre-commit hook's `files: ^openretailscience/` filter skips it.

## Out of scope

The upstream failure this run was reporting on — `OSV-Scanner (uv.lock)` in [Security Audit run 30612560210](https://github.com/Data-Simply/openretailscience/actions/runs/30612560210) — is a genuine dependency finding, with its SARIF uploaded to the Security tab. It is unrelated to this notifier bug and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MLmidpXyedhWYYE9PiJtY

---
_Generated by [Claude Code](https://claude.ai/code/session_013MLmidpXyedhWYYE9PiJtY)_