### PR TITLE
fix(skills): install Databricks skills into the user's workspace home

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ describe the public API — analyses, plots, options, and how to connect to data
 If you add, rename, or remove a public class, function, plot, or option, update
 the skill in the same PR. `tests/test_skills.py` guards this: it re-executes
 every import example and every bundled example script, and it requires the
-`references/*.md` files on disk and the links pointing at them to match exactly,
-so a new reference file must also be linked from the skill. Run
+reference files under `references/` and the links pointing at them to match
+exactly, so a new reference file must also be linked from the skill. Run
 `uv run pytest tests/test_skills.py` before pushing.
 
 ### Getting Help

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,10 @@ describe the public API — analyses, plots, options, and how to connect to data
 
 If you add, rename, or remove a public class, function, plot, or option, update
 the skill in the same PR. `tests/test_skills.py` guards this: it re-executes
-every import example in the skill and fails if one no longer resolves, and it
-checks that every referenced file exists. Run `uv run pytest tests/test_skills.py`
-before pushing.
+every import example and every bundled example script, and it requires the
+`references/*.md` files on disk and the links pointing at them to match exactly,
+so a new reference file must also be linked from the skill. Run
+`uv run pytest tests/test_skills.py` before pushing.
 
 ### Getting Help
 

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -69,13 +69,7 @@ which the workspace filesystem often reports asynchronously as an
 
 Your workspace username is detected from Spark's `current_user()`, which needs an
 active Spark session — every notebook has one, an init script or a bare Python
-job does not. Set `DATABRICKS_USER` for those, or to override a detected value:
-
-```python
-import os
-
-os.environ["DATABRICKS_USER"] = "you@company.com"
-```
+job does not. Export `DATABRICKS_USER` for those, or to override a detected value.
 
 Run it from a notebook:
 

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -69,16 +69,18 @@ asynchronously, as an `AsyncFlushFailedException` pointing at a flush rather tha
 at the write that was rejected. Install without `global_mode` unless you intend
 to publish the skill to everyone.
 
-Your username comes from the `DATABRICKS_USER` environment variable, falling back
-to the notebook's working directory when it sits under `/Workspace/Users/`. When
-neither resolves, `install_skills()` raises rather than writing somewhere you may
-not own — set `DATABRICKS_USER` to your workspace username and re-run:
+Your workspace username is detected for you, from Spark's `current_user()`. On
+compute with no Spark session, set the `DATABRICKS_USER` environment variable
+instead — it also overrides the detected value:
 
 ```python
 import os
 
 os.environ["DATABRICKS_USER"] = "you@company.com"
 ```
+
+When neither resolves, `install_skills()` raises rather than writing somewhere you
+may not own.
 
 Run it from a notebook, or from a cluster init script so it re-applies on every
 start:

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -57,16 +57,28 @@ automatically. A pip-installed package lives on the cluster's ephemeral storage,
 which is wiped on restart, and Databricks Genie reads skills from a persistent
 workspace location that cannot symlink back into that storage. So on Databricks
 the installer **copies** the skill into the Genie skills directory instead of
-linking it:
+linking it.
 
-Both modes install to your own workspace home,
-`/Workspace/Users/<you>/.assistant/skills/` — the workspace-wide
-`/Workspace/.assistant/skills/` directory is never written to, because it
-requires workspace admin rights. Your username comes from the `DATABRICKS_USER`
-environment variable, falling back to the notebook's working directory under
-`/Workspace/Users/`. When neither resolves, `install_skills()` raises rather than
-writing somewhere you may not own; set `DATABRICKS_USER` to your workspace
-username and re-run.
+- Default → `/Workspace/Users/<you>/.assistant/skills/`, your own workspace home.
+- Global mode → `/Workspace/.assistant/skills/`, shared with the whole workspace.
+
+Only workspace admins may write to the workspace-wide directory, so
+`install_skills(global_mode=True)` without admin rights fails with a
+`PERMISSION_DENIED` (403) from the workspace filesystem — often surfaced
+asynchronously, as an `AsyncFlushFailedException` pointing at a flush rather than
+at the write that was rejected. Install without `global_mode` unless you intend
+to publish the skill to everyone.
+
+Your username comes from the `DATABRICKS_USER` environment variable, falling back
+to the notebook's working directory when it sits under `/Workspace/Users/`. When
+neither resolves, `install_skills()` raises rather than writing somewhere you may
+not own — set `DATABRICKS_USER` to your workspace username and re-run:
+
+```python
+import os
+
+os.environ["DATABRICKS_USER"] = "you@company.com"
+```
 
 Run it from a notebook, or from a cluster init script so it re-applies on every
 start:

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -59,9 +59,14 @@ workspace location that cannot symlink back into that storage. So on Databricks
 the installer **copies** the skill into the Genie skills directory instead of
 linking it:
 
-- Project mode → `/Workspace/.assistant/skills/`
-- Global mode → `/Workspace/Users/<you>/.assistant/skills/` (falling back to the
-  shared workspace directory when the user cannot be determined)
+Both modes install to your own workspace home,
+`/Workspace/Users/<you>/.assistant/skills/` — the workspace-wide
+`/Workspace/.assistant/skills/` directory is never written to, because it
+requires workspace admin rights. Your username comes from the `DATABRICKS_USER`
+environment variable, falling back to the notebook's working directory under
+`/Workspace/Users/`. When neither resolves, `install_skills()` raises rather than
+writing somewhere you may not own; set `DATABRICKS_USER` to your workspace
+username and re-run.
 
 Run it from a notebook, or from a cluster init script so it re-applies on every
 start:
@@ -77,7 +82,7 @@ upgrade the package. Re-run `install_skills()` after upgrading OpenRetailScience
 (a cluster init script is the easiest way to keep it current).
 
 !!! warning "Managed directory"
-    The workspace `.assistant/skills/` directory is treated as installer-managed:
+    Your workspace `.assistant/skills/` directory is treated as installer-managed:
     a folder there whose name matches a bundled skill is refreshed on every run.
     If you hand-author your own skill under that directory, give it a different
     name so `install_skills()` does not overwrite it.

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -62,25 +62,20 @@ linking it.
 - Default → `/Workspace/Users/<you>/.assistant/skills/`, your own workspace home.
 - Global mode → `/Workspace/.assistant/skills/`, shared with the whole workspace.
 
-Only workspace admins may write to the workspace-wide directory, so
-`install_skills(global_mode=True)` without admin rights fails with a
-`PERMISSION_DENIED` (403) from the workspace filesystem — often surfaced
-asynchronously, as an `AsyncFlushFailedException` pointing at a flush rather than
-at the write that was rejected. Install without `global_mode` unless you intend
-to publish the skill to everyone.
+Only workspace admins may write to the workspace-wide directory. Without those
+rights `install_skills(global_mode=True)` fails with `PERMISSION_DENIED` (403),
+which the workspace filesystem often reports asynchronously as an
+`AsyncFlushFailedException` naming a flush rather than the rejected write.
 
-Your workspace username is detected for you, from Spark's `current_user()`. On
-compute with no Spark session, set the `DATABRICKS_USER` environment variable
-instead — it also overrides the detected value:
+Your workspace username is detected from Spark's `current_user()`. On compute with
+no Spark session, set `DATABRICKS_USER` instead; it also overrides the detected
+value:
 
 ```python
 import os
 
 os.environ["DATABRICKS_USER"] = "you@company.com"
 ```
-
-When neither resolves, `install_skills()` raises rather than writing somewhere you
-may not own.
 
 Run it from a notebook, or from a cluster init script so it re-applies on every
 start:

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -67,9 +67,9 @@ rights `install_skills(global_mode=True)` fails with `PERMISSION_DENIED` (403),
 which the workspace filesystem often reports asynchronously as an
 `AsyncFlushFailedException` naming a flush rather than the rejected write.
 
-Your workspace username is detected from Spark's `current_user()`. On compute with
-no Spark session, set `DATABRICKS_USER` instead; it also overrides the detected
-value:
+Your workspace username is detected from Spark's `current_user()`, which needs an
+active Spark session — every notebook has one, an init script or a bare Python
+job does not. Set `DATABRICKS_USER` for those, or to override a detected value:
 
 ```python
 import os
@@ -77,8 +77,7 @@ import os
 os.environ["DATABRICKS_USER"] = "you@company.com"
 ```
 
-Run it from a notebook, or from a cluster init script so it re-applies on every
-start:
+Run it from a notebook:
 
 ```python
 from openretailscience.skills import install_skills
@@ -87,8 +86,9 @@ install_skills()
 ```
 
 Because this is a copy rather than a link, it does **not** update itself when you
-upgrade the package. Re-run `install_skills()` after upgrading OpenRetailScience
-(a cluster init script is the easiest way to keep it current).
+upgrade the package: re-run `install_skills()` after upgrading OpenRetailScience.
+A cluster init script can do that on every start, as long as it exports
+`DATABRICKS_USER` — it runs before any Spark session exists.
 
 !!! warning "Managed directory"
     Your workspace `.assistant/skills/` directory is treated as installer-managed:

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -25,17 +25,18 @@ the installed package never drift apart:
   `.claude/skills/using-openretailscience/` when Claude Code is detected (a
   `~/.claude` directory exists).
 - **Global mode** links into the equivalent directories under your home folder.
+  Not available on Databricks (see below).
 
 Each skill installs as a subfolder named after itself, so the bundled skill
 lands at `using-openretailscience/` inside whichever skills directory applies.
 
-Because the entries are symlinks back into the installed package, a
-`pip install -U openretailscience` updates the skill in place, so there is nothing
+Outside Databricks the entries are symlinks back into the installed package, so a
+`pip install -U openretailscience` updates the skill in place and there is nothing
 to reinstall.
 
 ```python
 install_skills()                       # project install
-install_skills(global_mode=True)       # install for all your projects
+install_skills(global_mode=True)       # install for all your projects (not on Databricks)
 ```
 
 The operation is **idempotent**: re-running it re-uses existing links and never
@@ -52,26 +53,22 @@ one left by an earlier install.
 
 ## Databricks
 
-Databricks works differently, and `install_skills()` adapts
+Databricks works differently, and the default `install_skills()` adapts
 automatically. A pip-installed package lives on the cluster's ephemeral storage,
 which is wiped on restart, and Databricks Genie reads skills from a persistent
 workspace location that cannot symlink back into that storage. So on Databricks
 the installer **copies** the skill into the Genie skills directory instead of
 linking it.
 
-- Default → `/Workspace/Users/<you>/.assistant/skills/`, your own workspace home.
-- Global mode → `/Workspace/.assistant/skills/`, shared with the whole workspace.
+Skills go to `/Workspace/Users/<you>/.assistant/skills/`, your own workspace home.
+`global_mode=True` raises `NotImplementedError` there: the workspace-wide
+`/Workspace/.assistant/skills/` needs admin rights, and a single shared copy
+cannot match the package version each user has installed.
 
-Only workspace admins may write to the workspace-wide directory. Without those
-rights `install_skills(global_mode=True)` fails with `PERMISSION_DENIED` (403),
-which the workspace filesystem often reports asynchronously as an
-`AsyncFlushFailedException` naming a flush rather than the rejected write.
-
-Your workspace username is detected from Spark's `current_user()`, which needs an
-active Spark session — every notebook has one, an init script or a bare Python
-job does not. Export `DATABRICKS_USER` for those, or to override a detected value.
-
-Run it from a notebook:
+Run it from a notebook, as yourself. Your workspace home comes from the Spark
+session's `current_user()`, so two cases raise rather than install: a context with
+no session (a cluster init script, a bare Python job), and an identity with no
+workspace home of its own, such as a job running as a service principal.
 
 ```python
 from openretailscience.skills import install_skills
@@ -81,8 +78,6 @@ install_skills()
 
 Because this is a copy rather than a link, it does **not** update itself when you
 upgrade the package: re-run `install_skills()` after upgrading OpenRetailScience.
-A cluster init script can do that on every start, as long as it exports
-`DATABRICKS_USER` — it runs before any Spark session exists.
 
 !!! warning "Managed directory"
     Your workspace `.assistant/skills/` directory is treated as installer-managed:
@@ -96,7 +91,7 @@ A cluster init script can do that on every start, as long as it exports
 | --- | --- | --- |
 | Local / project | symlink | Yes, automatically |
 | Global (home) | symlink | Yes, automatically |
-| Databricks | copy | No, re-run `install_skills()` |
+| Databricks (no global mode) | copy | No, re-run `install_skills()` |
 
 The skill's content is maintained alongside the codebase and validated in CI, so
 each release ships guidance that matches that version's public API.

--- a/docs/getting_started/agent_skills.md
+++ b/docs/getting_started/agent_skills.md
@@ -66,9 +66,9 @@ Skills go to `/Workspace/Users/<you>/.assistant/skills/`, your own workspace hom
 cannot match the package version each user has installed.
 
 Run it from a notebook, as yourself. Your workspace home comes from the Spark
-session's `current_user()`, so two cases raise rather than install: a context with
-no session (a cluster init script, a bare Python job), and an identity with no
-workspace home of its own, such as a job running as a service principal.
+session's `current_user()`, so cases like these raise rather than install: a
+context with no session (a cluster init script, a bare Python job), and an identity
+with no workspace home of its own, such as a job running as a service principal.
 
 ```python
 from openretailscience.skills import install_skills

--- a/openretailscience/skills.py
+++ b/openretailscience/skills.py
@@ -20,8 +20,8 @@ Linking behaviour:
 * On Databricks the package lives on ephemeral compute that is wiped on cluster
   restart, and Genie reads skills from a persistent ``/Workspace`` location that
   cannot symlink into site-packages. There we always **copy** skills into the
-  Genie skills directory; re-run :func:`install_skills` after upgrading the
-  package to refresh the copy.
+  user's own ``/Workspace/Users/<user>/.assistant/skills`` directory; re-run
+  :func:`install_skills` after upgrading the package to refresh the copy.
 """
 
 from __future__ import annotations
@@ -156,28 +156,49 @@ def _get_target_dirs(base: Path) -> list[Path]:
     return targets
 
 
-def _get_databricks_target_dirs(*, global_mode: bool) -> list[Path]:
-    """Return the persistent Databricks Genie skills directory.
+def _databricks_user_home() -> Path | None:
+    """Return the caller's ``/Workspace/Users/<user>`` directory, if it can be resolved.
 
-    Project mode installs to the shared workspace skills directory; global mode
-    installs to the per-user directory when the user is known, otherwise falls
-    back to the shared directory with a note.
-
-    Args:
-        global_mode (bool): Whether to install per-user rather than shared.
+    Prefers the ``DATABRICKS_USER`` environment variable; otherwise derives the
+    user from the working directory, which for a workspace notebook sits under
+    ``/Workspace/Users/<user>/``.
 
     Returns:
-        list[Path]: The single Genie skills directory to copy into.
+        Path | None: The workspace home directory, or None when unresolvable.
     """
-    if global_mode:
-        user = os.environ.get(_DATABRICKS_USER_ENV) or None  # blank env var counts as unknown
-        if user is not None:
-            base = _DATABRICKS_WORKSPACE_ROOT / DATABRICKS_USERS_DIR / user
-            return [_skills_dir(base, DATABRICKS_ASSISTANT_DIR)]
-        print(  # noqa: T201 - user-facing installer output
-            "Could not determine the Databricks user; installing to the shared workspace skills directory instead."
+    users_root = _DATABRICKS_WORKSPACE_ROOT / DATABRICKS_USERS_DIR
+    user = os.environ.get(_DATABRICKS_USER_ENV) or None  # blank env var counts as unknown
+    if user is not None:
+        return users_root / user
+    cwd = Path.cwd()
+    if users_root in cwd.parents:
+        return users_root / cwd.relative_to(users_root).parts[0]
+    return None
+
+
+def _get_databricks_target_dir() -> Path:
+    """Return the Databricks Genie skills directory in the caller's workspace home.
+
+    The shared ``/Workspace/.assistant/skills`` directory is deliberately not a
+    fallback: writing there requires workspace admin rights, and attempting it
+    fails with an opaque asynchronous 403 from the workspace filesystem.
+
+    Returns:
+        Path: The Genie skills directory to copy into.
+
+    Raises:
+        RuntimeError: When the caller's workspace home cannot be resolved.
+    """
+    home = _databricks_user_home()
+    if home is None or not home.is_dir():
+        attempted = home if home is not None else _DATABRICKS_WORKSPACE_ROOT / DATABRICKS_USERS_DIR
+        msg = (
+            f"Could not resolve your Databricks workspace home (looked under {attempted}). "
+            f"Set the {_DATABRICKS_USER_ENV} environment variable to your workspace username "
+            "(e.g. you@company.com) and re-run install_skills()."
         )
-    return [_skills_dir(_DATABRICKS_WORKSPACE_ROOT, DATABRICKS_ASSISTANT_DIR)]
+        raise RuntimeError(msg)
+    return _skills_dir(home, DATABRICKS_ASSISTANT_DIR)
 
 
 def _relative_symlink_target(source_path: Path, target_path: Path) -> str:
@@ -379,12 +400,13 @@ def install_skills(global_mode: bool = False) -> SkillInstallResult:
     In project mode (default) skills are linked into the current project's
     ``.agents/skills/`` (and ``.claude/skills/`` when Claude Code is detected). In
     global mode they are linked into the equivalent home directories. On
-    Databricks, skills are copied into the persistent Genie workspace skills
-    directory instead of linked. The operation is idempotent.
+    Databricks both modes copy the skills into the caller's persistent workspace
+    Genie skills directory instead. The operation is idempotent.
 
     Args:
         global_mode (bool): Install to user-level home directories instead of the
-            current project. Defaults to False.
+            current project. Defaults to False. Ignored on Databricks, which has
+            no project tree in the workspace.
 
     Returns:
         SkillInstallResult: The skills that were installed, already up to date,
@@ -393,7 +415,7 @@ def install_skills(global_mode: bool = False) -> SkillInstallResult:
     Raises:
         FileNotFoundError: When the bundled skills directory is missing.
         RuntimeError: When the bundled skills directory contains no installable
-            skills.
+            skills, or when the Databricks workspace home cannot be resolved.
     """
     source_dir = _get_source_skills_dir()
     if not source_dir.is_dir():
@@ -406,7 +428,7 @@ def install_skills(global_mode: bool = False) -> SkillInstallResult:
         raise RuntimeError(msg)
 
     if _DATABRICKS_RUNTIME_ENV in os.environ:
-        target_dirs = _get_databricks_target_dirs(global_mode=global_mode)
+        target_dirs = [_get_databricks_target_dir()]
         use_copy = True
     elif global_mode:
         target_dirs = _get_target_dirs(Path.home())

--- a/openretailscience/skills.py
+++ b/openretailscience/skills.py
@@ -42,11 +42,7 @@ SKILLS_SUBDIR = "skills"
 
 # Databricks Genie / Assistant reads skills from ``<root>/.assistant/skills``.
 DATABRICKS_ASSISTANT_DIR = ".assistant"
-DATABRICKS_USERS_DIR = "Users"
 _DATABRICKS_RUNTIME_ENV = "DATABRICKS_RUNTIME_VERSION"
-_DATABRICKS_USER_ENV = "DATABRICKS_USER"
-# Persistent workspace root on Databricks. Kept as a module constant so tests
-# can redirect it away from the real ``/Workspace`` mount.
 _DATABRICKS_WORKSPACE_ROOT = Path("/Workspace")
 
 
@@ -109,7 +105,7 @@ def _find_project_root(start: Path | None = None) -> Path:
     Returns:
         Path: The resolved project root.
     """
-    start_dir = (start or Path.cwd()).resolve()
+    start_dir = (start if start is not None else Path.cwd()).resolve()
     home = Path.home().resolve()
 
     git_root: Path | None = None
@@ -137,81 +133,37 @@ def _skills_dir(base: Path, harness_dir: str) -> Path:
     return base / harness_dir / SKILLS_SUBDIR
 
 
-def _get_target_dirs(base: Path) -> list[Path]:
-    """Return the ``.agents/skills`` (and ``.claude/skills``) targets under ``base``.
-
-    Always targets ``<base>/.agents/skills``; adds ``<base>/.claude/skills`` when
-    Claude Code is detected (a ``~/.claude`` directory exists).
-
-    Args:
-        base (Path): The resolved project root (project mode) or home directory
-            (global mode).
-
-    Returns:
-        list[Path]: Target skill directories.
-    """
-    targets = [_skills_dir(base, AGENTS_DIR_NAME)]
-    if (Path.home() / CLAUDE_DIR_NAME).is_dir():
-        targets.append(_skills_dir(base, CLAUDE_DIR_NAME))
-    return targets
-
-
-def _spark_current_user() -> str | None:
-    """Return the workspace username Databricks is running the session as.
-
-    Returns:
-        str | None: The username from Spark's ``current_user()``, or None when no
-        Spark session is active.
-    """
-    from pyspark.sql import SparkSession  # noqa: PLC0415 - deferred: importing pyspark is slow
-
-    spark = SparkSession.getActiveSession()
-    if spark is None:
-        return None
-    return str(spark.sql("SELECT current_user()").collect()[0][0])
-
-
-def _databricks_user_home() -> Path | None:
-    """Return the caller's ``/Workspace/Users/<user>`` directory, if it can be resolved.
-
-    ``DATABRICKS_USER`` overrides the detected username, and is the only source
-    outside a notebook, where no Spark session is running.
-
-    Returns:
-        Path | None: The workspace home directory, or None when unresolvable.
-    """
-    user = os.environ.get(_DATABRICKS_USER_ENV) or _spark_current_user()  # blank env var counts as unset
-    if user is None:
-        return None
-    return _DATABRICKS_WORKSPACE_ROOT / DATABRICKS_USERS_DIR / user
-
-
-def _get_databricks_target_dir(*, global_mode: bool) -> Path:
-    """Return the Databricks Genie skills directory to copy into.
-
-    Only workspace admins may write to the workspace-wide directory, so an
-    unresolvable workspace home raises rather than falling back to it: that write
-    fails with an opaque asynchronous 403 from the workspace filesystem.
-
-    Args:
-        global_mode (bool): Install for the whole workspace rather than the caller.
+def _get_databricks_target_dir() -> Path:
+    """Return the Genie skills directory in the caller's Databricks workspace home.
 
     Returns:
         Path: The Genie skills directory to copy into.
 
     Raises:
-        RuntimeError: When the caller's workspace home cannot be resolved.
+        ImportError: When pyspark is unavailable, so the caller cannot be named.
+        RuntimeError: When no Spark session is running to name the caller, when
+            ``current_user()`` does not name a workspace user, or when that user's
+            workspace home does not exist.
     """
-    if global_mode:
-        return _skills_dir(_DATABRICKS_WORKSPACE_ROOT, DATABRICKS_ASSISTANT_DIR)
+    from pyspark.sql import SparkSession  # noqa: PLC0415 - pyspark is not a dependency; Databricks provides it
 
-    home = _databricks_user_home()
-    if home is None or not home.is_dir():
-        attempted = home if home is not None else _DATABRICKS_WORKSPACE_ROOT / DATABRICKS_USERS_DIR
+    spark = SparkSession.getActiveSession()
+    if spark is None:
+        msg = "Installing to your Databricks workspace home needs an active Spark session; run this from a notebook."
+        raise RuntimeError(msg)
+
+    rows = spark.sql("SELECT current_user()").collect()
+    user = str(rows[0][0]) if len(rows) > 0 else ""
+    # An empty, "..", or otherwise path-like name would join back out to the admin-only workspace root.
+    if user in {"", ".."} or user != Path(user).name:
+        msg = f"Databricks current_user() did not name a workspace user: {user!r}"
+        raise RuntimeError(msg)
+
+    home = _DATABRICKS_WORKSPACE_ROOT / "Users" / user
+    if not home.is_dir():
         msg = (
-            f"Could not resolve your Databricks workspace home (looked under {attempted}). "
-            f"Set the {_DATABRICKS_USER_ENV} environment variable to your workspace username "
-            "(e.g. you@company.com) and re-run install_skills()."
+            f"Databricks workspace home does not exist: {home}. current_user() returned {user!r}, which has no "
+            "workspace home of its own (a job running as a service principal, for example)."
         )
         raise RuntimeError(msg)
     return _skills_dir(home, DATABRICKS_ASSISTANT_DIR)
@@ -286,11 +238,8 @@ def _is_owned_target(target_path: Path, bundled_names: set[str]) -> bool:
 
     A target is owned when it is a symlink whose name matches a bundled skill, or
     a real directory named after a bundled skill that itself contains a
-    ``SKILL.md`` (a prior copy install). Anything else is user content.
-
-    Ownership only permits replacement; whether an owned *real directory* is
-    actually replaced depends on the install method (see :func:`_prepare_target`):
-    symlink mode always leaves real directories in place, copy mode refreshes them.
+    ``SKILL.md`` (a prior copy install). Anything else is user content. Ownership
+    only permits replacement; :func:`_prepare_target` decides whether it happens.
 
     Args:
         target_path (Path): The candidate target.
@@ -324,7 +273,7 @@ def _prepare_target(
         use_copy (bool): Whether the install method is copy (vs. symlink).
 
     Returns:
-        str: One of ``"install"``, ``"up_to_date"``, or ``"skip"``.
+        Literal["install", "up_to_date", "skip"]: The disposition for this target.
     """
     if not target_path.exists() and not target_path.is_symlink():
         return "install"
@@ -340,11 +289,6 @@ def _prepare_target(
         target_path.unlink()  # os.unlink semantics: remove the link, not its target
         return "install"
 
-    # Owned real directory. A byte-identical tree is a current install (a prior
-    # copy-fallback run, or a Databricks copy), so report it up to date. Otherwise
-    # copy mode refreshes it, while symlink mode skips it: a non-matching real
-    # directory may be user-authored content that merely shares a bundled skill's
-    # name, so it must not be deleted.
     if _skill_copy_matches(source_path, target_path):
         return "up_to_date"
     if not use_copy:
@@ -395,21 +339,6 @@ def _install_one(
     result.installed.append(label)
 
 
-def _print_result(result: SkillInstallResult) -> None:
-    """Print a summary of the installation outcome.
-
-    Args:
-        result (SkillInstallResult): The completed install result.
-    """
-    for label, paths in (
-        ("Installed", result.installed),
-        ("Already up to date", result.up_to_date),
-        ("Skipped (conflicting file)", result.skipped),
-    ):
-        for path in paths:
-            print(f"{label}: {path}")  # noqa: T201
-
-
 def install_skills(global_mode: bool = False) -> SkillInstallResult:
     """Install the package's bundled agent skills.
 
@@ -417,13 +346,11 @@ def install_skills(global_mode: bool = False) -> SkillInstallResult:
     ``.agents/skills/`` (and ``.claude/skills/`` when Claude Code is detected). In
     global mode they are linked into the equivalent home directories. On
     Databricks skills are copied into the caller's persistent workspace Genie
-    skills directory instead — or, in global mode, into the workspace-wide one,
-    which only workspace admins may write to. The operation is idempotent.
+    skills directory instead. The operation is idempotent.
 
     Args:
-        global_mode (bool): Install for every project rather than the current one:
-            the user-level home directories, or on Databricks the workspace-wide
-            skills directory. Defaults to False.
+        global_mode (bool): Install into the user-level home directories rather
+            than the current project. Defaults to False. Unsupported on Databricks.
 
     Returns:
         SkillInstallResult: The skills that were installed, already up to date,
@@ -433,6 +360,8 @@ def install_skills(global_mode: bool = False) -> SkillInstallResult:
         FileNotFoundError: When the bundled skills directory is missing.
         RuntimeError: When the bundled skills directory contains no installable
             skills, or when the Databricks workspace home cannot be resolved.
+        NotImplementedError: When ``global_mode`` is requested on Databricks.
+        ImportError: When pyspark is unavailable on Databricks.
     """
     source_dir = _get_source_skills_dir()
     if not source_dir.is_dir():
@@ -445,13 +374,19 @@ def install_skills(global_mode: bool = False) -> SkillInstallResult:
         raise RuntimeError(msg)
 
     if _DATABRICKS_RUNTIME_ENV in os.environ:
-        target_dirs = [_get_databricks_target_dir(global_mode=global_mode)]
+        if global_mode:
+            msg = (
+                "global_mode is not supported on Databricks: the workspace-wide skills directory needs admin "
+                "rights, and one shared copy cannot match the package version each user has installed."
+            )
+            raise NotImplementedError(msg)
+        target_dirs = [_get_databricks_target_dir()]
         use_copy = True
-    elif global_mode:
-        target_dirs = _get_target_dirs(Path.home())
-        use_copy = False
     else:
-        target_dirs = _get_target_dirs(_find_project_root())
+        base = Path.home() if global_mode else _find_project_root()
+        target_dirs = [_skills_dir(base, AGENTS_DIR_NAME)]
+        if (Path.home() / CLAUDE_DIR_NAME).is_dir():  # Claude Code is installed
+            target_dirs.append(_skills_dir(base, CLAUDE_DIR_NAME))
         use_copy = False
 
     result = SkillInstallResult()
@@ -460,5 +395,11 @@ def install_skills(global_mode: bool = False) -> SkillInstallResult:
         for target_dir in target_dirs:
             _install_one(skill_name, source_dir, target_dir, result, bundled_names, use_copy=use_copy)
 
-    _print_result(result)
+    for label, paths in (
+        ("Installed", result.installed),
+        ("Already up to date", result.up_to_date),
+        ("Skipped (conflicting file)", result.skipped),
+    ):
+        for path in paths:
+            print(f"{label}: {path}")  # noqa: T201
     return result

--- a/openretailscience/skills.py
+++ b/openretailscience/skills.py
@@ -39,6 +39,9 @@ SKILL_MARKER_FILENAME = "SKILL.md"
 AGENTS_DIR_NAME = ".agents"
 CLAUDE_DIR_NAME = ".claude"
 SKILLS_SUBDIR = "skills"
+# pip byte-compiles the package it installs, leaving these inside the bundled skill.
+# The Databricks workspace mount rejects them with OSError 95, part-way through a copy.
+BYTECODE_CACHE_DIR = "__pycache__"
 
 # Databricks Genie / Assistant reads skills from ``<root>/.assistant/skills``.
 DATABRICKS_ASSISTANT_DIR = ".assistant"
@@ -152,8 +155,8 @@ def _get_databricks_target_dir() -> Path:
         msg = "Installing to your Databricks workspace home needs an active Spark session; run this from a notebook."
         raise RuntimeError(msg)
 
-    rows = spark.sql("SELECT current_user()").collect()
-    user = str(rows[0][0]) if len(rows) > 0 else ""
+    # A SELECT of a scalar function always yields exactly one row.
+    user = str(spark.sql("SELECT current_user()").collect()[0][0])
     # An empty, "..", or otherwise path-like name would join back out to the admin-only workspace root.
     if user in {"", ".."} or user != Path(user).name:
         msg = f"Databricks current_user() did not name a workspace user: {user!r}"
@@ -161,10 +164,7 @@ def _get_databricks_target_dir() -> Path:
 
     home = _DATABRICKS_WORKSPACE_ROOT / "Users" / user
     if not home.is_dir():
-        msg = (
-            f"Databricks workspace home does not exist: {home}. current_user() returned {user!r}, which has no "
-            "workspace home of its own (a job running as a service principal, for example)."
-        )
+        msg = f"Databricks workspace home not found: {home}. current_user() returned {user!r}."
         raise RuntimeError(msg)
     return _skills_dir(home, DATABRICKS_ASSISTANT_DIR)
 
@@ -208,6 +208,18 @@ def _try_symlink(source_path: Path, target_path: Path) -> bool:
     return True
 
 
+def _copied_paths(root: Path) -> list[Path]:
+    """List the paths under ``root`` that an install copies.
+
+    Args:
+        root (Path): A skill directory, bundled or installed.
+
+    Returns:
+        list[Path]: Sorted paths relative to ``root``, excluding bytecode caches.
+    """
+    return sorted(p.relative_to(root) for p in root.rglob("*") if BYTECODE_CACHE_DIR not in p.parts)
+
+
 def _skill_copy_matches(source_path: Path, target_path: Path) -> bool:
     """Return whether a copied skill directory matches the source byte-for-byte.
 
@@ -220,8 +232,8 @@ def _skill_copy_matches(source_path: Path, target_path: Path) -> bool:
     """
     if not target_path.is_dir():
         return False
-    source_files = sorted(p.relative_to(source_path) for p in source_path.rglob("*"))
-    if source_files != sorted(p.relative_to(target_path) for p in target_path.rglob("*")):
+    source_files = _copied_paths(source_path)
+    if source_files != _copied_paths(target_path):
         return False
     for rel in source_files:
         source_file = source_path / rel
@@ -335,7 +347,7 @@ def _install_one(
     # so a skipped skill never leaves an empty directory behind.
     target_dir.mkdir(parents=True, exist_ok=True)
     if use_copy or not _try_symlink(source_path, target_path):
-        shutil.copytree(source_path, target_path)
+        shutil.copytree(source_path, target_path, ignore=shutil.ignore_patterns(BYTECODE_CACHE_DIR))
     result.installed.append(label)
 
 

--- a/openretailscience/skills.py
+++ b/openretailscience/skills.py
@@ -176,12 +176,16 @@ def _databricks_user_home() -> Path | None:
     return None
 
 
-def _get_databricks_target_dir() -> Path:
-    """Return the Databricks Genie skills directory in the caller's workspace home.
+def _get_databricks_target_dir(*, global_mode: bool) -> Path:
+    """Return the Databricks Genie skills directory to copy into.
 
-    The shared ``/Workspace/.assistant/skills`` directory is deliberately not a
-    fallback: writing there requires workspace admin rights, and attempting it
-    fails with an opaque asynchronous 403 from the workspace filesystem.
+    Global mode targets the workspace-wide directory, which only workspace admins
+    may write to. Otherwise the skills go to the caller's own workspace home,
+    which is never silently swapped for the workspace-wide directory: falling back
+    there fails with an opaque asynchronous 403 from the workspace filesystem.
+
+    Args:
+        global_mode (bool): Install for the whole workspace rather than the caller.
 
     Returns:
         Path: The Genie skills directory to copy into.
@@ -189,6 +193,9 @@ def _get_databricks_target_dir() -> Path:
     Raises:
         RuntimeError: When the caller's workspace home cannot be resolved.
     """
+    if global_mode:
+        return _skills_dir(_DATABRICKS_WORKSPACE_ROOT, DATABRICKS_ASSISTANT_DIR)
+
     home = _databricks_user_home()
     if home is None or not home.is_dir():
         attempted = home if home is not None else _DATABRICKS_WORKSPACE_ROOT / DATABRICKS_USERS_DIR
@@ -400,13 +407,14 @@ def install_skills(global_mode: bool = False) -> SkillInstallResult:
     In project mode (default) skills are linked into the current project's
     ``.agents/skills/`` (and ``.claude/skills/`` when Claude Code is detected). In
     global mode they are linked into the equivalent home directories. On
-    Databricks both modes copy the skills into the caller's persistent workspace
-    Genie skills directory instead. The operation is idempotent.
+    Databricks skills are copied into the caller's persistent workspace Genie
+    skills directory instead — or, in global mode, into the workspace-wide one,
+    which only workspace admins may write to. The operation is idempotent.
 
     Args:
-        global_mode (bool): Install to user-level home directories instead of the
-            current project. Defaults to False. Ignored on Databricks, which has
-            no project tree in the workspace.
+        global_mode (bool): Install for every project rather than the current one:
+            the user-level home directories, or on Databricks the workspace-wide
+            skills directory. Defaults to False.
 
     Returns:
         SkillInstallResult: The skills that were installed, already up to date,
@@ -428,7 +436,7 @@ def install_skills(global_mode: bool = False) -> SkillInstallResult:
         raise RuntimeError(msg)
 
     if _DATABRICKS_RUNTIME_ENV in os.environ:
-        target_dirs = [_get_databricks_target_dir()]
+        target_dirs = [_get_databricks_target_dir(global_mode=global_mode)]
         use_copy = True
     elif global_mode:
         target_dirs = _get_target_dirs(Path.home())

--- a/openretailscience/skills.py
+++ b/openretailscience/skills.py
@@ -174,8 +174,8 @@ def _spark_current_user() -> str | None:
 def _databricks_user_home() -> Path | None:
     """Return the caller's ``/Workspace/Users/<user>`` directory, if it can be resolved.
 
-    ``DATABRICKS_USER`` overrides the detected username, for compute with no Spark
-    session.
+    ``DATABRICKS_USER`` overrides the detected username, and is the only source
+    outside a notebook, where no Spark session is running.
 
     Returns:
         Path | None: The workspace home directory, or None when unresolvable.

--- a/openretailscience/skills.py
+++ b/openretailscience/skills.py
@@ -156,24 +156,34 @@ def _get_target_dirs(base: Path) -> list[Path]:
     return targets
 
 
+def _spark_current_user() -> str | None:
+    """Return the workspace username Databricks is running the session as.
+
+    Returns:
+        str | None: The username from Spark's ``current_user()``, or None when no
+        Spark session is active (so the username has to come from elsewhere).
+    """
+    from pyspark.sql import SparkSession  # noqa: PLC0415 - deferred: importing pyspark is slow
+
+    spark = SparkSession.getActiveSession()
+    if spark is None:
+        return None
+    return str(spark.sql("SELECT current_user()").collect()[0][0])
+
+
 def _databricks_user_home() -> Path | None:
     """Return the caller's ``/Workspace/Users/<user>`` directory, if it can be resolved.
 
-    Prefers the ``DATABRICKS_USER`` environment variable; otherwise derives the
-    user from the working directory, which for a workspace notebook sits under
-    ``/Workspace/Users/<user>/``.
+    The username comes from Spark's ``current_user()``, with the ``DATABRICKS_USER``
+    environment variable as an override for compute that has no Spark session.
 
     Returns:
         Path | None: The workspace home directory, or None when unresolvable.
     """
-    users_root = _DATABRICKS_WORKSPACE_ROOT / DATABRICKS_USERS_DIR
-    user = os.environ.get(_DATABRICKS_USER_ENV) or None  # blank env var counts as unknown
-    if user is not None:
-        return users_root / user
-    cwd = Path.cwd()
-    if users_root in cwd.parents:
-        return users_root / cwd.relative_to(users_root).parts[0]
-    return None
+    user = os.environ.get(_DATABRICKS_USER_ENV) or _spark_current_user()  # blank env var counts as unset
+    if user is None:
+        return None
+    return _DATABRICKS_WORKSPACE_ROOT / DATABRICKS_USERS_DIR / user
 
 
 def _get_databricks_target_dir(*, global_mode: bool) -> Path:

--- a/openretailscience/skills.py
+++ b/openretailscience/skills.py
@@ -161,7 +161,7 @@ def _spark_current_user() -> str | None:
 
     Returns:
         str | None: The username from Spark's ``current_user()``, or None when no
-        Spark session is active (so the username has to come from elsewhere).
+        Spark session is active.
     """
     from pyspark.sql import SparkSession  # noqa: PLC0415 - deferred: importing pyspark is slow
 
@@ -174,8 +174,8 @@ def _spark_current_user() -> str | None:
 def _databricks_user_home() -> Path | None:
     """Return the caller's ``/Workspace/Users/<user>`` directory, if it can be resolved.
 
-    The username comes from Spark's ``current_user()``, with the ``DATABRICKS_USER``
-    environment variable as an override for compute that has no Spark session.
+    ``DATABRICKS_USER`` overrides the detected username, for compute with no Spark
+    session.
 
     Returns:
         Path | None: The workspace home directory, or None when unresolvable.
@@ -189,10 +189,9 @@ def _databricks_user_home() -> Path | None:
 def _get_databricks_target_dir(*, global_mode: bool) -> Path:
     """Return the Databricks Genie skills directory to copy into.
 
-    Global mode targets the workspace-wide directory, which only workspace admins
-    may write to. Otherwise the skills go to the caller's own workspace home,
-    which is never silently swapped for the workspace-wide directory: falling back
-    there fails with an opaque asynchronous 403 from the workspace filesystem.
+    Only workspace admins may write to the workspace-wide directory, so an
+    unresolvable workspace home raises rather than falling back to it: that write
+    fails with an opaque asynchronous 403 from the workspace filesystem.
 
     Args:
         global_mode (bool): Install for the whole workspace rather than the caller.

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -8,8 +8,10 @@ import runpy
 import shutil
 import sys
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
 
 import pytest
+from pyspark.sql import SparkSession
 
 from openretailscience import skills
 from openretailscience.options import get_option, list_options, set_option
@@ -331,6 +333,13 @@ class TestDatabricksInstall:
         """The per-user Genie skills directory install_skills must write to."""
         return workspace_root / "Users" / DATABRICKS_USER / ".assistant" / "skills"
 
+    @pytest.fixture
+    def spark_session(self, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+        """Stand in for the Databricks-provided active Spark session (an external dependency)."""
+        session = MagicMock()
+        monkeypatch.setattr(SparkSession, "getActiveSession", lambda: session)
+        return session
+
     def test_copies_to_per_user_assistant_dir(
         self, source_dir: Path, workspace_root: Path, user_skills_dir: Path
     ) -> None:
@@ -365,18 +374,29 @@ class TestDatabricksInstall:
 
         assert (workspace_root / ".assistant" / "skills" / SKILL_NAMES[0]).is_dir()
 
-    def test_user_is_derived_from_workspace_cwd_when_env_unset(
-        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path, monkeypatch: pytest.MonkeyPatch
+    def test_user_comes_from_spark_current_user_when_env_unset(
+        self, source_dir: Path, user_skills_dir: Path, spark_session: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Without DATABRICKS_USER, the user comes from a notebook cwd under /Workspace/Users."""
+        """Without DATABRICKS_USER, the workspace user is read from Spark's current_user()."""
         monkeypatch.delenv("DATABRICKS_USER")
-        notebook_dir = workspace_root / "Users" / DATABRICKS_USER / "retail-analysis"
-        notebook_dir.mkdir()
-        monkeypatch.chdir(notebook_dir)
+        spark_session.sql.return_value.collect.return_value = [[DATABRICKS_USER]]
 
         install_skills()
 
+        assert "current_user()" in spark_session.sql.call_args.args[0]
         assert (user_skills_dir / SKILL_NAMES[0] / "SKILL.md").is_file()
+
+    def test_env_user_overrides_spark_current_user(
+        self, source_dir: Path, user_skills_dir: Path, workspace_root: Path, spark_session: MagicMock
+    ) -> None:
+        """DATABRICKS_USER wins over current_user(), so a wrong detection can be corrected by hand."""
+        (workspace_root / "Users" / "service-principal").mkdir()
+        spark_session.sql.return_value.collect.return_value = [["service-principal"]]
+
+        install_skills()
+
+        assert (user_skills_dir / SKILL_NAMES[0]).is_dir()
+        assert not (workspace_root / "Users" / "service-principal" / ".assistant").exists()
 
     @pytest.mark.parametrize("user_env", [None, "", "wrong.user@retail.com"])
     def test_raises_when_workspace_user_cannot_be_resolved(

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -335,7 +335,7 @@ class TestDatabricksInstall:
 
     @pytest.fixture
     def spark_session(self, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
-        """Stand in for the Databricks-provided active Spark session (an external dependency)."""
+        """Stand in for the Databricks-provided active Spark session."""
         session = MagicMock()
         monkeypatch.setattr(SparkSession, "getActiveSession", lambda: session)
         return session
@@ -351,14 +351,14 @@ class TestDatabricksInstall:
             assert target.is_dir()
             assert not target.is_symlink()
             assert (target / "SKILL.md").is_file()
-        # The workspace-wide directory needs admin rights: writing there by default
-        # is what raised 403 PERMISSION_DENIED for non-admin users.
+        # The workspace-wide directory needs admin rights, so a default install
+        # must not touch it.
         assert not (workspace_root / ".assistant").exists()
 
     def test_global_mode_copies_to_workspace_wide_dir(
         self, source_dir: Path, workspace_root: Path, user_skills_dir: Path
     ) -> None:
-        """Global mode installs for the whole workspace, which only admins may write to."""
+        """Global mode installs into the workspace-wide directory, not the user's home."""
         install_skills(global_mode=True)
 
         assert (workspace_root / ".assistant" / "skills" / SKILL_NAMES[0] / "SKILL.md").is_file()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -62,10 +62,14 @@ def _import_error(statement: str) -> str | None:
     return None
 
 
+def _shipped_reference_files() -> list[Path]:
+    """Return every reference markdown file of the shipped skill, at any depth."""
+    return sorted((_get_source_skills_dir() / SHIPPED_SKILL_NAME / "references").rglob("*.md"))
+
+
 def _shipped_skill_markdown() -> list[Path]:
     """Return SKILL.md and every reference markdown file of the shipped skill."""
-    skill_root = _get_source_skills_dir() / SHIPPED_SKILL_NAME
-    return [skill_root / "SKILL.md", *sorted(skill_root.glob("references/*.md"))]
+    return [_get_source_skills_dir() / SHIPPED_SKILL_NAME / "SKILL.md", *_shipped_reference_files()]
 
 
 def _skill_import_statements() -> list[str]:
@@ -216,9 +220,15 @@ class TestSymlinkInstall:
         assert len(result.skipped) == 0
         assert len(result.up_to_date) == len(SKILL_NAMES)
 
-    @pytest.mark.parametrize("conflict_kind", ["unrelated_file", "user_authored_skill"])
+    @pytest.mark.parametrize(
+        ("preserved_relpath", "content"),
+        [
+            pytest.param(SKILL_NAMES[0], "user data", id="unrelated_file"),
+            pytest.param(f"{SKILL_NAMES[0]}/SKILL.md", "my own skill", id="user_authored_skill"),
+        ],
+    )
     def test_conflicting_target_is_skipped_not_clobbered(
-        self, source_dir: Path, project_dir: Path, conflict_kind: str
+        self, source_dir: Path, project_dir: Path, preserved_relpath: str, content: str
     ) -> None:
         """A conflicting target is left byte-for-byte intact and reported skipped.
 
@@ -228,19 +238,13 @@ class TestSymlinkInstall:
         """
         target_dir = project_dir / ".agents" / "skills"
         conflict = target_dir / SKILL_NAMES[0]
-        if conflict_kind == "unrelated_file":
-            target_dir.mkdir(parents=True)
-            conflict.write_text("user data", encoding="utf-8")
-            preserved = conflict
-        else:
-            conflict.mkdir(parents=True)
-            (conflict / "SKILL.md").write_text("my own skill", encoding="utf-8")
-            preserved = conflict / "SKILL.md"
-        expected = preserved.read_text(encoding="utf-8")
+        preserved = target_dir / preserved_relpath
+        preserved.parent.mkdir(parents=True)
+        preserved.write_text(content, encoding="utf-8")
 
         result = install_skills()
 
-        assert preserved.read_text(encoding="utf-8") == expected
+        assert preserved.read_text(encoding="utf-8") == content
         assert not conflict.is_symlink()
         assert result.skipped == [str(conflict.relative_to(project_dir))]
         # The non-conflicting skill still installs.
@@ -364,7 +368,7 @@ class TestDatabricksInstall:
         [
             pytest.param([[""]], id="blank"),
             pytest.param([[".."]], id="parent-traversal"),
-            pytest.param([["/tmp"]], id="absolute"),  # noqa: S108
+            pytest.param([["/Workspace/Users/absent-user@retail.com"]], id="absolute"),
             pytest.param([[f"team/{DATABRICKS_USER}"]], id="nested"),
         ],
     )
@@ -373,9 +377,8 @@ class TestDatabricksInstall:
     ) -> None:
         """A blank or path-like current_user() is refused before it is joined into a path.
 
-        A blank, ``..``, or absolute name joins to a directory that exists, so nothing
-        downstream would stop the install: pathlib drops an empty segment, keeps ``..``,
-        and restarts from an absolute one. A nested name escapes the user's own home.
+        Each of these joins outside the caller's own workspace home: pathlib drops an
+        empty segment, keeps ``..``, and restarts from an absolute one.
         """
         spark_session.sql.return_value.collect.return_value = rows
 
@@ -490,6 +493,22 @@ class TestBundledSkill:
         description_body = block.split("description:", 1)[1].replace(">-", " ").strip()
         assert len(description_body) >= MIN_DESCRIPTION_LENGTH
 
+    def test_nested_reference_files_are_scanned(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A reference file in a subdirectory is one of the files the guards read.
+
+        The link guard below enumerates ``references/`` recursively, so a nested file
+        is required to be linked. Unless it is scanned too, its import examples ship
+        unchecked. Patched on this module, which imported the name directly.
+        """
+        skill_root = tmp_path / SHIPPED_SKILL_NAME
+        (skill_root / "references" / "metrics").mkdir(parents=True)
+        (skill_root / "SKILL.md").write_text("See `references/metrics/segstats.md`.\n", encoding="utf-8")
+        nested = skill_root / "references" / "metrics" / "segstats.md"
+        nested.write_text("# Segment transaction stats\n", encoding="utf-8")
+        monkeypatch.setattr(sys.modules[__name__], "_get_source_skills_dir", lambda: tmp_path)
+
+        assert _shipped_skill_markdown() == [skill_root / "SKILL.md", nested]
+
     def test_every_reference_file_is_linked_and_every_link_resolves(self) -> None:
         """The reference files the skill links to are exactly the ones on disk.
 
@@ -502,7 +521,7 @@ class TestBundledSkill:
             referenced.update(REFERENCE_RE.findall(md_file.read_text(encoding="utf-8")))
 
         # as_posix(): the links are written with forward slashes on every platform.
-        on_disk = {path.relative_to(skill_root).as_posix() for path in (skill_root / "references").rglob("*.md")}
+        on_disk = {path.relative_to(skill_root).as_posix() for path in _shipped_reference_files()}
         assert len(on_disk) >= MIN_REFERENCE_FILES
         assert referenced == on_disk
 
@@ -523,25 +542,23 @@ class TestFindProjectRoot:
     """Unit tests for _find_project_root."""
 
     @pytest.mark.parametrize(
-        ("markers", "root_is_ancestor"),
+        "marker",
         [
-            pytest.param([".git"], True, id="git-ancestor"),
-            pytest.param([".agents"], True, id="agents-ancestor"),
-            pytest.param([".claude"], True, id="claude-ancestor"),
-            pytest.param([], False, id="no-markers"),
+            pytest.param(".git", id="git-ancestor"),
+            pytest.param(".agents", id="agents-ancestor"),
+            pytest.param(".claude", id="claude-ancestor"),
+            pytest.param(None, id="no-markers"),
         ],
     )
-    def test_marker_on_an_ancestor_selects_the_root(
-        self, tmp_path: Path, fake_home: Path, markers: list[str], root_is_ancestor: bool
-    ) -> None:
+    def test_marker_on_an_ancestor_selects_the_root(self, tmp_path: Path, fake_home: Path, marker: str | None) -> None:
         """Any of .git, .agents or .claude on an ancestor makes it the root; without one, the start dir is."""
         repo = tmp_path / "repo"
         sub = repo / "pkg"
         sub.mkdir(parents=True)
-        for marker in markers:
+        if marker is not None:
             (repo / marker).mkdir()
 
-        assert _find_project_root(sub) == (repo if root_is_ancestor else sub)
+        assert _find_project_root(sub) == (sub if marker is None else repo)
 
     def test_agents_ancestor_wins_over_a_nearer_git_root(self, tmp_path: Path, fake_home: Path) -> None:
         """A .agents marker outranks a .git directory found closer to the start dir."""

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -346,24 +346,26 @@ class TestDatabricksInstall:
     def test_raises_when_workspace_home_does_not_exist(
         self, source_dir: Path, workspace_root: Path, spark_session: MagicMock
     ) -> None:
-        """A username with no workspace home raises rather than creating one the caller may not own."""
-        spark_session.sql.return_value.collect.return_value = [["service-principal-1234"]]
+        """A username with no workspace home raises rather than creating one, naming the path it checked."""
+        principal = "service-principal-1234"
+        spark_session.sql.return_value.collect.return_value = [[principal]]
+        missing_home = workspace_root / "Users" / principal
 
-        with pytest.raises(RuntimeError, match="service-principal-1234"):
+        with pytest.raises(RuntimeError) as excinfo:
             install_skills()
 
-        assert not (workspace_root / "Users" / "service-principal-1234").exists()
+        expected = f"Databricks workspace home not found: {missing_home}. current_user() returned {principal!r}."
+        assert str(excinfo.value) == expected
+        assert not missing_home.exists()
         assert list(workspace_root.rglob(DATABRICKS_ASSISTANT_DIR)) == []
 
     @pytest.mark.parametrize(
         "rows",
         [
-            pytest.param([], id="no-rows"),
             pytest.param([[""]], id="blank"),
             pytest.param([[".."]], id="parent-traversal"),
-            # Exists, so only the guard stops the install, and is harmless if it regresses.
             pytest.param([["/tmp"]], id="absolute"),  # noqa: S108
-            pytest.param([["team/analyst@retail.com"]], id="nested"),
+            pytest.param([[f"team/{DATABRICKS_USER}"]], id="nested"),
         ],
     )
     def test_raises_when_current_user_is_not_a_workspace_user(
@@ -371,13 +373,14 @@ class TestDatabricksInstall:
     ) -> None:
         """A blank or path-like current_user() is refused before it is joined into a path.
 
-        Each of these joins to a directory that exists, so the workspace-home check
-        would wave it through: pathlib drops an empty segment, restarts from an
-        absolute one, and keeps ``..``.
+        A blank, ``..``, or absolute name joins to a directory that exists, so nothing
+        downstream would stop the install: pathlib drops an empty segment, keeps ``..``,
+        and restarts from an absolute one. A nested name escapes the user's own home.
         """
         spark_session.sql.return_value.collect.return_value = rows
 
-        with pytest.raises(RuntimeError, match="current_user"):
+        # The guard's own wording; the workspace-home error also mentions current_user().
+        with pytest.raises(RuntimeError, match="did not name a workspace user"):
             install_skills()
 
         assert list(workspace_root.rglob(DATABRICKS_ASSISTANT_DIR)) == []
@@ -426,6 +429,28 @@ class TestDatabricksInstall:
         assert target.is_dir()
         assert not target.is_symlink()
         assert (target / "SKILL.md").read_bytes() == (source_dir / SKILL_NAMES[0] / "SKILL.md").read_bytes()
+
+    def test_bytecode_caches_are_skipped_and_do_not_make_the_copy_look_stale(
+        self, source_dir: Path, user_skills_dir: Path
+    ) -> None:
+        """Bytecode caches are skipped: pip creates them and /Workspace refuses them.
+
+        Copying one raises ``OSError: [Errno 95] Operation not supported`` part-way
+        through the tree. Excluding caches from the copy but not from the comparison
+        would then make every re-run treat its own copy as stale.
+        """
+        cache_dir = source_dir / SKILL_NAMES[0] / "scripts" / "__pycache__"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "example_bar.cpython-312.pyc").write_bytes(b"\x00compiled")
+
+        installed = install_skills()
+        rerun = install_skills()
+
+        installed_skill = user_skills_dir / SKILL_NAMES[0]
+        assert (installed_skill / "SKILL.md").is_file()
+        assert not (installed_skill / "scripts" / "__pycache__").exists()
+        assert len(installed.installed) == len(SKILL_NAMES)
+        assert len(rerun.up_to_date) == len(SKILL_NAMES)
 
     def test_copy_is_independent_of_source(self, source_dir: Path, user_skills_dir: Path) -> None:
         """The copied skill survives the ephemeral package being wiped on restart."""
@@ -733,7 +758,4 @@ class TestExampleScripts:
     @pytest.mark.parametrize("script", _example_scripts(), ids=lambda p: p.name)
     def test_example_script_runs(self, script: Path) -> None:
         """The example script runs end-to-end against the installed package."""
-        namespace = runpy.run_path(str(script), run_name="__main__")
-
-        # Catches a script reduced to its docstring: it runs clean and binds nothing.
-        assert len([name for name in namespace if not name.startswith("__")]) > 0
+        runpy.run_path(str(script), run_name="__main__")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 # Two realistic bundled-skill names plus a junk dir with no SKILL.md.
 SKILL_NAMES = ("retail-metrics", "using-openretailscience")
+DATABRICKS_USER = "analyst@retail.com"
 FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---", re.DOTALL)
 SHIPPED_SKILL_NAME = "using-openretailscience"
 # Fenced code blocks, and openretailscience import statements inside them.
@@ -319,21 +320,59 @@ class TestDatabricksInstall:
     def workspace_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         """Simulate a Databricks runtime with a redirected persistent workspace root."""
         root = tmp_path / "Workspace"
-        root.mkdir()
+        (root / "Users" / DATABRICKS_USER).mkdir(parents=True)
         monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "15.4")
-        monkeypatch.delenv("DATABRICKS_USER", raising=False)
+        monkeypatch.setenv("DATABRICKS_USER", DATABRICKS_USER)
         monkeypatch.setattr(skills, "_DATABRICKS_WORKSPACE_ROOT", root)
         return root
 
-    def test_project_mode_copies_to_shared_assistant_dir(self, source_dir: Path, workspace_root: Path) -> None:
-        """On Databricks, project install copies (not links) into .assistant/skills."""
-        install_skills()
+    @pytest.fixture
+    def user_skills_dir(self, workspace_root: Path) -> Path:
+        """The per-user Genie skills directory install_skills must write to."""
+        return workspace_root / "Users" / DATABRICKS_USER / ".assistant" / "skills"
+
+    @pytest.mark.parametrize("global_mode", [False, True])
+    def test_copies_to_per_user_assistant_dir(
+        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path, global_mode: bool
+    ) -> None:
+        """Both modes copy (not link) into the user's own workspace .assistant/skills."""
+        install_skills(global_mode=global_mode)
 
         for name in SKILL_NAMES:
-            target = workspace_root / ".assistant" / "skills" / name
+            target = user_skills_dir / name
             assert target.is_dir()
             assert not target.is_symlink()
             assert (target / "SKILL.md").is_file()
+        # The shared workspace-root directory needs admin rights: writing there is
+        # what raised 403 PERMISSION_DENIED for non-admin users.
+        assert not (workspace_root / ".assistant").exists()
+
+    def test_user_is_derived_from_workspace_cwd_when_env_unset(
+        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without DATABRICKS_USER, the user comes from a notebook cwd under /Workspace/Users."""
+        monkeypatch.delenv("DATABRICKS_USER")
+        notebook_dir = workspace_root / "Users" / DATABRICKS_USER / "retail-analysis"
+        notebook_dir.mkdir()
+        monkeypatch.chdir(notebook_dir)
+
+        install_skills()
+
+        assert (user_skills_dir / SKILL_NAMES[0] / "SKILL.md").is_file()
+
+    @pytest.mark.parametrize("user_env", [None, "", "wrong.user@retail.com"])
+    def test_raises_when_workspace_user_cannot_be_resolved(
+        self, source_dir: Path, workspace_root: Path, monkeypatch: pytest.MonkeyPatch, user_env: str | None
+    ) -> None:
+        """An unknown, blank, or non-existent workspace user raises instead of writing to the shared dir."""
+        monkeypatch.delenv("DATABRICKS_USER")
+        if user_env is not None:
+            monkeypatch.setenv("DATABRICKS_USER", user_env)
+
+        with pytest.raises(RuntimeError, match="DATABRICKS_USER"):
+            install_skills()
+
+        assert not (workspace_root / ".assistant").exists()
 
     def test_rerun_reports_up_to_date_when_copy_matches(self, source_dir: Path, workspace_root: Path) -> None:
         """Re-running on Databricks with unchanged skills reports them up to date."""
@@ -343,7 +382,9 @@ class TestDatabricksInstall:
         assert len(result.installed) == 0
         assert len(result.up_to_date) == len(SKILL_NAMES)
 
-    def test_rerun_refreshes_copy_when_source_changed(self, source_dir: Path, workspace_root: Path) -> None:
+    def test_rerun_refreshes_copy_when_source_changed(
+        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path
+    ) -> None:
         """A changed bundled skill is re-copied over the stale Databricks copy."""
         install_skills()
         (source_dir / SKILL_NAMES[0] / "SKILL.md").write_text(
@@ -353,18 +394,18 @@ class TestDatabricksInstall:
 
         result = install_skills()
 
-        target = workspace_root / ".assistant" / "skills" / SKILL_NAMES[0] / "SKILL.md"
+        target = user_skills_dir / SKILL_NAMES[0] / "SKILL.md"
         assert "Updated." in target.read_text(encoding="utf-8")
         assert len(result.installed) == 1
 
-    def test_existing_workspace_skill_dir_is_replaced(self, source_dir: Path, workspace_root: Path) -> None:
+    def test_existing_workspace_skill_dir_is_replaced(self, source_dir: Path, user_skills_dir: Path) -> None:
         """In copy mode the managed Genie skills dir is refreshed, replacing an owned same-name dir.
 
         This is the documented asymmetry with symlink mode: the workspace
         ``.assistant/skills`` directory is installer-managed, so a same-named
         directory there is treated as a prior copy and overwritten on re-run.
         """
-        existing = workspace_root / ".assistant" / "skills" / SKILL_NAMES[0]
+        existing = user_skills_dir / SKILL_NAMES[0]
         existing.mkdir(parents=True)
         (existing / "SKILL.md").write_text("stale copy", encoding="utf-8")
 
@@ -373,14 +414,14 @@ class TestDatabricksInstall:
         assert existing.is_dir()
         assert (existing / "SKILL.md").read_bytes() == (source_dir / SKILL_NAMES[0] / "SKILL.md").read_bytes()
 
-    def test_existing_symlink_is_replaced_with_real_copy(self, source_dir: Path, workspace_root: Path) -> None:
+    def test_existing_symlink_is_replaced_with_real_copy(self, source_dir: Path, user_skills_dir: Path) -> None:
         """In copy mode an owned symlink at the target is unlinked and replaced by a real copy.
 
         A prior symlink-mode install (or a hand-made link) can leave a symlink at
         a Databricks target. Copy mode must not keep it: it unlinks the symlink
         and copies the skill so the result survives the package being wiped.
         """
-        target = workspace_root / ".assistant" / "skills" / SKILL_NAMES[0]
+        target = user_skills_dir / SKILL_NAMES[0]
         target.parent.mkdir(parents=True)
         target.symlink_to(source_dir / SKILL_NAMES[0])
 
@@ -390,7 +431,7 @@ class TestDatabricksInstall:
         assert not target.is_symlink()
         assert (target / "SKILL.md").read_bytes() == (source_dir / SKILL_NAMES[0] / "SKILL.md").read_bytes()
 
-    def test_copy_is_independent_of_source(self, source_dir: Path, workspace_root: Path) -> None:
+    def test_copy_is_independent_of_source(self, source_dir: Path, user_skills_dir: Path) -> None:
         """The copied skill survives the ephemeral package being wiped on restart."""
         install_skills()
         expected = (source_dir / SKILL_NAMES[0] / "SKILL.md").read_bytes()
@@ -398,33 +439,7 @@ class TestDatabricksInstall:
         # Simulate the ephemeral package being wiped on cluster restart.
         shutil.rmtree(source_dir)
 
-        target = workspace_root / ".assistant" / "skills" / SKILL_NAMES[0] / "SKILL.md"
-        assert target.read_bytes() == expected
-
-    def test_global_mode_uses_per_user_dir_when_user_known(
-        self, source_dir: Path, workspace_root: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Global Databricks install targets the per-user workspace dir when known."""
-        monkeypatch.setenv("DATABRICKS_USER", "analyst@retail.com")
-
-        install_skills(global_mode=True)
-
-        target = workspace_root / "Users" / "analyst@retail.com" / ".assistant" / "skills" / SKILL_NAMES[0]
-        assert target.is_dir()
-
-    @pytest.mark.parametrize("user_env", [None, ""])
-    def test_global_mode_falls_back_to_shared_when_user_missing_or_blank(
-        self, source_dir: Path, workspace_root: Path, monkeypatch: pytest.MonkeyPatch, user_env: str | None
-    ) -> None:
-        """Global Databricks install falls back to the shared dir when the user is unset or blank."""
-        if user_env is not None:
-            monkeypatch.setenv("DATABRICKS_USER", user_env)
-
-        install_skills(global_mode=True)
-
-        assert (workspace_root / ".assistant" / "skills" / SKILL_NAMES[0]).is_dir()
-        # A blank user must not produce a malformed ``/Workspace/Users//...`` path.
-        assert not (workspace_root / "Users").exists()
+        assert (user_skills_dir / SKILL_NAMES[0] / "SKILL.md").read_bytes() == expected
 
 
 class TestBundledSkill:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -7,11 +7,11 @@ import re
 import runpy
 import shutil
 import sys
+from pathlib import PurePath
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
-from pyspark.sql import SparkSession
 
 from openretailscience import skills
 from openretailscience.options import get_option, list_options, set_option
@@ -26,12 +26,18 @@ from openretailscience.skills import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
     from pathlib import Path
+    from typing import NoReturn
 
 # Two realistic bundled-skill names plus a junk dir with no SKILL.md.
 SKILL_NAMES = ("retail-metrics", "using-openretailscience")
 DATABRICKS_USER = "analyst@retail.com"
+# Spelled out, not imported: renaming the package constant must fail these tests,
+# because Databricks reads this exact path.
+DATABRICKS_ASSISTANT_DIR = ".assistant"
+# Patched by name so pyspark, a dev-only transitive dependency, stays out of imports.
+GET_ACTIVE_SESSION = "pyspark.sql.SparkSession.getActiveSession"
 FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---", re.DOTALL)
 SHIPPED_SKILL_NAME = "using-openretailscience"
 # Fenced code blocks, and openretailscience import statements inside them.
@@ -39,15 +45,12 @@ CODE_FENCE_RE = re.compile(r"```[a-zA-Z]*\n(.*?)```", re.DOTALL)
 IMPORT_RE = re.compile(r"^[ \t]*(?:from|import)\s+openretailscience[\w. ,]*(?:import[\w. ,]+)?$", re.MULTILINE)
 # Markdown references to sibling skill files, e.g. `references/plotting.md`.
 REFERENCE_RE = re.compile(r"references/[\w./-]+\.md")
-MIN_REFERENCE_FILES = 3
-# Lower-bound sanity check: the skill teaches far more, so this floor only guards
-# against the import-extraction pipeline silently matching nothing.
+# Lower bounds, not targets: the skill ships far more of each. Without them a glob
+# that matches nothing would let the guards below pass vacuously.
 MIN_IMPORT_EXAMPLES = 20
-MIN_DESCRIPTION_LENGTH = 50
-# Floor on the number of bundled example scripts. An empty or truncated glob would
-# make the parametrized drift guard collect zero cases and pass silently; this
-# floor makes that fail loudly instead.
+MIN_REFERENCE_FILES = 3
 MIN_EXAMPLE_SCRIPTS = 30
+MIN_DESCRIPTION_LENGTH = 50
 
 
 def _import_error(statement: str) -> str | None:
@@ -74,19 +77,19 @@ def _skill_import_statements() -> list[str]:
     return statements
 
 
-def _raise_oserror(*_args: object, **_kwargs: object) -> None:
+def _raise_oserror(*_args: object, **_kwargs: object) -> NoReturn:
     """Raise OSError; a patched-call stand-in for a failing operation (unsupported symlink, cross-drive path)."""
     msg = "symlinks not supported"
     raise OSError(msg)
 
 
-def _raise_value_error(*_args: object, **_kwargs: object) -> str:
+def _raise_value_error(*_args: object, **_kwargs: object) -> NoReturn:
     """Stand-in for os.path.relpath that reports incompatible paths."""
     msg = "paths are on different drives"
     raise ValueError(msg)
 
 
-def _raise_not_implemented(*_args: object, **_kwargs: object) -> None:
+def _raise_not_implemented(*_args: object, **_kwargs: object) -> NoReturn:
     """Raise NotImplementedError; a patched-call stand-in for an operation unsupported on the platform."""
     raise NotImplementedError
 
@@ -123,10 +126,15 @@ def source_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 @pytest.fixture
 def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Redirect ``Path.home()`` to a temp dir and clear Databricks detection."""
+    """Redirect ``Path.home()`` to a temp dir and clear Databricks detection.
+
+    ``USERPROFILE`` too: ``ntpath.expanduser`` ignores ``HOME``, so on Windows a
+    global-mode test would install into the developer's real home directory.
+    """
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
     monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION", raising=False)
     return home
 
@@ -157,72 +165,85 @@ class TestDiscoverSkills:
         assert _discover_skills(tmp_path / "does-not-exist") == []
 
 
-class TestProjectInstall:
-    """Tests for project-mode (symlink) installation."""
+class TestSymlinkInstall:
+    """Tests for symlink installation, into a project (default) or the home directory."""
 
-    def test_creates_symlinks_resolving_to_source(self, source_dir: Path, project_dir: Path) -> None:
-        """Project install symlinks each skill into .agents/skills back to the source."""
-        result = install_skills()
+    @pytest.mark.parametrize("global_mode", [False, True])
+    def test_creates_symlinks_resolving_to_source(
+        self, source_dir: Path, project_dir: Path, fake_home: Path, global_mode: bool
+    ) -> None:
+        """Each skill is symlinked into the .agents/skills of the project or the home dir."""
+        result = install_skills(global_mode=global_mode)
 
-        target_dir = project_dir / ".agents" / "skills"
+        target_dir = (fake_home if global_mode else project_dir) / ".agents" / "skills"
         for name in SKILL_NAMES:
             link = target_dir / name
             assert link.is_symlink()
             assert link.resolve() == (source_dir / name).resolve()
         assert len(result.installed) == len(SKILL_NAMES)
 
+    @pytest.mark.parametrize("global_mode", [False, True])
     @pytest.mark.parametrize("claude_present", [True, False])
     def test_claude_dir_targeted_only_when_claude_home_exists(
-        self, source_dir: Path, project_dir: Path, fake_home: Path, claude_present: bool
+        self, source_dir: Path, project_dir: Path, fake_home: Path, claude_present: bool, global_mode: bool
     ) -> None:
         """The .claude/skills target is used only when ~/.claude exists."""
         if claude_present:
             (fake_home / ".claude").mkdir()
 
-        install_skills()
+        install_skills(global_mode=global_mode)
 
-        claude_skill = project_dir / ".claude" / "skills" / SKILL_NAMES[0]
-        assert claude_skill.is_symlink() is claude_present
+        base = fake_home if global_mode else project_dir
+        assert (base / ".claude" / "skills" / SKILL_NAMES[0]).is_symlink() is claude_present
 
-    def test_rerun_is_idempotent(self, source_dir: Path, project_dir: Path) -> None:
-        """Re-running reports all skills up to date and installs nothing new."""
+    @pytest.mark.parametrize("symlinks_supported", [True, False])
+    def test_rerun_is_idempotent(
+        self, source_dir: Path, project_dir: Path, monkeypatch: pytest.MonkeyPatch, symlinks_supported: bool
+    ) -> None:
+        """A second run reports every skill up to date, whether it linked or fell back to copying.
+
+        The fallback case is the interesting one: the first run leaves a real
+        directory in a symlink-mode target, and the second must recognize that copy
+        as its own (byte-identical to the source) rather than skip it as a conflict.
+        """
+        if not symlinks_supported:
+            monkeypatch.setattr("pathlib.Path.symlink_to", _raise_oserror)
+
         install_skills()
         result = install_skills()
 
         assert len(result.installed) == 0
+        assert len(result.skipped) == 0
         assert len(result.up_to_date) == len(SKILL_NAMES)
-        for name in SKILL_NAMES:
-            assert (project_dir / ".agents" / "skills" / name).is_symlink()
 
-    def test_unrelated_existing_file_is_skipped_not_clobbered(self, source_dir: Path, project_dir: Path) -> None:
-        """A pre-existing unrelated file at a target path is left untouched."""
+    @pytest.mark.parametrize("conflict_kind", ["unrelated_file", "user_authored_skill"])
+    def test_conflicting_target_is_skipped_not_clobbered(
+        self, source_dir: Path, project_dir: Path, conflict_kind: str
+    ) -> None:
+        """A conflicting target is left byte-for-byte intact and reported skipped.
+
+        Two separate refusals: an unrelated file is not the installer's to touch at
+        all, while a real skill directory is owned by name but still left alone in
+        symlink mode, because it may be the user's own rather than a prior install.
+        """
         target_dir = project_dir / ".agents" / "skills"
-        target_dir.mkdir(parents=True)
         conflict = target_dir / SKILL_NAMES[0]
-        conflict.write_text("user data", encoding="utf-8")
+        if conflict_kind == "unrelated_file":
+            target_dir.mkdir(parents=True)
+            conflict.write_text("user data", encoding="utf-8")
+            preserved = conflict
+        else:
+            conflict.mkdir(parents=True)
+            (conflict / "SKILL.md").write_text("my own skill", encoding="utf-8")
+            preserved = conflict / "SKILL.md"
+        expected = preserved.read_text(encoding="utf-8")
 
         result = install_skills()
 
-        assert conflict.read_text(encoding="utf-8") == "user data"
+        assert preserved.read_text(encoding="utf-8") == expected
         assert not conflict.is_symlink()
-        assert len(result.skipped) == 1
+        assert result.skipped == [str(conflict.relative_to(project_dir))]
         # The non-conflicting skill still installs.
-        assert (target_dir / SKILL_NAMES[1]).is_symlink()
-
-    def test_existing_real_skill_dir_is_skipped_in_symlink_mode(self, source_dir: Path, project_dir: Path) -> None:
-        """A user's own real skill dir (same name, with SKILL.md) is skipped, not clobbered."""
-        target_dir = project_dir / ".agents" / "skills"
-        user_skill = target_dir / SKILL_NAMES[0]
-        user_skill.mkdir(parents=True)
-        (user_skill / "SKILL.md").write_text("my own skill", encoding="utf-8")
-
-        result = install_skills()
-
-        assert user_skill.is_dir()
-        assert not user_skill.is_symlink()
-        assert (user_skill / "SKILL.md").read_text(encoding="utf-8") == "my own skill"
-        assert str(user_skill.relative_to(project_dir)) in result.skipped
-        # The non-conflicting skill still installs as a symlink.
         assert (target_dir / SKILL_NAMES[1]).is_symlink()
 
     def test_stale_symlink_is_repointed_to_source(self, source_dir: Path, project_dir: Path) -> None:
@@ -240,24 +261,9 @@ class TestProjectInstall:
         assert link.resolve() == (source_dir / SKILL_NAMES[0]).resolve()
         assert str(link.relative_to(project_dir)) in result.installed
 
-    def test_skipped_skill_leaves_no_empty_directory(self, source_dir: Path, project_dir: Path) -> None:
-        """A skill skipped for a conflict does not create its own empty target dir."""
-        target_dir = project_dir / ".agents" / "skills"
-        target_dir.mkdir(parents=True)
-        (target_dir / SKILL_NAMES[0]).write_text("user data", encoding="utf-8")
-
-        install_skills()
-
-        # The conflicting target stays a file; no empty directory replaces it.
-        assert (target_dir / SKILL_NAMES[0]).is_file()
-
-
-class TestCopyFallback:
-    """Tests for the copy fallback when symlinks are unsupported."""
-
     @pytest.mark.parametrize("raiser", [_raise_oserror, _raise_not_implemented])
     def test_copies_directory_when_symlink_unsupported(
-        self, source_dir: Path, project_dir: Path, monkeypatch: pytest.MonkeyPatch, raiser: object
+        self, source_dir: Path, project_dir: Path, monkeypatch: pytest.MonkeyPatch, raiser: Callable[..., NoReturn]
     ) -> None:
         """When creating the symlink raises OSError or NotImplementedError, the skill is copied instead."""
         # Patch Path.symlink_to (what _try_symlink calls), not os.symlink: on Python 3.10 pathlib binds
@@ -272,48 +278,6 @@ class TestCopyFallback:
             assert not target.is_symlink()
             assert (target / "SKILL.md").read_bytes() == (source_dir / name / "SKILL.md").read_bytes()
 
-    def test_rerun_after_copy_fallback_reports_up_to_date(
-        self, source_dir: Path, project_dir: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Re-running after a copy fallback reports the skills up to date, not skipped.
-
-        When symlinks stay unsupported, the first install copies a real directory
-        into the symlink-mode target; a second run must recognize that copy as its
-        own (byte-identical to the source) and report it up to date instead of
-        skipping it as a name conflict.
-        """
-        # Patch the symlink call itself (see test_copies_directory_when_symlink_unsupported).
-        monkeypatch.setattr("pathlib.Path.symlink_to", _raise_oserror)
-
-        install_skills()
-        result = install_skills()
-
-        assert len(result.up_to_date) == len(SKILL_NAMES)
-        assert len(result.skipped) == 0
-        assert len(result.installed) == 0
-
-
-class TestGlobalInstall:
-    """Tests for global-mode installation into home directories."""
-
-    def test_targets_home_agents_dir(self, source_dir: Path, fake_home: Path) -> None:
-        """Global install symlinks skills into ~/.agents/skills."""
-        result = install_skills(global_mode=True)
-
-        for name in SKILL_NAMES:
-            link = fake_home / ".agents" / "skills" / name
-            assert link.is_symlink()
-            assert link.resolve() == (source_dir / name).resolve()
-        assert len(result.installed) == len(SKILL_NAMES)
-
-    def test_targets_home_claude_dir_when_present(self, source_dir: Path, fake_home: Path) -> None:
-        """Global install also targets ~/.claude/skills when Claude Code is present."""
-        (fake_home / ".claude").mkdir()
-
-        install_skills(global_mode=True)
-
-        assert (fake_home / ".claude" / "skills" / SKILL_NAMES[0]).is_symlink()
-
 
 class TestDatabricksInstall:
     """Tests for the Databricks copy-to-Workspace branch."""
@@ -323,94 +287,100 @@ class TestDatabricksInstall:
         """Simulate a Databricks runtime with a redirected persistent workspace root."""
         root = tmp_path / "Workspace"
         (root / "Users" / DATABRICKS_USER).mkdir(parents=True)
-        monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "15.4")
-        monkeypatch.setenv("DATABRICKS_USER", DATABRICKS_USER)
+        monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "17.3")
         monkeypatch.setattr(skills, "_DATABRICKS_WORKSPACE_ROOT", root)
         return root
 
     @pytest.fixture
     def user_skills_dir(self, workspace_root: Path) -> Path:
         """The per-user Genie skills directory install_skills must write to."""
-        return workspace_root / "Users" / DATABRICKS_USER / ".assistant" / "skills"
+        return workspace_root / "Users" / DATABRICKS_USER / DATABRICKS_ASSISTANT_DIR / "skills"
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def spark_session(self, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
-        """Stand in for the Databricks-provided active Spark session."""
+        """Stand in for the Databricks-provided active Spark session, answering current_user()."""
         session = MagicMock()
-        monkeypatch.setattr(SparkSession, "getActiveSession", lambda: session)
+        session.sql.return_value.collect.return_value = [[DATABRICKS_USER]]
+        monkeypatch.setattr(GET_ACTIVE_SESSION, lambda: session)
         return session
 
     def test_copies_to_per_user_assistant_dir(
-        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path
+        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path, spark_session: MagicMock
     ) -> None:
-        """The default install copies (not links) into the user's own workspace .assistant/skills."""
+        """The default install copies (not links) into the workspace home of the current_user()."""
         install_skills()
 
+        assert "current_user()" in spark_session.sql.call_args.args[0]
         for name in SKILL_NAMES:
             target = user_skills_dir / name
             assert target.is_dir()
             assert not target.is_symlink()
             assert (target / "SKILL.md").is_file()
-        # The workspace-wide directory needs admin rights, so a default install
-        # must not touch it.
-        assert not (workspace_root / ".assistant").exists()
+        # The workspace-wide directory needs admin rights.
+        assert not (workspace_root / DATABRICKS_ASSISTANT_DIR).exists()
 
-    def test_global_mode_copies_to_workspace_wide_dir(
-        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path
+    def test_global_mode_is_refused(
+        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path, spark_session: MagicMock
     ) -> None:
-        """Global mode installs into the workspace-wide directory, not the user's home."""
-        install_skills(global_mode=True)
+        """Workspace-wide installs are refused rather than attempted without admin rights."""
+        with pytest.raises(NotImplementedError, match="global_mode"):
+            install_skills(global_mode=True)
 
-        assert (workspace_root / ".assistant" / "skills" / SKILL_NAMES[0] / "SKILL.md").is_file()
+        # Refusing before the session lookup keeps a sessionless caller from being
+        # told to fix the wrong thing.
+        spark_session.sql.assert_not_called()
+        assert not (workspace_root / DATABRICKS_ASSISTANT_DIR).exists()
         assert not user_skills_dir.exists()
 
-    def test_global_mode_does_not_need_the_workspace_user(
+    def test_raises_without_a_spark_session(
         self, source_dir: Path, workspace_root: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The workspace-wide target is user-independent, so an unresolvable user is not an error."""
-        monkeypatch.delenv("DATABRICKS_USER")
+        """With no session to name the user, the install raises instead of guessing a target."""
+        monkeypatch.setattr(GET_ACTIVE_SESSION, lambda: None)
 
-        install_skills(global_mode=True)
-
-        assert (workspace_root / ".assistant" / "skills" / SKILL_NAMES[0]).is_dir()
-
-    def test_user_comes_from_spark_current_user_when_env_unset(
-        self, source_dir: Path, user_skills_dir: Path, spark_session: MagicMock, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Without DATABRICKS_USER, the workspace user is read from Spark's current_user()."""
-        monkeypatch.delenv("DATABRICKS_USER")
-        spark_session.sql.return_value.collect.return_value = [[DATABRICKS_USER]]
-
-        install_skills()
-
-        assert "current_user()" in spark_session.sql.call_args.args[0]
-        assert (user_skills_dir / SKILL_NAMES[0] / "SKILL.md").is_file()
-
-    def test_env_user_overrides_spark_current_user(
-        self, source_dir: Path, user_skills_dir: Path, workspace_root: Path, spark_session: MagicMock
-    ) -> None:
-        """DATABRICKS_USER wins over current_user(), so a wrong detection can be corrected by hand."""
-        (workspace_root / "Users" / "service-principal").mkdir()
-        spark_session.sql.return_value.collect.return_value = [["service-principal"]]
-
-        install_skills()
-
-        assert (user_skills_dir / SKILL_NAMES[0]).is_dir()
-        assert not (workspace_root / "Users" / "service-principal" / ".assistant").exists()
-
-    @pytest.mark.parametrize("user_env", [None, "", "wrong.user@retail.com"])
-    def test_raises_when_workspace_user_cannot_be_resolved(
-        self, source_dir: Path, workspace_root: Path, monkeypatch: pytest.MonkeyPatch, user_env: str | None
-    ) -> None:
-        """An unknown, blank, or non-existent workspace user raises instead of writing to the shared dir."""
-        monkeypatch.delenv("DATABRICKS_USER")
-        if user_env is not None:
-            monkeypatch.setenv("DATABRICKS_USER", user_env)
-
-        with pytest.raises(RuntimeError, match="DATABRICKS_USER"):
+        with pytest.raises(RuntimeError, match="Spark session"):
             install_skills()
 
-        assert not (workspace_root / ".assistant").exists()
+        assert list(workspace_root.rglob(DATABRICKS_ASSISTANT_DIR)) == []
+
+    def test_raises_when_workspace_home_does_not_exist(
+        self, source_dir: Path, workspace_root: Path, spark_session: MagicMock
+    ) -> None:
+        """A username with no workspace home raises rather than creating one the caller may not own."""
+        spark_session.sql.return_value.collect.return_value = [["service-principal-1234"]]
+
+        with pytest.raises(RuntimeError, match="service-principal-1234"):
+            install_skills()
+
+        assert not (workspace_root / "Users" / "service-principal-1234").exists()
+        assert list(workspace_root.rglob(DATABRICKS_ASSISTANT_DIR)) == []
+
+    @pytest.mark.parametrize(
+        "rows",
+        [
+            pytest.param([], id="no-rows"),
+            pytest.param([[""]], id="blank"),
+            pytest.param([[".."]], id="parent-traversal"),
+            # Exists, so only the guard stops the install, and is harmless if it regresses.
+            pytest.param([["/tmp"]], id="absolute"),  # noqa: S108
+            pytest.param([["team/analyst@retail.com"]], id="nested"),
+        ],
+    )
+    def test_raises_when_current_user_is_not_a_workspace_user(
+        self, source_dir: Path, workspace_root: Path, spark_session: MagicMock, rows: list[list[str]]
+    ) -> None:
+        """A blank or path-like current_user() is refused before it is joined into a path.
+
+        Each of these joins to a directory that exists, so the workspace-home check
+        would wave it through: pathlib drops an empty segment, restarts from an
+        absolute one, and keeps ``..``.
+        """
+        spark_session.sql.return_value.collect.return_value = rows
+
+        with pytest.raises(RuntimeError, match="current_user"):
+            install_skills()
+
+        assert list(workspace_root.rglob(DATABRICKS_ASSISTANT_DIR)) == []
 
     def test_rerun_reports_up_to_date_when_copy_matches(self, source_dir: Path, workspace_root: Path) -> None:
         """Re-running on Databricks with unchanged skills reports them up to date."""
@@ -420,9 +390,7 @@ class TestDatabricksInstall:
         assert len(result.installed) == 0
         assert len(result.up_to_date) == len(SKILL_NAMES)
 
-    def test_rerun_refreshes_copy_when_source_changed(
-        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path
-    ) -> None:
+    def test_rerun_refreshes_copy_when_source_changed(self, source_dir: Path, user_skills_dir: Path) -> None:
         """A changed bundled skill is re-copied over the stale Databricks copy."""
         install_skills()
         (source_dir / SKILL_NAMES[0] / "SKILL.md").write_text(
@@ -436,32 +404,22 @@ class TestDatabricksInstall:
         assert "Updated." in target.read_text(encoding="utf-8")
         assert len(result.installed) == 1
 
-    def test_existing_workspace_skill_dir_is_replaced(self, source_dir: Path, user_skills_dir: Path) -> None:
-        """In copy mode the managed Genie skills dir is refreshed, replacing an owned same-name dir.
+    @pytest.mark.parametrize("existing_kind", ["stale_copy", "symlink"])
+    def test_existing_target_is_replaced_by_a_current_copy(
+        self, source_dir: Path, user_skills_dir: Path, existing_kind: str
+    ) -> None:
+        """A stale copy or a leftover symlink at the target is replaced by a real, current copy.
 
-        This is the documented asymmetry with symlink mode: the workspace
-        ``.assistant/skills`` directory is installer-managed, so a same-named
-        directory there is treated as a prior copy and overwritten on re-run.
-        """
-        existing = user_skills_dir / SKILL_NAMES[0]
-        existing.mkdir(parents=True)
-        (existing / "SKILL.md").write_text("stale copy", encoding="utf-8")
-
-        install_skills()
-
-        assert existing.is_dir()
-        assert (existing / "SKILL.md").read_bytes() == (source_dir / SKILL_NAMES[0] / "SKILL.md").read_bytes()
-
-    def test_existing_symlink_is_replaced_with_real_copy(self, source_dir: Path, user_skills_dir: Path) -> None:
-        """In copy mode an owned symlink at the target is unlinked and replaced by a real copy.
-
-        A prior symlink-mode install (or a hand-made link) can leave a symlink at
-        a Databricks target. Copy mode must not keep it: it unlinks the symlink
-        and copies the skill so the result survives the package being wiped.
+        It must end up a real directory: a symlink would point back into the package
+        that a cluster restart wipes.
         """
         target = user_skills_dir / SKILL_NAMES[0]
         target.parent.mkdir(parents=True)
-        target.symlink_to(source_dir / SKILL_NAMES[0])
+        if existing_kind == "stale_copy":
+            target.mkdir()
+            (target / "SKILL.md").write_text("stale copy", encoding="utf-8")
+        else:
+            target.symlink_to(source_dir / SKILL_NAMES[0])
 
         install_skills()
 
@@ -485,11 +443,11 @@ class TestBundledSkill:
 
     def test_shipped_skill_is_discoverable(self) -> None:
         """The real bundled skill is discovered from the installed package."""
-        assert "using-openretailscience" in _discover_skills(_get_source_skills_dir())
+        assert SHIPPED_SKILL_NAME in _discover_skills(_get_source_skills_dir())
 
     def test_shipped_skill_frontmatter_is_valid(self) -> None:
         """The shipped SKILL.md has YAML frontmatter with matching name and a description."""
-        skill_md = _get_source_skills_dir() / "using-openretailscience" / "SKILL.md"
+        skill_md = _get_source_skills_dir() / SHIPPED_SKILL_NAME / "SKILL.md"
         text = skill_md.read_text(encoding="utf-8")
 
         match = FRONTMATTER_RE.match(text)
@@ -498,7 +456,7 @@ class TestBundledSkill:
 
         name_match = re.search(r"^name:\s*(\S+)", block, re.MULTILINE)
         assert name_match is not None
-        assert name_match.group(1) == "using-openretailscience"
+        assert name_match.group(1) == SHIPPED_SKILL_NAME
 
         assert "description:" in block
         # The description is a YAML folded scalar (``>-``) with its body on the
@@ -507,16 +465,21 @@ class TestBundledSkill:
         description_body = block.split("description:", 1)[1].replace(">-", " ").strip()
         assert len(description_body) >= MIN_DESCRIPTION_LENGTH
 
-    def test_referenced_files_exist(self) -> None:
-        """Every references/*.md path the shipped skill points at exists on disk."""
+    def test_every_reference_file_is_linked_and_every_link_resolves(self) -> None:
+        """The reference files the skill links to are exactly the ones on disk.
+
+        Equality catches drift in both directions: a link to a file that was renamed
+        or deleted, and a reference file no agent will ever be pointed at.
+        """
         skill_root = _get_source_skills_dir() / SHIPPED_SKILL_NAME
         referenced: set[str] = set()
         for md_file in _shipped_skill_markdown():
             referenced.update(REFERENCE_RE.findall(md_file.read_text(encoding="utf-8")))
 
-        assert len(referenced) >= MIN_REFERENCE_FILES, "SKILL.md should link to its reference files"
-        for rel in sorted(referenced):
-            assert (skill_root / rel).is_file(), f"skill references a missing file: {rel}"
+        # as_posix(): the links are written with forward slashes on every platform.
+        on_disk = {path.relative_to(skill_root).as_posix() for path in (skill_root / "references").rglob("*.md")}
+        assert len(on_disk) >= MIN_REFERENCE_FILES
+        assert referenced == on_disk
 
     def test_import_examples_resolve_against_the_package(self) -> None:
         """Every openretailscience import the skill teaches still resolves.
@@ -528,36 +491,43 @@ class TestBundledSkill:
         statements = _skill_import_statements()
         assert len(statements) >= MIN_IMPORT_EXAMPLES, "skill should teach many concrete imports"
         failures = [msg for statement in statements if (msg := _import_error(statement)) is not None]
-        assert not failures, "skill imports no longer resolve:\n" + "\n".join(failures)
+        assert len(failures) == 0, "skill imports no longer resolve:\n" + "\n".join(failures)
 
 
 class TestFindProjectRoot:
     """Unit tests for _find_project_root."""
 
-    def test_returns_git_root_from_subdirectory(self, tmp_path: Path, fake_home: Path) -> None:
-        """A .git ancestor is used as the project root."""
+    @pytest.mark.parametrize(
+        ("markers", "root_is_ancestor"),
+        [
+            pytest.param([".git"], True, id="git-ancestor"),
+            pytest.param([".agents"], True, id="agents-ancestor"),
+            pytest.param([".claude"], True, id="claude-ancestor"),
+            pytest.param([], False, id="no-markers"),
+        ],
+    )
+    def test_marker_on_an_ancestor_selects_the_root(
+        self, tmp_path: Path, fake_home: Path, markers: list[str], root_is_ancestor: bool
+    ) -> None:
+        """Any of .git, .agents or .claude on an ancestor makes it the root; without one, the start dir is."""
         repo = tmp_path / "repo"
-        (repo / ".git").mkdir(parents=True)
         sub = repo / "pkg"
-        sub.mkdir()
+        sub.mkdir(parents=True)
+        for marker in markers:
+            (repo / marker).mkdir()
 
-        assert _find_project_root(sub) == repo
+        assert _find_project_root(sub) == (repo if root_is_ancestor else sub)
 
-    def test_agents_ancestor_wins_over_git_walk(self, tmp_path: Path, fake_home: Path) -> None:
-        """An existing .agents dir on an ancestor is preferred as the root."""
+    def test_agents_ancestor_wins_over_a_nearer_git_root(self, tmp_path: Path, fake_home: Path) -> None:
+        """A .agents marker outranks a .git directory found closer to the start dir."""
         root = tmp_path / "proj"
         (root / ".agents").mkdir(parents=True)
-        sub = root / "nested"
-        sub.mkdir()
-
-        assert _find_project_root(sub) == root
-
-    def test_falls_back_to_start_dir_without_markers(self, tmp_path: Path, fake_home: Path) -> None:
-        """With no .agents/.claude/.git found, the start dir itself is returned."""
-        start = tmp_path / "loose"
+        nested = root / "nested"
+        (nested / ".git").mkdir(parents=True)
+        start = nested / "pkg"
         start.mkdir()
 
-        assert _find_project_root(start) == start
+        assert _find_project_root(start) == root
 
     def test_never_crosses_into_home(self, fake_home: Path) -> None:
         """A marker at the home directory is ignored; the search stops at that boundary."""
@@ -571,47 +541,45 @@ class TestFindProjectRoot:
 class TestSkillCopyMatches:
     """Unit tests for _skill_copy_matches."""
 
-    def test_true_for_identical_trees(self, tmp_path: Path) -> None:
-        """Two directories with the same files and bytes match."""
-        source = _make_bare_skill(tmp_path / "src", "s")
-        target = _make_bare_skill(tmp_path / "dst", "s")
-        assert _skill_copy_matches(source, target) is True
+    @pytest.mark.parametrize("nested_reference", [False, True], ids=["flat", "with-references-dir"])
+    def test_true_for_identical_trees(self, tmp_path: Path, nested_reference: bool) -> None:
+        """Identical trees match, including every file of a nested references directory."""
+        source = _make_bare_skill(tmp_path / "src", SKILL_NAMES[0])
+        target = _make_bare_skill(tmp_path / "dst", SKILL_NAMES[0])
+        if nested_reference:
+            for root in (source, target):
+                (root / "references").mkdir()
+                (root / "references" / "plotting.md").write_text("# Plotting\n", encoding="utf-8")
 
-    def test_true_for_identical_multi_file_trees(self, tmp_path: Path) -> None:
-        """A match iterates every file (including a nested references dir) and returns True."""
-        source = _make_bare_skill(tmp_path / "src", "s")
-        target = _make_bare_skill(tmp_path / "dst", "s")
-        for root in (source, target):
-            (root / "references").mkdir()
-            (root / "references" / "guide.md").write_text("shared body", encoding="utf-8")
         assert _skill_copy_matches(source, target) is True
 
     def test_false_when_target_is_not_a_directory(self, tmp_path: Path) -> None:
         """A non-directory target never matches."""
-        source = _make_bare_skill(tmp_path / "src", "s")
-        target = tmp_path / "a-file"
-        target.write_text("x", encoding="utf-8")
+        source = _make_bare_skill(tmp_path / "src", SKILL_NAMES[0])
+        target = tmp_path / SKILL_NAMES[0]
+        target.write_text("# Retail metrics\n", encoding="utf-8")
         assert _skill_copy_matches(source, target) is False
 
     def test_false_when_file_sets_differ(self, tmp_path: Path) -> None:
-        """Different relative file sets do not match."""
-        source = _make_bare_skill(tmp_path / "src", "s")
-        (source / "extra.md").write_text("more", encoding="utf-8")
-        target = _make_bare_skill(tmp_path / "dst", "s")
+        """A file present only in the source means no match."""
+        source = _make_bare_skill(tmp_path / "src", SKILL_NAMES[0])
+        (source / "references").mkdir()
+        (source / "references" / "plotting.md").write_text("# Plotting\n", encoding="utf-8")
+        target = _make_bare_skill(tmp_path / "dst", SKILL_NAMES[0])
         assert _skill_copy_matches(source, target) is False
 
     def test_false_when_bytes_differ(self, tmp_path: Path) -> None:
-        """Same file names but different bytes do not match."""
-        source = _make_bare_skill(tmp_path / "src", "s", body=b"one")
-        target = _make_bare_skill(tmp_path / "dst", "s", body=b"two")
+        """Same file names but different content means no match."""
+        source = _make_bare_skill(tmp_path / "src", SKILL_NAMES[0], body=b"# Retail metrics\n")
+        target = _make_bare_skill(tmp_path / "dst", SKILL_NAMES[0], body=b"# Retail metrics, revised\n")
         assert _skill_copy_matches(source, target) is False
 
     def test_false_on_file_versus_directory_mismatch(self, tmp_path: Path) -> None:
-        """A path that is a file in source but a directory in target returns False, not raises."""
-        source = _make_bare_skill(tmp_path / "src", "s")
-        (source / "refs").write_text("a file", encoding="utf-8")
-        target = _make_bare_skill(tmp_path / "dst", "s")
-        (target / "refs").mkdir()
+        """A path that is a file in the source but a directory in the target returns False, not raises."""
+        source = _make_bare_skill(tmp_path / "src", SKILL_NAMES[0])
+        (source / "references").write_text("not a directory", encoding="utf-8")
+        target = _make_bare_skill(tmp_path / "dst", SKILL_NAMES[0])
+        (target / "references").mkdir()
         assert _skill_copy_matches(source, target) is False
 
 
@@ -620,30 +588,50 @@ class TestIsOwnedTarget:
 
     def test_false_for_unbundled_name(self, tmp_path: Path) -> None:
         """A directory whose name is not a bundled skill is never owned."""
-        other = _make_bare_skill(tmp_path, "other-skill")
-        assert _is_owned_target(other, {"using-openretailscience"}) is False
+        other = _make_bare_skill(tmp_path, "my-own-skill")
+        assert _is_owned_target(other, {SHIPPED_SKILL_NAME}) is False
 
     def test_true_for_symlink_with_bundled_name(self, tmp_path: Path) -> None:
         """A symlink named after a bundled skill is owned."""
         real = tmp_path / "real"
         real.mkdir()
-        link = tmp_path / "using-openretailscience"
+        link = tmp_path / SHIPPED_SKILL_NAME
         link.symlink_to(real, target_is_directory=True)
-        assert _is_owned_target(link, {"using-openretailscience"}) is True
+        assert _is_owned_target(link, {SHIPPED_SKILL_NAME}) is True
 
     def test_false_for_real_dir_without_marker(self, tmp_path: Path) -> None:
-        """A real directory with a bundled name but no SKILL.md is not owned."""
-        directory = tmp_path / "using-openretailscience"
+        """A real directory with a bundled name but no SKILL.md is user content, not ours."""
+        directory = tmp_path / SHIPPED_SKILL_NAME
         directory.mkdir()
-        assert _is_owned_target(directory, {"using-openretailscience"}) is False
+        assert _is_owned_target(directory, {SHIPPED_SKILL_NAME}) is False
+
+    def test_true_for_real_dir_with_marker(self, tmp_path: Path) -> None:
+        """A real directory with a bundled name and a SKILL.md is a prior copy install.
+
+        This is the branch that authorizes deleting an existing tree.
+        """
+        prior_copy = _make_bare_skill(tmp_path, SHIPPED_SKILL_NAME)
+        assert _is_owned_target(prior_copy, {SHIPPED_SKILL_NAME}) is True
 
 
 class TestRelativeSymlinkTarget:
     """Unit tests for _relative_symlink_target."""
 
+    def test_returns_a_relative_path_that_rejoins_to_the_source(self, tmp_path: Path) -> None:
+        """The link target is relative, which is what lets the tree survive being relocated."""
+        source = tmp_path / "site-packages" / "openretailscience" / SHIPPED_SKILL_NAME
+        source.mkdir(parents=True)
+        target = tmp_path / "project" / ".agents" / "skills" / SHIPPED_SKILL_NAME
+        target.parent.mkdir(parents=True)
+
+        result = _relative_symlink_target(source, target)
+
+        assert not PurePath(result).is_absolute()
+        assert os.path.realpath(target.parent / result) == os.path.realpath(source)
+
     @pytest.mark.parametrize("raiser", [_raise_value_error, _raise_oserror])
     def test_falls_back_to_absolute_source_on_relpath_error(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, raiser: object
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, raiser: Callable[..., NoReturn]
     ) -> None:
         """A ValueError (cross-drive) or OSError while computing the relative path falls back."""
         source = tmp_path / "src"
@@ -658,63 +646,62 @@ class TestRelativeSymlinkTarget:
 class TestInstallSkillsErrors:
     """Error paths for install_skills when the bundled source is missing or empty."""
 
-    def test_missing_source_dir_raises(self, tmp_path: Path, fake_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A missing bundled skills directory raises FileNotFoundError."""
-        missing = tmp_path / "nope" / ".agents" / "skills"
-        monkeypatch.setattr(skills, "_get_source_skills_dir", lambda: missing)
+    @pytest.mark.parametrize(
+        ("source_exists", "expected_error", "match"),
+        [
+            pytest.param(False, FileNotFoundError, "Bundled skills directory", id="missing-source-dir"),
+            pytest.param(True, RuntimeError, "No installable skills", id="empty-source-dir"),
+        ],
+    )
+    def test_unusable_source_dir_raises(
+        self,
+        tmp_path: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        source_exists: bool,
+        expected_error: type[Exception],
+        match: str,
+    ) -> None:
+        """A bundled skills directory that is missing, or present but empty, fails loudly."""
+        source = tmp_path / "src" / ".agents" / "skills"
+        if source_exists:
+            source.mkdir(parents=True)
+        monkeypatch.setattr(skills, "_get_source_skills_dir", lambda: source)
 
-        with pytest.raises(FileNotFoundError, match="Bundled skills directory"):
+        with pytest.raises(expected_error, match=match):
             install_skills()
 
-    def test_empty_source_dir_raises(self, tmp_path: Path, fake_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A bundled skills directory that exists but holds no valid skills raises RuntimeError."""
-        empty = tmp_path / "src" / ".agents" / "skills"
-        empty.mkdir(parents=True)
-        monkeypatch.setattr(skills, "_get_source_skills_dir", lambda: empty)
 
-        with pytest.raises(RuntimeError, match="No installable skills"):
-            install_skills()
+def _example_scripts_dir() -> Path:
+    """Return the directory holding the shipped skill's example scripts."""
+    return _get_source_skills_dir() / SHIPPED_SKILL_NAME / "scripts"
 
 
 def _example_scripts() -> list[Path]:
     """Return every runnable example script bundled with the shipped skill."""
-    scripts_dir = _get_source_skills_dir() / SHIPPED_SKILL_NAME / "scripts"
-    return sorted(scripts_dir.glob("example_*.py"))
-
-
-def test_example_scripts_are_discovered() -> None:
-    """The drift guard must actually find the shipped scripts.
-
-    An empty glob makes the parametrized ``test_example_script_runs`` collect zero
-    cases and pass silently, disabling the guard; pin a floor so truncation fails.
-    """
-    assert len(_example_scripts()) >= MIN_EXAMPLE_SCRIPTS
+    return sorted(_example_scripts_dir().glob("example_*.py"))
 
 
 class TestExampleScripts:
     """Every bundled example script must run against the installed package.
 
-    This is the drift guard: if a public API a script demonstrates is renamed or
-    removed, that script fails here instead of silently teaching an agent a broken
-    pattern. Execution is required because the failures the scripts can hide
-    (missing DataFrame columns, removed functions, changed signatures) only
-    surface at runtime, not at import or lint time.
+    This is the drift guard: a script demonstrating a renamed or removed API fails
+    here instead of silently teaching an agent a broken pattern. It has to execute,
+    because what the scripts hide (missing DataFrame columns, changed signatures)
+    only surfaces at runtime.
 
     Scripts run in-process with runpy so the heavy openretailscience / matplotlib
-    imports load once and are reused across every script, instead of paying a cold
-    interpreter start per script.
+    imports load once instead of per script.
     """
 
     @pytest.fixture(autouse=True)
     def _script_sandbox(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
         """Sandbox each in-process script run.
 
-        All scripts share one interpreter, so snapshot and restore the global
-        options and clear matplotlib figures around every run: one script must not
-        leak configuration into, or observe stray figures from, another. Restoring
-        the prior option values (rather than resetting to library defaults) keeps
-        the class from clobbering any project/session configuration. Plots render
-        headless and any generated PNGs land in a temp directory, not the repo.
+        All scripts share one interpreter, so no script may leak options into, or
+        observe stray figures from, another. Options are restored to their prior
+        values rather than library defaults, so a project or session configuration
+        survives. Plots render headless into a temp directory, not the repo.
         """
         saved_options = {option: get_option(option) for option in list_options()}
         monkeypatch.setenv("MPLBACKEND", "Agg")
@@ -732,7 +719,21 @@ class TestExampleScripts:
         for option, value in saved_options.items():
             set_option(option, value)
 
+    def test_every_bundled_script_is_collected(self) -> None:
+        """Every .py file shipped in scripts/ is picked up by the drift guard.
+
+        The guard is parametrized over a glob, so a script renamed off the
+        ``example_*`` pattern would drop out of the suite without failing anything.
+        """
+        collected = _example_scripts()
+
+        assert len(collected) >= MIN_EXAMPLE_SCRIPTS
+        assert {path.name for path in collected} == {path.name for path in _example_scripts_dir().glob("*.py")}
+
     @pytest.mark.parametrize("script", _example_scripts(), ids=lambda p: p.name)
     def test_example_script_runs(self, script: Path) -> None:
         """The example script runs end-to-end against the installed package."""
-        runpy.run_path(str(script), run_name="__main__")
+        namespace = runpy.run_path(str(script), run_name="__main__")
+
+        # Catches a script reduced to its docstring: it runs clean and binds nothing.
+        assert len([name for name in namespace if not name.startswith("__")]) > 0

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -331,21 +331,39 @@ class TestDatabricksInstall:
         """The per-user Genie skills directory install_skills must write to."""
         return workspace_root / "Users" / DATABRICKS_USER / ".assistant" / "skills"
 
-    @pytest.mark.parametrize("global_mode", [False, True])
     def test_copies_to_per_user_assistant_dir(
-        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path, global_mode: bool
+        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path
     ) -> None:
-        """Both modes copy (not link) into the user's own workspace .assistant/skills."""
-        install_skills(global_mode=global_mode)
+        """The default install copies (not links) into the user's own workspace .assistant/skills."""
+        install_skills()
 
         for name in SKILL_NAMES:
             target = user_skills_dir / name
             assert target.is_dir()
             assert not target.is_symlink()
             assert (target / "SKILL.md").is_file()
-        # The shared workspace-root directory needs admin rights: writing there is
-        # what raised 403 PERMISSION_DENIED for non-admin users.
+        # The workspace-wide directory needs admin rights: writing there by default
+        # is what raised 403 PERMISSION_DENIED for non-admin users.
         assert not (workspace_root / ".assistant").exists()
+
+    def test_global_mode_copies_to_workspace_wide_dir(
+        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path
+    ) -> None:
+        """Global mode installs for the whole workspace, which only admins may write to."""
+        install_skills(global_mode=True)
+
+        assert (workspace_root / ".assistant" / "skills" / SKILL_NAMES[0] / "SKILL.md").is_file()
+        assert not user_skills_dir.exists()
+
+    def test_global_mode_does_not_need_the_workspace_user(
+        self, source_dir: Path, workspace_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The workspace-wide target is user-independent, so an unresolvable user is not an error."""
+        monkeypatch.delenv("DATABRICKS_USER")
+
+        install_skills(global_mode=True)
+
+        assert (workspace_root / ".assistant" / "skills" / SKILL_NAMES[0]).is_dir()
 
     def test_user_is_derived_from_workspace_cwd_when_env_unset(
         self, source_dir: Path, workspace_root: Path, user_skills_dir: Path, monkeypatch: pytest.MonkeyPatch

--- a/uv.lock
+++ b/uv.lock
@@ -2028,7 +2028,7 @@ wheels = [
 
 [[package]]
 name = "openretailscience"
-version = "0.47.0"
+version = "0.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Problem

`install_skills()` failed on Databricks for any user without workspace admin rights:

```
AsyncFlushFaliedException: One or more writes may have failed when writing to Databricks Workspace.
: wsfs/workspace/workspace.go:1377 Error(message=HTTP Request failed, dest=CP, api=POST 2.0/workspace/mkdirs,
  errno=permission denied, statusCode=403, stack=<nil>)
 -> 403 Forbidden: PERMISSION_DENIED: <user> does not have View permissions on 0.
```

The default (project) mode targeted `/Workspace/.assistant/skills`, the workspace-wide directory that only
admins may write to. The per-user directory was reachable only via `global_mode=True`, and even that fell
back to the shared directory whenever the user could not be determined. The 403 surfaced as an
`AsyncFlushFailedException` because the `/Workspace` FUSE mount flushes writes asynchronously, so the
traceback named a flush rather than the rejected `mkdirs`.

## Change

| `global_mode` | Databricks behaviour |
| --- | --- |
| `False` (default) | copies into `/Workspace/Users/<you>/.assistant/skills/`, the caller's own workspace home |
| `True` | raises `NotImplementedError` |

- The default install goes to the caller's own workspace home. The workspace-wide directory is no longer a
  target at all: it needs admin rights, and a single shared copy cannot match the package version each user
  has pip-installed.
- The workspace username comes from Spark's `current_user()`, so an ordinary `install_skills()` needs no
  configuration. Databricks does not set `DATABRICKS_USER` (see the probe below), so detection is
  load-bearing rather than decorative.
- `current_user()` is validated before it is joined into a path. A blank, `..`, absolute or multi-segment
  value would otherwise retarget a directory that exists — the shared `Users` root, the admin-only workspace
  root, or a path outside `/Workspace` — and the workspace-home check would wave it through.
- Anything unresolvable raises with the path it tried, rather than silently installing somewhere the caller
  may not own. That includes no active Spark session (a cluster init script or bare Python job) and an
  identity with no workspace home, such as a job running as a service principal.

## Verified on Databricks

Probed manually on DBR 17.3 / pyspark 4.0.0 (identifiers anonymised):

```
pyspark version   : 4.0.0
runtime           : 17.3
DATABRICKS_USER   : None
notebook `spark`  : pyspark.sql.connect.session.SparkSession
getActiveSession  : pyspark.sql.connect.session.SparkSession
current_user()    : 'analyst@example.com'
home is a dir     : True -> /Workspace/Users/analyst@example.com
write + readback  : OK
```

Each line confirms an assumption this PR rests on: `getActiveSession()` returns the session (pyspark 4.0
unifies the classic and Spark Connect APIs, so no Connect-specific fallback is needed); `current_user()`
returns the workspace email, which matches the folder name under `/Workspace/Users/`; `DATABRICKS_USER` is
unset, so the environment variable the old code consulted was never going to resolve anyone; and a
create-write-readback cycle under the user's own home succeeds, exercising the same flush that produced the
403.

## Testing

95 tests in `tests/test_skills.py`, written red first, with `openretailscience/skills.py` at full line and
branch coverage; ruff check and format clean. They cover the default landing in the per-user directory and
never creating `/Workspace/.assistant`, the `global_mode` refusal happening before the Spark lookup, the
degenerate `current_user()` values above, the no-session and missing-workspace-home failures, and re-run
idempotence across the symlink, copy-fallback and Databricks paths.

Those tests run against a temp directory standing in for `/Workspace` and a mocked Spark session, so they
pin this repo's own wiring rather than Databricks behaviour — the manual probe above is what evidences the
Databricks side. #543 tracks closing that gap with a `databricks-integration.yml` workflow alongside the
existing per-backend integration suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)