### PR TITLE
test(databricks): add Databricks integration tests and on-platform skills coverage

### DIFF
--- a/.github/workflows/bigquery-integration.yml
+++ b/.github/workflows/bigquery-integration.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          uv sync --locked
+          uv sync --locked --group integration
 
       - name: Set up GCP Authentication
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0

--- a/.github/workflows/databricks-integration.yml
+++ b/.github/workflows/databricks-integration.yml
@@ -1,0 +1,231 @@
+name: Databricks Integration Tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      GCP_SA_KEY:
+        required: true
+      GCP_INFRA_PROJECT_ID:
+        required: true
+      DATABRICKS_CI_HOST:
+        required: true
+      DATABRICKS_CI_CLIENT_ID:
+        required: true
+      DATABRICKS_CI_HTTP_PATH:
+        required: true
+      DATABRICKS_CI_CATALOG:
+        required: true
+      DATABRICKS_CI_SCHEMA:
+        required: true
+
+permissions:
+  contents: read
+
+# install_skills writes to one path per identity, so two runs as the same service principal
+# would delete each other's copies mid-test. Queue rather than cancel: a cancelled run
+# leaves its staged files behind.
+concurrency:
+  group: databricks-integration
+  cancel-in-progress: false
+
+jobs:
+  integration-tests:
+    name: Run Databricks Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+
+      - name: Install Dependencies
+        run: |
+          uv sync --locked --group integration
+
+      - name: Set up GCP Authentication
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Fetch Databricks OAuth Secret
+        env:
+          GCP_INFRA_PROJECT_ID: ${{ secrets.GCP_INFRA_PROJECT_ID }}
+        run: |
+          secret=$(gcloud secrets versions access latest \
+            --secret=databricks-oauth-secret \
+            --project="$GCP_INFRA_PROJECT_ID")
+          echo "::add-mask::$secret"
+          # Delimited form: a bare KEY=VALUE lets a secret containing a newline inject
+          # further environment variables into every later step.
+          {
+            echo "DATABRICKS_CLIENT_SECRET<<GH_ENV_EOF"
+            echo "$secret"
+            echo "GH_ENV_EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Run Integration Tests
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_CI_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CI_CLIENT_ID }}
+          DATABRICKS_CI_HTTP_PATH: ${{ secrets.DATABRICKS_CI_HTTP_PATH }}
+          DATABRICKS_CI_CATALOG: ${{ secrets.DATABRICKS_CI_CATALOG }}
+          DATABRICKS_CI_SCHEMA: ${{ secrets.DATABRICKS_CI_SCHEMA }}
+        run: |
+          uv run pytest tests/integration -k "databricks" -v
+
+  skills-install-tests:
+    name: Run install_skills() On Databricks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+
+      # The job installs this wheel, so the run tests the working tree, not the last PyPI release.
+      - name: Build Wheel
+        run: uv build --wheel
+
+      - name: Install Databricks CLI
+        uses: databricks/setup-cli@8b7b124dc4f5b9621e959ea61cf4d3dd4e421f67 # v1.9.0
+
+      - name: Set up GCP Authentication
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Fetch Databricks OAuth Secret
+        env:
+          GCP_INFRA_PROJECT_ID: ${{ secrets.GCP_INFRA_PROJECT_ID }}
+        run: |
+          secret=$(gcloud secrets versions access latest \
+            --secret=databricks-oauth-secret \
+            --project="$GCP_INFRA_PROJECT_ID")
+          echo "::add-mask::$secret"
+          # Delimited form: a bare KEY=VALUE lets a secret containing a newline inject
+          # further environment variables into every later step.
+          {
+            echo "DATABRICKS_CLIENT_SECRET<<GH_ENV_EOF"
+            echo "$secret"
+            echo "GH_ENV_EOF"
+          } >> "$GITHUB_ENV"
+
+      # A notebook, not a python_file task: only a notebook has the pre-created Spark session
+      # install_skills looks for, and %pip byte-compiles the skill the way a user's install does.
+      - name: Run Workspace Skill Tests On Serverless Compute
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_CI_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CI_CLIENT_ID }}
+          DATABRICKS_CI_CATALOG: ${{ secrets.DATABRICKS_CI_CATALOG }}
+          DATABRICKS_CI_SCHEMA: ${{ secrets.DATABRICKS_CI_SCHEMA }}
+        run: |
+          set -euo pipefail
+          staging="/Volumes/${DATABRICKS_CI_CATALOG}/${DATABRICKS_CI_SCHEMA}/test_data/ci/${GITHUB_RUN_ID}"
+          notebook_dir="/Users/${DATABRICKS_CLIENT_ID}/ci/${GITHUB_RUN_ID}"
+          wheel=$(basename "$(ls dist/*.whl)")
+
+          # Recorded only once it exists, so the cleanup step never chases a path that was
+          # never created. --overwrite because GITHUB_RUN_ID is stable across re-runs.
+          databricks fs mkdir "dbfs:${staging}"
+          echo "STAGING_DIR=$staging" >> "$GITHUB_ENV"
+          databricks fs cp --overwrite "dist/${wheel}" "dbfs:${staging}/${wheel}"
+          databricks fs cp --overwrite tests/integration/test_workspace_skills.py \
+            "dbfs:${staging}/test_workspace_skills.py"
+
+          cat > runner.py <<NOTEBOOK
+          # Databricks notebook source
+          # MAGIC %pip install ${staging}/${wheel} pytest
+
+          # COMMAND ----------
+
+          # MAGIC %restart_python
+
+          # COMMAND ----------
+
+          import contextlib
+          import io
+          import os
+          import shutil
+          import tempfile
+
+          import pytest
+
+          # The one assertion outside the test module, because inside it this is the skip
+          # condition: serverless failing to set it would skip every test and report success.
+          assert "DATABRICKS_RUNTIME_VERSION" in os.environ
+
+          # Copied to local disk: pytest probes up the tree for a rootdir config file, and
+          # stat-ing one on the volume mount raises OSError 22 rather than reporting it absent.
+          local_test = shutil.copy("${staging}/test_workspace_skills.py", tempfile.mkdtemp())
+
+          report = io.StringIO()
+          with contextlib.redirect_stdout(report):
+              exit_code = pytest.main([local_test, "-v", "-p", "no:cacheprovider"])
+          if exit_code != 0:
+              raise RuntimeError(f"pytest exited {exit_code}\n{report.getvalue()}")
+
+          # Cell output is not retrievable after the run; the exported value is, so it is
+          # what the CI step below prints.
+          dbutils.notebook.exit(report.getvalue().strip().splitlines()[-1])
+          NOTEBOOK
+
+          databricks workspace mkdirs "$notebook_dir"
+          echo "NOTEBOOK_DIR=$notebook_dir" >> "$GITHUB_ENV"
+          databricks workspace import --overwrite --file runner.py --format SOURCE --language PYTHON \
+            "${notebook_dir}/run_skills_tests"
+
+          # Notebook tasks take their libraries from %pip, so there is no environment block:
+          # serverless is what a job gets when no cluster is specified.
+          jq -n \
+            --arg notebook "${notebook_dir}/run_skills_tests" \
+            --arg name "openretailscience install_skills ${GITHUB_RUN_ID}" \
+            '{
+              run_name: $name,
+              tasks: [{task_key: "install_skills", notebook_task: {notebook_path: $notebook}}]
+            }' > run.json
+
+          databricks jobs submit --json @run.json --output json > result.json
+          jq . result.json
+          # The submit response carries no notebook output, so the pytest report comes from
+          # the run-output endpoint instead.
+          databricks jobs get-run-output "$(jq -r '.tasks[0].run_id' result.json)" || true
+          # The CLI does not fail every unsuccessful run, so the result state decides.
+          state=$(jq -r '.status.termination_details.type // .state.result_state // "UNKNOWN"' result.json)
+          if [ "$state" != "SUCCESS" ]; then
+            echo "::error::Databricks run finished as $state; see the run output above."
+            exit 1
+          fi
+
+      - name: Clean Up Staged Files
+        if: always()
+        env:
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_CI_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CI_CLIENT_ID }}
+        run: |
+          if [ -n "${STAGING_DIR:-}" ]; then
+            databricks fs rm --recursive "dbfs:${STAGING_DIR}"
+          fi
+          if [ -n "${NOTEBOOK_DIR:-}" ]; then
+            databricks workspace delete --recursive "$NOTEBOOK_DIR"
+          fi

--- a/.github/workflows/oracle-integration.yml
+++ b/.github/workflows/oracle-integration.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          uv sync --locked
+          uv sync --locked --group integration
 
       # Oracle 23ai Free (the supported LTS); the Compose file pins the gvenzl image.
       - name: Start Oracle

--- a/.github/workflows/pyspark-integration.yml
+++ b/.github/workflows/pyspark-integration.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          uv sync --locked
+          uv sync --locked --group integration
 
       - name: Run Integration Tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,18 @@ jobs:
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
 
+  databricks-integration-tests:
+    name: Databricks Integration Tests
+    uses: ./.github/workflows/databricks-integration.yml
+    secrets:
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+      GCP_INFRA_PROJECT_ID: ${{ secrets.GCP_INFRA_PROJECT_ID }}
+      DATABRICKS_CI_HOST: ${{ secrets.DATABRICKS_CI_HOST }}
+      DATABRICKS_CI_CLIENT_ID: ${{ secrets.DATABRICKS_CI_CLIENT_ID }}
+      DATABRICKS_CI_HTTP_PATH: ${{ secrets.DATABRICKS_CI_HTTP_PATH }}
+      DATABRICKS_CI_CATALOG: ${{ secrets.DATABRICKS_CI_CATALOG }}
+      DATABRICKS_CI_SCHEMA: ${{ secrets.DATABRICKS_CI_SCHEMA }}
+
   pyspark-integration-tests:
     name: PySpark Integration Tests
     uses: ./.github/workflows/pyspark-integration.yml
@@ -108,7 +120,16 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [security-audit, pre-commit, bigquery-integration-tests, pyspark-integration-tests, snowflake-integration-tests, sqlserver-integration-tests, oracle-integration-tests, multi-python-tests]
+    needs:
+      - security-audit
+      - pre-commit
+      - bigquery-integration-tests
+      - databricks-integration-tests
+      - pyspark-integration-tests
+      - snowflake-integration-tests
+      - sqlserver-integration-tests
+      - oracle-integration-tests
+      - multi-python-tests
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/snowflake-integration.yml
+++ b/.github/workflows/snowflake-integration.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          uv sync --locked
+          uv sync --locked --group integration
 
       - name: Set up GCP Authentication
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0

--- a/.github/workflows/sqlserver-integration.yml
+++ b/.github/workflows/sqlserver-integration.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          uv sync --locked
+          uv sync --locked --group integration
 
       - name: Install Microsoft ODBC Driver 18
         run: |

--- a/README.md
+++ b/README.md
@@ -258,9 +258,8 @@ tox -p auto
 ### Integration Tests
 
 Integration tests verify that all analysis modules work correctly across different backends: distributed computing
-engines (PySpark, BigQuery, Snowflake) and relational databases (SQL Server, Oracle). These tests ensure the
-Ibis-based code paths function properly across different execution environments. SQL Server and Oracle run against
-throwaway Docker containers, so they execute the same way locally and in CI.
+engines (PySpark, BigQuery, Snowflake, Databricks) and relational databases (SQL Server, Oracle). These tests ensure
+the Ibis-based code paths function properly across different execution environments.
 
 #### PySpark Integration Tests
 
@@ -268,7 +267,7 @@ The PySpark integration tests run locally using the same pytest framework as oth
 
 **Prerequisites:**
 
-- Python environment with dependencies installed (`uv sync`)
+- Python environment with the backend drivers installed (`uv sync --group integration`)
 
 **Running locally:**
 
@@ -298,8 +297,8 @@ The BigQuery integration tests verify compatibility with Google BigQuery as a ba
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/service-account-key.json
 export GCP_PROJECT_ID=your-project-id
 
-# Install dependencies
-uv sync
+# Install dependencies (the backend drivers live in a non-default group)
+uv sync --group integration
 
 # Run all BigQuery tests
 uv run pytest tests/integration -k "bigquery" -v
@@ -329,8 +328,8 @@ export SNOWFLAKE_CI_DATABASE=your-database
 export SNOWFLAKE_CI_SCHEMA=your-schema
 export SNOWFLAKE_CI_PRIVATE_KEY_PATH=/path/to/your/private-key.p8
 
-# Install dependencies
-uv sync
+# Install dependencies (the backend drivers live in a non-default group)
+uv sync --group integration
 
 # Run all Snowflake tests
 uv run pytest tests/integration -k "snowflake" -v
@@ -339,10 +338,73 @@ uv run pytest tests/integration -k "snowflake" -v
 uv run pytest tests/integration/test_cohort_analysis.py -k "snowflake" -v
 ```
 
+#### Databricks Integration Tests
+
+The Databricks integration tests verify compatibility with Databricks as a backend. They query a pre-loaded
+Unity Catalog table over a SQL warehouse, authenticating as an OAuth machine-to-machine service principal.
+
+**Prerequisites:**
+
+- A Databricks workspace with a SQL warehouse and Unity Catalog
+- An OAuth service principal (client ID and secret) with `USE_CATALOG`, `USE_SCHEMA` and `SELECT` on the test
+  schema, plus `CREATE VOLUME`, `READ VOLUME` and `WRITE VOLUME`: Ibis creates a volume on connect to stage
+  memtables, so a principal holding only `SELECT` cannot open the connection
+- The test dataset loaded in Unity Catalog (table: `<catalog>.<schema>.transactions`), kept in step with
+  `data/transactions.parquet`, which the seeded backends build their copy from
+- A `test_data` volume in the same schema, which CI stages the wheel and test module into
+
+**Running locally:**
+
+```bash
+# Set up Databricks connection. HOST/CLIENT_ID/CLIENT_SECRET are the standard
+# Databricks SDK variables, so a ~/.databrickscfg profile works instead.
+export DATABRICKS_HOST=https://your-workspace.cloud.databricks.com
+export DATABRICKS_CLIENT_ID=your-service-principal-client-id
+export DATABRICKS_CLIENT_SECRET=your-service-principal-secret
+export DATABRICKS_CI_HTTP_PATH=/sql/1.0/warehouses/your-warehouse-id
+export DATABRICKS_CI_CATALOG=your-catalog
+export DATABRICKS_CI_SCHEMA=your-schema
+
+# Install dependencies (the backend drivers live in a non-default group)
+uv sync --group integration
+
+# Run all Databricks tests
+uv run pytest tests/integration -k "databricks" -v
+
+# Run specific test module
+uv run pytest tests/integration/test_cohort_analysis.py -k "databricks" -v
+```
+
+##### install_skills() on Databricks
+
+`install_skills` copies the bundled agent skills into `/Workspace/Users/<current_user()>/.assistant/skills`,
+a mount that exists only on Databricks compute. Coverage is shared between:
+
+- `tests/test_skills.py::TestDatabricksInstall` runs on every commit, against a temp directory and a
+  stub Spark session. It covers the states a real workspace will not produce on demand.
+- `tests/integration/test_workspace_skills.py` holds every assertion made against the real mount.
+  Plain pytest skips it.
+- The `skills-install-tests` job in `.github/workflows/databricks-integration.yml` delivers it, running
+  a wheel built from the working tree rather than the last PyPI release.
+- The notebook that job generates is where the `DATABRICKS_RUNTIME_VERSION` guard lives.
+
+To run them by hand, attach a Databricks notebook to serverless compute and execute the following.
+They delete and reinstall the bundled skills in your own workspace home:
+
+```python
+%pip install openretailscience pytest
+%restart_python
+```
+
+```python
+import pytest
+pytest.main(["/Workspace/path/to/test_workspace_skills.py", "-v", "-p", "no:cacheprovider"])
+```
+
 #### SQL Server and Oracle Integration Tests
 
 SQL Server and Oracle run against throwaway Docker containers, so they execute the same way locally and in CI.
-CI covers the supported free editions — SQL Server Developer 2022 and 2025, and Oracle 23ai Free.
+CI covers the supported free editions: SQL Server Developer 2022 and 2025, and Oracle 23ai Free.
 
 These backends have a one-time setup (the SQL Server ODBC driver) and per-version image tags, so their
 instructions live next to the Compose files. See

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ name  = "Murray Vanwyk"
 [dependency-groups]
 dev = [
     "freezegun>=1.5.1,<2",
-    "ibis-framework[bigquery,mssql,oracle,pyspark,snowflake]>=10.0.0,<13",
     "nbstripout>=0.7.1,<0.10",
     "pre-commit>=3.6.2,<5",
     "pytest-cov>=4.1.0,<8",
@@ -53,6 +52,10 @@ docs = [
     "mkdocstrings-python>=1.11,<3",
 ]
 examples = [ "jupyterlab>=4.2.5,<5", "tqdm>=4.66.1,<5" ]
+integration = [
+    "databricks-sdk>=0.60,<1",
+    "ibis-framework[bigquery,databricks,mssql,oracle,pyspark,snowflake]>=10.0.0,<13",
+]
 
 [build-system]
 build-backend = "hatchling.build"
@@ -141,7 +144,13 @@ select = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=openretailscience --cov-report=term-missing  --cov-branch --ignore=tests/integration --import-mode=importlib"
+addopts = [
+    "--cov=openretailscience",
+    "--cov-report=term-missing",
+    "--cov-branch",
+    "--ignore=tests/integration",
+    "--import-mode=importlib",
+]
 
 [tool.coverage.run]
 branch = true

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,7 +12,7 @@ import pandas as pd
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
 
     from ibis.backends import BaseBackend
     from ibis.expr.types import Table
@@ -22,8 +22,7 @@ _TRANSACTIONS_TABLE_NAME = "transactions"
 
 # Connection details for the local throwaway containers defined in
 # tests/integration/docker/. These are fixed, non-secret values that must match the
-# corresponding docker-compose files; they are intentionally hardcoded rather than
-# configured via environment variables.
+# corresponding docker-compose files.
 _MSSQL_HOST = "localhost"
 _MSSQL_PORT = 1433
 _MSSQL_USER = "sa"
@@ -41,6 +40,10 @@ _ORACLE_SERVICE_NAME = "FREEPDB1"  # 23ai Free pluggable database
 _PORT_PROBE_TIMEOUT_SECONDS = 1.0
 _CONNECT_MAX_ATTEMPTS = 30
 _CONNECT_RETRY_SECONDS = 2.0
+
+# Ibis creates this volume on connect to stage memtables. Named, because the default embeds the
+# process id, so every run would leave another volume behind in the CI schema.
+_DATABRICKS_MEMTABLE_VOLUME = "ibis_memtables"
 
 
 def _read_transactions() -> pd.DataFrame:
@@ -60,15 +63,13 @@ def _read_transactions() -> pd.DataFrame:
 def _require_container_reachable(host: str, port: int, name: str) -> None:
     """Fail loudly if the backend container is not listening on host:port.
 
-    This is a fast pre-flight check so a missing or failed-to-start container surfaces
-    as an immediate, clear error rather than skipping (which would hide the problem) or
-    burning the whole connection-retry budget. It deliberately does not call
-    ``pytest.skip``: these tests are only selected when the backend is meant to run.
+    Deliberately does not call ``pytest.skip``: these tests are only selected when the
+    backend is meant to run, so a container that failed to start must not be passed over.
 
     Args:
-        host: Host the container is expected to listen on.
-        port: Port the container is expected to listen on.
-        name: Human-readable backend name used in the error message.
+        host (str): Host the container is expected to listen on.
+        port (int): Port the container is expected to listen on.
+        name (str): Human-readable backend name used in the error message.
 
     Raises:
         RuntimeError: If nothing is accepting connections on host:port.
@@ -85,7 +86,7 @@ def _connect_with_retry(connect: Callable[[], BaseBackend]) -> BaseBackend:
     """Establish a backend connection, retrying while the container starts up.
 
     Args:
-        connect: Zero-argument callable that opens and returns a backend connection.
+        connect (Callable[[], BaseBackend]): Zero-argument callable that opens and returns a backend connection.
 
     Returns:
         BaseBackend: The established Ibis backend connection.
@@ -108,7 +109,7 @@ def _seed_transactions(connection: BaseBackend) -> Table:
     """Load the transactions sample data into a connected backend and return it.
 
     Args:
-        connection: An Ibis backend connection to seed.
+        connection (BaseBackend): An Ibis backend connection to seed.
 
     Returns:
         Table: The seeded transactions table expression.
@@ -170,30 +171,66 @@ def _oracle_transactions_table() -> Table:
     return _seed_transactions(connection)
 
 
+@pytest.fixture(scope="session")
+def _databricks_transactions_table() -> Iterator[Table]:
+    """Open one Databricks connection per session and close it on teardown.
+
+    Closing matters: the Thrift transport is otherwise torn down by the garbage collector,
+    which logs against pytest's already-closed capture stream.
+
+    Yields:
+        Table: The transactions table on the Databricks backend.
+    """
+    from databricks.sdk.core import Config  # noqa: PLC0415 - keeps the other backends collectable without it
+
+    # Config() takes the OAuth credentials from DATABRICKS_HOST/CLIENT_ID/CLIENT_SECRET, the SDK's
+    # own names. credentials_provider needs a callable returning cfg.authenticate, not the method.
+    config = Config()
+    connection = ibis.databricks.connect(
+        server_hostname=config.hostname,
+        http_path=os.environ["DATABRICKS_CI_HTTP_PATH"],
+        credentials_provider=lambda: config.authenticate,
+        catalog=os.environ["DATABRICKS_CI_CATALOG"],
+        schema=os.environ["DATABRICKS_CI_SCHEMA"],
+        memtable_volume=_DATABRICKS_MEMTABLE_VOLUME,
+    )
+    try:
+        yield connection.table(_TRANSACTIONS_TABLE_NAME)
+    finally:
+        connection.disconnect()
+
+
 @pytest.fixture(
-    params=["bigquery", "pyspark", "snowflake", "mssql", "oracle"],
+    params=["bigquery", "databricks", "pyspark", "snowflake", "mssql", "oracle"],
     ids=lambda backend: f"backend={backend}",
 )
 def transactions_table(request: pytest.FixtureRequest) -> Table:
-    """Parameterized fixture that provides transactions table from different backends."""
+    """Provide the transactions table from each backend in turn.
+
+    Args:
+        request (pytest.FixtureRequest): Fixture request carrying the backend name.
+
+    Returns:
+        Table: The transactions table on the parametrized backend.
+
+    Raises:
+        ValueError: If the parametrized backend name is not handled.
+    """
     if request.param == "bigquery":
         connection = ibis.bigquery.connect(
             project_id=os.environ["GCP_PROJECT_ID"],
         )
-        return connection.table("test_data.transactions")
+        return connection.table(f"test_data.{_TRANSACTIONS_TABLE_NAME}")
     if request.param == "pyspark":
         connection = ibis.pyspark.connect()
-        # Use pandas to read the parquet file first, then convert to Spark
-        # This handles timestamp compatibility issues automatically
         df = pd.read_parquet(_TRANSACTIONS_PARQUET)
         # Pyspark has no time column so we have to convert it to a datetime
         df["transaction_time"] = pd.to_datetime(
             df["transaction_date"].astype(str) + " " + df["transaction_time"].astype(str),
         )
         spark_df = connection._session.createDataFrame(df)
-        # Create a temporary view and read it back as an ibis table
-        spark_df.createOrReplaceTempView("transactions")
-        return connection.table("transactions")
+        spark_df.createOrReplaceTempView(_TRANSACTIONS_TABLE_NAME)
+        return connection.table(_TRANSACTIONS_TABLE_NAME)
     if request.param == "snowflake":
         connection = ibis.snowflake.connect(
             account=os.environ["SNOWFLAKE_CI_ACCOUNT"],
@@ -203,11 +240,10 @@ def transactions_table(request: pytest.FixtureRequest) -> Table:
             schema=os.environ["SNOWFLAKE_CI_SCHEMA"],
             warehouse=os.environ["SNOWFLAKE_CI_WAREHOUSE"],
         )
-        table = connection.table("TRANSACTIONS")
+        table = connection.table(_TRANSACTIONS_TABLE_NAME.upper())
         # Snowflake returns UPPERCASE column names; lowercase them for compatibility with integration tests
         return table.rename({col.lower(): col for col in table.columns})
-    if request.param in ("mssql", "oracle"):
-        # Containerized backends are seeded once per session by their own fixtures.
+    if request.param in ("databricks", "mssql", "oracle"):
         return request.getfixturevalue(f"_{request.param}_transactions_table")
     error_msg = f"Unknown backend: {request.param}"
     raise ValueError(error_msg)

--- a/tests/integration/test_workspace_skills.py
+++ b/tests/integration/test_workspace_skills.py
@@ -1,0 +1,205 @@
+"""Tests for ``install_skills`` running on Databricks compute.
+
+The Databricks branch of ``install_skills`` copies into ``/Workspace/Users/<current_user()>``,
+a mount that exists only on the platform, so ``tests/test_skills.py::TestDatabricksInstall`` can
+only pin our own wiring against a temp directory and a mocked Spark session.
+
+Plain pytest skips these; ``.github/workflows/databricks-integration.yml`` runs them. README.md,
+under "install_skills() on Databricks", maps the pieces.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+import openretailscience
+from openretailscience.skills import (
+    AGENTS_DIR_NAME,
+    BYTECODE_CACHE_DIR,
+    DATABRICKS_ASSISTANT_DIR,
+    SKILL_MARKER_FILENAME,
+    SKILLS_SUBDIR,
+    install_skills,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_DATABRICKS_RUNTIME_ENV = "DATABRICKS_RUNTIME_VERSION"
+
+# /Workspace and Users are spelled out, not imported: they are the location these tests exist to
+# pin, and an expectation derived from the code under test would agree with a wrong answer.
+_WORKSPACE_ROOT = Path("/Workspace")
+_WORKSPACE_USERS_ROOT = _WORKSPACE_ROOT / "Users"
+# The admin-only workspace-wide directory a default install must never write.
+_WORKSPACE_SKILLS_DIR = _WORKSPACE_ROOT / DATABRICKS_ASSISTANT_DIR / SKILLS_SUBDIR
+
+_SCRIPTS_SUBDIR = "scripts"
+
+pytestmark = pytest.mark.skipif(
+    _DATABRICKS_RUNTIME_ENV not in os.environ,
+    reason="install_skills' Databricks branch needs the real /Workspace mount",
+)
+
+
+def _bundled_skill_names(bundled_skills_dir: Path) -> list[str]:
+    """List the skill folders shipped in the installed package.
+
+    Args:
+        bundled_skills_dir (Path): The package's bundled skills directory.
+
+    Returns:
+        list[str]: Sorted skill folder names.
+    """
+    return sorted(
+        entry.name
+        for entry in bundled_skills_dir.iterdir()
+        if entry.is_dir() and (entry / SKILL_MARKER_FILENAME).is_file()
+    )
+
+
+def _installed_skill_names(skills_dir: Path, bundled_skills_dir: Path) -> list[str]:
+    """List the bundled skills that are present under ``skills_dir``.
+
+    Args:
+        skills_dir (Path): A skills directory an install may have written to.
+        bundled_skills_dir (Path): The package's bundled skills directory.
+
+    Returns:
+        list[str]: Names present under ``skills_dir``, empty when nothing was installed there.
+    """
+    return [name for name in _bundled_skill_names(bundled_skills_dir) if (skills_dir / name).exists()]
+
+
+def _remove_installed_copies(workspace_skills_dir: Path, bundled_skills_dir: Path) -> None:
+    """Delete only the copies this package owns, leaving any other skills in place.
+
+    Args:
+        workspace_skills_dir (Path): The Genie skills directory in the caller's workspace home.
+        bundled_skills_dir (Path): The package's bundled skills directory.
+    """
+    for name in _bundled_skill_names(bundled_skills_dir):
+        shutil.rmtree(workspace_skills_dir / name, ignore_errors=True)
+
+
+@pytest.fixture(scope="module")
+def bundled_skills_dir() -> Path:
+    """The skills directory shipped inside the installed package."""
+    return Path(openretailscience.__file__).parent / AGENTS_DIR_NAME / SKILLS_SUBDIR
+
+
+@pytest.fixture(scope="module")
+def workspace_skills_dir() -> Path:
+    """The Genie skills directory in the workspace home of the identity running the job."""
+    # Imported here, not at module scope: pytest imports the module before evaluating any mark,
+    # so a module-scope import would raise instead of letting the skipif above take effect.
+    from pyspark.sql import SparkSession  # noqa: PLC0415 - only Databricks compute provides pyspark
+
+    spark = SparkSession.getActiveSession()
+    assert spark is not None, "Databricks compute did not provide an active Spark session"
+    user = str(spark.sql("SELECT current_user()").collect()[0][0])
+    return _WORKSPACE_USERS_ROOT / user / DATABRICKS_ASSISTANT_DIR / SKILLS_SUBDIR
+
+
+@pytest.fixture(autouse=True)
+def _clean_workspace_target(workspace_skills_dir: Path, bundled_skills_dir: Path) -> Iterator[None]:
+    """Clear previously installed copies so each test starts from a known workspace state.
+
+    Args:
+        workspace_skills_dir (Path): The Genie skills directory in the caller's workspace home.
+        bundled_skills_dir (Path): The package's bundled skills directory.
+
+    Yields:
+        None: Control to the test.
+    """
+    _remove_installed_copies(workspace_skills_dir, bundled_skills_dir)
+    yield
+    _remove_installed_copies(workspace_skills_dir, bundled_skills_dir)
+
+
+class TestWorkspaceInstall:
+    """Tests for install_skills against a real Databricks workspace filesystem."""
+
+    def test_installs_a_readable_copy_into_the_callers_workspace_home(
+        self, workspace_skills_dir: Path, bundled_skills_dir: Path
+    ) -> None:
+        """Every bundled skill lands in the caller's own workspace home and reads back intact."""
+        result = install_skills()
+
+        names = _bundled_skill_names(bundled_skills_dir)
+        assert len(result.installed) == len(names)
+        assert len(result.skipped) == 0
+        for name in names:
+            target = workspace_skills_dir / name
+            # A symlink would point back into the package that a cluster restart wipes.
+            assert not target.is_symlink()
+            assert (target / SKILL_MARKER_FILENAME).read_bytes() == (
+                bundled_skills_dir / name / SKILL_MARKER_FILENAME
+            ).read_bytes()
+
+    def test_workspace_wide_directory_is_never_written(
+        self, workspace_skills_dir: Path, bundled_skills_dir: Path
+    ) -> None:
+        """The default install stays inside the user's home, not the admin-only workspace root.
+
+        Writing the workspace-wide directory is what failed with PERMISSION_DENIED for every
+        non-admin in #542.
+        """
+        install_skills()
+
+        assert workspace_skills_dir.is_dir()
+        assert _installed_skill_names(_WORKSPACE_SKILLS_DIR, bundled_skills_dir) == []
+
+    def test_pip_byte_compiles_the_skill_and_the_copy_leaves_it_behind(
+        self, workspace_skills_dir: Path, bundled_skills_dir: Path
+    ) -> None:
+        """The installed package carries bytecode caches, and none reach the workspace.
+
+        Copying one raises ``OSError 95`` on the ``/Workspace`` mount. The precondition is
+        asserted first: if ``%pip`` stopped byte-compiling, the rest would pass vacuously.
+        """
+        names = _bundled_skill_names(bundled_skills_dir)
+        python_dirs = {path.parent for path in bundled_skills_dir.rglob("*.py")}
+        # Set equality alone is satisfied by two empty sets, so the source is pinned first:
+        # every bundled skill ships its example scripts under scripts/.
+        assert python_dirs == {bundled_skills_dir / name / _SCRIPTS_SUBDIR for name in names}
+        assert {path.parent for path in bundled_skills_dir.rglob(BYTECODE_CACHE_DIR)} == python_dirs
+
+        install_skills()
+
+        for name in names:
+            assert list((workspace_skills_dir / name).rglob(BYTECODE_CACHE_DIR)) == []
+
+    def test_rerun_reports_up_to_date(self, bundled_skills_dir: Path) -> None:
+        """Re-running against the workspace filesystem re-copies nothing."""
+        install_skills()
+
+        result = install_skills()
+
+        assert len(result.installed) == 0
+        assert len(result.up_to_date) == len(_bundled_skill_names(bundled_skills_dir))
+
+    def test_rerun_refreshes_a_stale_copy(self, workspace_skills_dir: Path, bundled_skills_dir: Path) -> None:
+        """A workspace copy that no longer matches the package is rewritten."""
+        install_skills()
+        name = _bundled_skill_names(bundled_skills_dir)[0]
+        stale_marker = workspace_skills_dir / name / SKILL_MARKER_FILENAME
+        stale_marker.write_text("stale copy from an older release", encoding="utf-8")
+
+        result = install_skills()
+
+        assert stale_marker.read_bytes() == (bundled_skills_dir / name / SKILL_MARKER_FILENAME).read_bytes()
+        assert len(result.installed) == 1
+
+    def test_global_mode_is_refused(self, workspace_skills_dir: Path, bundled_skills_dir: Path) -> None:
+        """Workspace-wide installs are refused rather than attempted without admin rights."""
+        with pytest.raises(NotImplementedError, match="global_mode"):
+            install_skills(global_mode=True)
+
+        assert _installed_skill_names(_WORKSPACE_SKILLS_DIR, bundled_skills_dir) == []
+        assert _installed_skill_names(workspace_skills_dir, bundled_skills_dir) == []

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -8,6 +8,7 @@ import runpy
 import shutil
 import sys
 from pathlib import PurePath
+from types import ModuleType, SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
@@ -36,8 +37,7 @@ DATABRICKS_USER = "analyst@retail.com"
 # Spelled out, not imported: renaming the package constant must fail these tests,
 # because Databricks reads this exact path.
 DATABRICKS_ASSISTANT_DIR = ".assistant"
-# Patched by name so pyspark, a dev-only transitive dependency, stays out of imports.
-GET_ACTIVE_SESSION = "pyspark.sql.SparkSession.getActiveSession"
+PYSPARK_SQL_MODULE = "pyspark.sql"
 FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---", re.DOTALL)
 SHIPPED_SKILL_NAME = "using-openretailscience"
 # Fenced code blocks, and openretailscience import statements inside them.
@@ -96,6 +96,22 @@ def _raise_value_error(*_args: object, **_kwargs: object) -> NoReturn:
 def _raise_not_implemented(*_args: object, **_kwargs: object) -> NoReturn:
     """Raise NotImplementedError; a patched-call stand-in for an operation unsupported on the platform."""
     raise NotImplementedError
+
+
+def _fake_pyspark(monkeypatch: pytest.MonkeyPatch, session: MagicMock | None) -> None:
+    """Register a stub ``pyspark.sql`` whose ``getActiveSession`` returns ``session``.
+
+    Stubbed rather than installed: pyspark lives in the integration group, so importing it here
+    would pull its Spark jars into every default sync. The real ``getActiveSession`` is covered
+    by ``tests/integration/test_workspace_skills.py``.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture used to restore ``sys.modules`` afterwards.
+        session (MagicMock | None): Session to hand back, or None for a sessionless caller.
+    """
+    module = ModuleType(PYSPARK_SQL_MODULE)
+    module.SparkSession = SimpleNamespace(getActiveSession=lambda: session)
+    monkeypatch.setitem(sys.modules, PYSPARK_SQL_MODULE, module)
 
 
 def _make_bare_skill(root: Path, name: str, body: bytes = b"guidance") -> Path:
@@ -247,7 +263,6 @@ class TestSymlinkInstall:
         assert preserved.read_text(encoding="utf-8") == content
         assert not conflict.is_symlink()
         assert result.skipped == [str(conflict.relative_to(project_dir))]
-        # The non-conflicting skill still installs.
         assert (target_dir / SKILL_NAMES[1]).is_symlink()
 
     def test_stale_symlink_is_repointed_to_source(self, source_dir: Path, project_dir: Path) -> None:
@@ -284,9 +299,12 @@ class TestSymlinkInstall:
 
 
 class TestDatabricksInstall:
-    """Tests for the Databricks copy-to-Workspace branch."""
+    """Tests for the Databricks copy-to-Workspace branch, against a fake ``/Workspace``.
 
-    @pytest.fixture
+    ``tests/integration/test_workspace_skills.py`` runs the same branch against the real mount.
+    """
+
+    @pytest.fixture(autouse=True)
     def workspace_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         """Simulate a Databricks runtime with a redirected persistent workspace root."""
         root = tmp_path / "Workspace"
@@ -305,42 +323,30 @@ class TestDatabricksInstall:
         """Stand in for the Databricks-provided active Spark session, answering current_user()."""
         session = MagicMock()
         session.sql.return_value.collect.return_value = [[DATABRICKS_USER]]
-        monkeypatch.setattr(GET_ACTIVE_SESSION, lambda: session)
+        _fake_pyspark(monkeypatch, session)
         return session
 
-    def test_copies_to_per_user_assistant_dir(
-        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path, spark_session: MagicMock
+    def test_target_is_named_by_current_user(
+        self, source_dir: Path, user_skills_dir: Path, spark_session: MagicMock
     ) -> None:
-        """The default install copies (not links) into the workspace home of the current_user()."""
+        """The target is resolved from ``current_user()``, not a configured or cached identity."""
         install_skills()
 
         assert "current_user()" in spark_session.sql.call_args.args[0]
-        for name in SKILL_NAMES:
-            target = user_skills_dir / name
-            assert target.is_dir()
-            assert not target.is_symlink()
-            assert (target / "SKILL.md").is_file()
-        # The workspace-wide directory needs admin rights.
-        assert not (workspace_root / DATABRICKS_ASSISTANT_DIR).exists()
+        assert (user_skills_dir / SKILL_NAMES[0] / "SKILL.md").is_file()
 
-    def test_global_mode_is_refused(
-        self, source_dir: Path, workspace_root: Path, user_skills_dir: Path, spark_session: MagicMock
-    ) -> None:
-        """Workspace-wide installs are refused rather than attempted without admin rights."""
+    def test_global_mode_is_refused_before_the_session_lookup(self, source_dir: Path, spark_session: MagicMock) -> None:
+        """global_mode raises without consulting Spark, so a sessionless caller is not misdirected."""
         with pytest.raises(NotImplementedError, match="global_mode"):
             install_skills(global_mode=True)
 
-        # Refusing before the session lookup keeps a sessionless caller from being
-        # told to fix the wrong thing.
         spark_session.sql.assert_not_called()
-        assert not (workspace_root / DATABRICKS_ASSISTANT_DIR).exists()
-        assert not user_skills_dir.exists()
 
     def test_raises_without_a_spark_session(
         self, source_dir: Path, workspace_root: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """With no session to name the user, the install raises instead of guessing a target."""
-        monkeypatch.setattr(GET_ACTIVE_SESSION, lambda: None)
+        _fake_pyspark(monkeypatch, None)
 
         with pytest.raises(RuntimeError, match="Spark session"):
             install_skills()
@@ -387,28 +393,6 @@ class TestDatabricksInstall:
             install_skills()
 
         assert list(workspace_root.rglob(DATABRICKS_ASSISTANT_DIR)) == []
-
-    def test_rerun_reports_up_to_date_when_copy_matches(self, source_dir: Path, workspace_root: Path) -> None:
-        """Re-running on Databricks with unchanged skills reports them up to date."""
-        install_skills()
-        result = install_skills()
-
-        assert len(result.installed) == 0
-        assert len(result.up_to_date) == len(SKILL_NAMES)
-
-    def test_rerun_refreshes_copy_when_source_changed(self, source_dir: Path, user_skills_dir: Path) -> None:
-        """A changed bundled skill is re-copied over the stale Databricks copy."""
-        install_skills()
-        (source_dir / SKILL_NAMES[0] / "SKILL.md").write_text(
-            f"---\nname: {SKILL_NAMES[0]}\ndescription: Updated.\n---\n\n# updated\n",
-            encoding="utf-8",
-        )
-
-        result = install_skills()
-
-        target = user_skills_dir / SKILL_NAMES[0] / "SKILL.md"
-        assert "Updated." in target.read_text(encoding="utf-8")
-        assert len(result.installed) == 1
 
     @pytest.mark.parametrize("existing_kind", ["stale_copy", "symlink"])
     def test_existing_target_is_replaced_by_a_current_copy(
@@ -460,7 +444,6 @@ class TestDatabricksInstall:
         install_skills()
         expected = (source_dir / SKILL_NAMES[0] / "SKILL.md").read_bytes()
 
-        # Simulate the ephemeral package being wiped on cluster restart.
         shutil.rmtree(source_dir)
 
         assert (user_skills_dir / SKILL_NAMES[0] / "SKILL.md").read_bytes() == expected

--- a/uv.lock
+++ b/uv.lock
@@ -565,6 +565,42 @@ wheels = [
 ]
 
 [[package]]
+name = "databricks-sdk"
+version = "0.123.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "protobuf" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/ef/a08f2a0d6deecc35552baf89da44f9f05cc2e19313ec240dddd06978a09f/databricks_sdk-0.123.0.tar.gz", hash = "sha256:787068ccf1c537736bc6387486c15d2ac02937c876c980b5b2b43230a98e4d35", size = 1144384, upload-time = "2026-07-30T16:52:54.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/53/29048df757469edbb43f610188837951c86ac6ae63a6fbccb27edd01b86a/databricks_sdk-0.123.0-py3-none-any.whl", hash = "sha256:55ed566c48dcd25d8ea4ffec3f78236f63258078477e440529389c4bee95d80f", size = 1088731, upload-time = "2026-07-30T16:52:52.862Z" },
+]
+
+[[package]]
+name = "databricks-sql-connector"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lz4" },
+    { name = "oauthlib" },
+    { name = "openpyxl" },
+    { name = "pandas" },
+    { name = "pybreaker" },
+    { name = "pyjwt" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+    { name = "thrift" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/83/b5576b2cd457d8d393aca2d22b64cbb123e0eb91a46dddc50e5ec8b5e420/databricks_sql_connector-4.4.0.tar.gz", hash = "sha256:97d20b5e12e4aa50d16fe5fea3914f19319a207f2f4912a395a08497c25cb16f", size = 225152, upload-time = "2026-07-22T10:24:50.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/88/8bd874f39f8c3f2e36f60cebdee8b016a4f227bfc59c26c171afb6fa4825/databricks_sql_connector-4.4.0-py3-none-any.whl", hash = "sha256:6d9111dce577b954fa4684e5cf81484aaa810171d852d472c3c67ec4892bbb74", size = 252850, upload-time = "2026-07-22T10:24:48.623Z" },
+]
+
+[[package]]
 name = "db-dtypes"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -663,11 +699,20 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1068,6 +1113,14 @@ bigquery = [
     { name = "pyarrow" },
     { name = "pyarrow-hotfix" },
     { name = "pydata-google-auth" },
+    { name = "rich" },
+]
+databricks = [
+    { name = "databricks-sql-connector" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pyarrow-hotfix" },
     { name = "rich" },
 ]
 duckdb = [
@@ -1535,6 +1588,54 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/e9/9c0de8e45fef3d63f85eed3b1757f9aa511065942866331ef8b99421f433/kiwisolver-1.4.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:88a2df29d4724b9237fc0c6eaf2a1adae0cdc0b3e9f4d8e7dc54b16812d2d81a", size = 1908464, upload-time = "2023-08-24T09:29:16.539Z" },
     { url = "https://files.pythonhosted.org/packages/a3/60/4f0fd50b08f5be536ea0cef518ac7255d9dab43ca40f3b93b60e3ddf80dd/kiwisolver-1.4.5-cp312-cp312-win32.whl", hash = "sha256:72d40b33e834371fd330fb1472ca19d9b8327acb79a5821d4008391db8e29f20", size = 46473, upload-time = "2023-08-24T09:29:17.956Z" },
     { url = "https://files.pythonhosted.org/packages/63/50/2746566bdf4a6a842d117367d05c90cfb87ac04e9e2845aa1fa21f071362/kiwisolver-1.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:2c5674c4e74d939b9d91dda0fae10597ac7521768fec9e399c70a1f27e2ea2d9", size = 56004, upload-time = "2023-08-24T09:29:19.329Z" },
+]
+
+[[package]]
+name = "lz4"
+version = "4.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/45/2466d73d79e3940cad4b26761f356f19fd33f4409c96f100e01a5c566909/lz4-4.4.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d221fa421b389ab2345640a508db57da36947a437dfe31aeddb8d5c7b646c22d", size = 207396, upload-time = "2025-11-03T13:01:24.965Z" },
+    { url = "https://files.pythonhosted.org/packages/72/12/7da96077a7e8918a5a57a25f1254edaf76aefb457666fcc1066deeecd609/lz4-4.4.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7dc1e1e2dbd872f8fae529acd5e4839efd0b141eaa8ae7ce835a9fe80fbad89f", size = 207154, upload-time = "2025-11-03T13:01:26.922Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0e/0fb54f84fd1890d4af5bc0a3c1fa69678451c1a6bd40de26ec0561bb4ec5/lz4-4.4.5-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e928ec2d84dc8d13285b4a9288fd6246c5cde4f5f935b479f50d986911f085e3", size = 1291053, upload-time = "2025-11-03T13:01:28.396Z" },
+    { url = "https://files.pythonhosted.org/packages/15/45/8ce01cc2715a19c9e72b0e423262072c17d581a8da56e0bd4550f3d76a79/lz4-4.4.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daffa4807ef54b927451208f5f85750c545a4abbff03d740835fc444cd97f758", size = 1278586, upload-time = "2025-11-03T13:01:29.906Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/34/7be9b09015e18510a09b8d76c304d505a7cbc66b775ec0b8f61442316818/lz4-4.4.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a2b7504d2dffed3fd19d4085fe1cc30cf221263fd01030819bdd8d2bb101cf1", size = 1367315, upload-time = "2025-11-03T13:01:31.054Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/94/52cc3ec0d41e8d68c985ec3b2d33631f281d8b748fb44955bc0384c2627b/lz4-4.4.5-cp310-cp310-win32.whl", hash = "sha256:0846e6e78f374156ccf21c631de80967e03cc3c01c373c665789dc0c5431e7fc", size = 88173, upload-time = "2025-11-03T13:01:32.643Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/35/c3c0bdc409f551404355aeeabc8da343577d0e53592368062e371a3620e1/lz4-4.4.5-cp310-cp310-win_amd64.whl", hash = "sha256:7c4e7c44b6a31de77d4dc9772b7d2561937c9588a734681f70ec547cfbc51ecd", size = 99492, upload-time = "2025-11-03T13:01:33.813Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/02/4d88de2f1e97f9d05fd3d278fe412b08969bc94ff34942f5a3f09318144a/lz4-4.4.5-cp310-cp310-win_arm64.whl", hash = "sha256:15551280f5656d2206b9b43262799c89b25a25460416ec554075a8dc568e4397", size = 91280, upload-time = "2025-11-03T13:01:35.081Z" },
+    { url = "https://files.pythonhosted.org/packages/93/5b/6edcd23319d9e28b1bedf32768c3d1fd56eed8223960a2c47dacd2cec2af/lz4-4.4.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d6da84a26b3aa5da13a62e4b89ab36a396e9327de8cd48b436a3467077f8ccd4", size = 207391, upload-time = "2025-11-03T13:01:36.644Z" },
+    { url = "https://files.pythonhosted.org/packages/34/36/5f9b772e85b3d5769367a79973b8030afad0d6b724444083bad09becd66f/lz4-4.4.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:61d0ee03e6c616f4a8b69987d03d514e8896c8b1b7cc7598ad029e5c6aedfd43", size = 207146, upload-time = "2025-11-03T13:01:37.928Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f4/f66da5647c0d72592081a37c8775feacc3d14d2625bbdaabd6307c274565/lz4-4.4.5-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:33dd86cea8375d8e5dd001e41f321d0a4b1eb7985f39be1b6a4f466cd480b8a7", size = 1292623, upload-time = "2025-11-03T13:01:39.341Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fc/5df0f17467cdda0cad464a9197a447027879197761b55faad7ca29c29a04/lz4-4.4.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:609a69c68e7cfcfa9d894dc06be13f2e00761485b62df4e2472f1b66f7b405fb", size = 1279982, upload-time = "2025-11-03T13:01:40.816Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3b/b55cb577aa148ed4e383e9700c36f70b651cd434e1c07568f0a86c9d5fbb/lz4-4.4.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:75419bb1a559af00250b8f1360d508444e80ed4b26d9d40ec5b09fe7875cb989", size = 1368674, upload-time = "2025-11-03T13:01:42.118Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/31/e97e8c74c59ea479598e5c55cbe0b1334f03ee74ca97726e872944ed42df/lz4-4.4.5-cp311-cp311-win32.whl", hash = "sha256:12233624f1bc2cebc414f9efb3113a03e89acce3ab6f72035577bc61b270d24d", size = 88168, upload-time = "2025-11-03T13:01:43.282Z" },
+    { url = "https://files.pythonhosted.org/packages/18/47/715865a6c7071f417bef9b57c8644f29cb7a55b77742bd5d93a609274e7e/lz4-4.4.5-cp311-cp311-win_amd64.whl", hash = "sha256:8a842ead8ca7c0ee2f396ca5d878c4c40439a527ebad2b996b0444f0074ed004", size = 99491, upload-time = "2025-11-03T13:01:44.167Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e7/ac120c2ca8caec5c945e6356ada2aa5cfabd83a01e3170f264a5c42c8231/lz4-4.4.5-cp311-cp311-win_arm64.whl", hash = "sha256:83bc23ef65b6ae44f3287c38cbf82c269e2e96a26e560aa551735883388dcc4b", size = 91271, upload-time = "2025-11-03T13:01:45.016Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/016e4f6de37d806f7cc8f13add0a46c9a7cfc41a5ddc2bc831d7954cf1ce/lz4-4.4.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:df5aa4cead2044bab83e0ebae56e0944cc7fcc1505c7787e9e1057d6d549897e", size = 207163, upload-time = "2025-11-03T13:01:45.895Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/df/0fadac6e5bd31b6f34a1a8dbd4db6a7606e70715387c27368586455b7fc9/lz4-4.4.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d0bf51e7745484d2092b3a51ae6eb58c3bd3ce0300cf2b2c14f76c536d5697a", size = 207150, upload-time = "2025-11-03T13:01:47.205Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/17/34e36cc49bb16ca73fb57fbd4c5eaa61760c6b64bce91fcb4e0f4a97f852/lz4-4.4.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7b62f94b523c251cf32aa4ab555f14d39bd1a9df385b72443fd76d7c7fb051f5", size = 1292045, upload-time = "2025-11-03T13:01:48.667Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1c/b1d8e3741e9fc89ed3b5f7ef5f22586c07ed6bb04e8343c2e98f0fa7ff04/lz4-4.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c3ea562c3af274264444819ae9b14dbbf1ab070aff214a05e97db6896c7597e", size = 1279546, upload-time = "2025-11-03T13:01:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/e3867222474f6c1b76e89f3bd914595af69f55bf2c1866e984c548afdc15/lz4-4.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24092635f47538b392c4eaeff14c7270d2c8e806bf4be2a6446a378591c5e69e", size = 1368249, upload-time = "2025-11-03T13:01:51.273Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e7/d667d337367686311c38b580d1ca3d5a23a6617e129f26becd4f5dc458df/lz4-4.4.5-cp312-cp312-win32.whl", hash = "sha256:214e37cfe270948ea7eb777229e211c601a3e0875541c1035ab408fbceaddf50", size = 88189, upload-time = "2025-11-03T13:01:52.605Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/0b/a54cd7406995ab097fceb907c7eb13a6ddd49e0b231e448f1a81a50af65c/lz4-4.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:713a777de88a73425cf08eb11f742cd2c98628e79a8673d6a52e3c5f0c116f33", size = 99497, upload-time = "2025-11-03T13:01:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7e/dc28a952e4bfa32ca16fa2eb026e7a6ce5d1411fcd5986cd08c74ec187b9/lz4-4.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:a88cbb729cc333334ccfb52f070463c21560fca63afcf636a9f160a55fac3301", size = 91279, upload-time = "2025-11-03T13:01:54.419Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/46/08fd8ef19b782f301d56a9ccfd7dafec5fd4fc1a9f017cf22a1accb585d7/lz4-4.4.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6bb05416444fafea170b07181bc70640975ecc2a8c92b3b658c554119519716c", size = 207171, upload-time = "2025-11-03T13:01:56.595Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3f/ea3334e59de30871d773963997ecdba96c4584c5f8007fd83cfc8f1ee935/lz4-4.4.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b424df1076e40d4e884cfcc4c77d815368b7fb9ebcd7e634f937725cd9a8a72a", size = 207163, upload-time = "2025-11-03T13:01:57.721Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7b/7b3a2a0feb998969f4793c650bb16eff5b06e80d1f7bff867feb332f2af2/lz4-4.4.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:216ca0c6c90719731c64f41cfbd6f27a736d7e50a10b70fad2a9c9b262ec923d", size = 1292136, upload-time = "2025-11-03T13:02:00.375Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d1/f1d259352227bb1c185288dd694121ea303e43404aa77560b879c90e7073/lz4-4.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:533298d208b58b651662dd972f52d807d48915176e5b032fb4f8c3b6f5fe535c", size = 1279639, upload-time = "2025-11-03T13:02:01.649Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/fb/ba9256c48266a09012ed1d9b0253b9aa4fe9cdff094f8febf5b26a4aa2a2/lz4-4.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:451039b609b9a88a934800b5fc6ee401c89ad9c175abf2f4d9f8b2e4ef1afc64", size = 1368257, upload-time = "2025-11-03T13:02:03.35Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6d/dee32a9430c8b0e01bbb4537573cabd00555827f1a0a42d4e24ca803935c/lz4-4.4.5-cp313-cp313-win32.whl", hash = "sha256:a5f197ffa6fc0e93207b0af71b302e0a2f6f29982e5de0fbda61606dd3a55832", size = 88191, upload-time = "2025-11-03T13:02:04.406Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e0/f06028aea741bbecb2a7e9648f4643235279a770c7ffaf70bd4860c73661/lz4-4.4.5-cp313-cp313-win_amd64.whl", hash = "sha256:da68497f78953017deb20edff0dba95641cc86e7423dfadf7c0264e1ac60dc22", size = 99502, upload-time = "2025-11-03T13:02:05.886Z" },
+    { url = "https://files.pythonhosted.org/packages/61/72/5bef44afb303e56078676b9f2486f13173a3c1e7f17eaac1793538174817/lz4-4.4.5-cp313-cp313-win_arm64.whl", hash = "sha256:c1cfa663468a189dab510ab231aad030970593f997746d7a324d40104db0d0a9", size = 91285, upload-time = "2025-11-03T13:02:06.77Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/6a5c2952971af73f15ed4ebfdd69774b454bd0dc905b289082ca8664fba1/lz4-4.4.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67531da3b62f49c939e09d56492baf397175ff39926d0bd5bd2d191ac2bff95f", size = 207348, upload-time = "2025-11-03T13:02:08.117Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d7/fd62cbdbdccc35341e83aabdb3f6d5c19be2687d0a4eaf6457ddf53bba64/lz4-4.4.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a1acbbba9edbcbb982bc2cac5e7108f0f553aebac1040fbec67a011a45afa1ba", size = 207340, upload-time = "2025-11-03T13:02:09.152Z" },
+    { url = "https://files.pythonhosted.org/packages/77/69/225ffadaacb4b0e0eb5fd263541edd938f16cd21fe1eae3cd6d5b6a259dc/lz4-4.4.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a482eecc0b7829c89b498fda883dbd50e98153a116de612ee7c111c8bcf82d1d", size = 1293398, upload-time = "2025-11-03T13:02:10.272Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9e/2ce59ba4a21ea5dc43460cba6f34584e187328019abc0e66698f2b66c881/lz4-4.4.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e099ddfaa88f59dd8d36c8a3c66bd982b4984edf127eb18e30bb49bdba68ce67", size = 1281209, upload-time = "2025-11-03T13:02:12.091Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4f/4d946bd1624ec229b386a3bc8e7a85fa9a963d67d0a62043f0af0978d3da/lz4-4.4.5-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2af2897333b421360fdcce895c6f6281dc3fab018d19d341cf64d043fc8d90d", size = 1369406, upload-time = "2025-11-03T13:02:13.683Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/d429ba4720a9064722698b4b754fb93e42e625f1318b8fe834086c7c783b/lz4-4.4.5-cp313-cp313t-win32.whl", hash = "sha256:66c5de72bf4988e1b284ebdd6524c4bead2c507a2d7f172201572bac6f593901", size = 88325, upload-time = "2025-11-03T13:02:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/85/7ba10c9b97c06af6c8f7032ec942ff127558863df52d866019ce9d2425cf/lz4-4.4.5-cp313-cp313t-win_amd64.whl", hash = "sha256:cdd4bdcbaf35056086d910d219106f6a04e1ab0daa40ec0eeef1626c27d0fddb", size = 99643, upload-time = "2025-11-03T13:02:15.978Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4d/a175459fb29f909e13e57c8f475181ad8085d8d7869bd8ad99033e3ee5fa/lz4-4.4.5-cp313-cp313t-win_arm64.whl", hash = "sha256:28ccaeb7c5222454cd5f60fcd152564205bcb801bd80e125949d2dfbadc76bbd", size = 91504, upload-time = "2025-11-03T13:02:17.313Z" },
 ]
 
 [[package]]
@@ -2027,8 +2128,20 @@ wheels = [
 ]
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
 name = "openretailscience"
-version = "0.48.0"
+version = "0.48.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -2050,7 +2163,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "freezegun" },
-    { name = "ibis-framework", extra = ["bigquery", "mssql", "oracle", "pyspark", "snowflake"] },
     { name = "nbstripout" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -2070,6 +2182,10 @@ docs = [
 examples = [
     { name = "jupyterlab" },
     { name = "tqdm" },
+]
+integration = [
+    { name = "databricks-sdk" },
+    { name = "ibis-framework", extra = ["bigquery", "databricks", "mssql", "oracle", "pyspark", "snowflake"] },
 ]
 
 [package.metadata]
@@ -2092,7 +2208,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "freezegun", specifier = ">=1.5.1,<2" },
-    { name = "ibis-framework", extras = ["bigquery", "mssql", "oracle", "pyspark", "snowflake"], specifier = ">=10.0.0,<13" },
     { name = "nbstripout", specifier = ">=0.7.1,<0.10" },
     { name = "pre-commit", specifier = ">=3.6.2,<5" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
@@ -2112,6 +2227,10 @@ docs = [
 examples = [
     { name = "jupyterlab", specifier = ">=4.2.5,<5" },
     { name = "tqdm", specifier = ">=4.66.1,<5" },
+]
+integration = [
+    { name = "databricks-sdk", specifier = ">=0.60,<1" },
+    { name = "ibis-framework", extras = ["bigquery", "databricks", "mssql", "oracle", "pyspark", "snowflake"], specifier = ">=10.0.0,<13" },
 ]
 
 [[package]]
@@ -2539,6 +2658,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pybreaker"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/89/fbf98e383f1ec6d117af2cd983efdb3eb7018b63834c427025764194cac2/pybreaker-1.4.1.tar.gz", hash = "sha256:8df2d245c73ba40c8242c56ffb4f12138fbadc23e296224740c2028ea9dc1178", size = 15555, upload-time = "2025-09-21T15:12:04.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/75/e64d3d40a741e2be21d69154f4e5c43a66f0c603c5ef11f49e01429a5932/pybreaker-1.4.1-py3-none-any.whl", hash = "sha256:b4dab4a05195b7f2a64a6c1a6c4ba7a96534ef56ea7210e6bcb59f28897160e0", size = 12915, upload-time = "2025-09-21T15:12:02.284Z" },
 ]
 
 [[package]]
@@ -3146,7 +3274,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -3207,7 +3335,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
 wheels = [
@@ -3460,6 +3588,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/55/b5148dcbf72f5cde221f8bfe3b6a540da7aa1842f6b491ad979a6c8b84af/threadpoolctl-3.5.0.tar.gz", hash = "sha256:082433502dd922bf738de0d8bcc4fdcbf0979ff44c42bd40f5af8a282f6fa107", size = 41936, upload-time = "2024-04-29T13:50:16.544Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl", hash = "sha256:56c1e26c150397e58c4926da8eeee87533b1e32bef131bd4bf6a2f45f3185467", size = 18414, upload-time = "2024-04-29T13:50:14.014Z" },
+]
+
+[[package]]
+name = "thrift"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/bd/8f90501b11206e545da3343ed0e5740fc694be24a5f637d7dd7e4e3af927/thrift-0.24.0.tar.gz", hash = "sha256:9ef601c49e988475ff0e741d8e1b45feec23b48514e524341efc274191f1789c", size = 69228, upload-time = "2026-07-11T16:53:50.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/0b/5a7e760e711a4103557855613ae929c47a3949852cbcb403b7c21e0848fc/thrift-0.24.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:efe85c4508adaf6c9e6f7fac2b1c3c9beb4b39b19c375519966335a70b28e64a", size = 184200, upload-time = "2026-07-11T16:53:05.385Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/57/1af719a59c1e75ff25a8f917c4111e7f9c17f2a58840d44f697e11a8066d/thrift-0.24.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a2baaec0c5cd7ba3eace54b26d81fdf0f5a85010468687cf4a131871d65abfed", size = 183616, upload-time = "2026-07-11T16:53:06.578Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/51/5ec88cb4e7f0818e5048bb50c36a342675a40f381d8f53a62f588fc71de5/thrift-0.24.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cad27a826e86739a79a327e6afae5a9bea36aeed2989c4318fc2943b6cfad095", size = 488814, upload-time = "2026-07-11T16:53:07.711Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e7/3eb3b653f3eff1d14fe3c3ed17cab8d8ae1a0bd44f486fe7c667afe88f5d/thrift-0.24.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e26ca0f346e5ec2b6be9778573fb2e9d8b3eb162dbce94e61906176158b448b", size = 494575, upload-time = "2026-07-11T16:53:09.013Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cc/d55245458f990b4f440b71012f355d0cdcac294d7d949d1340c42973826e/thrift-0.24.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:498ae392090d7ae17ab59ebd8dfabda76528eeb22d3890a57c9f226003d7ed6e", size = 1434147, upload-time = "2026-07-11T16:53:10.195Z" },
+    { url = "https://files.pythonhosted.org/packages/54/35/505418d1797ba7940b5ea65d96e88c7e702ab2f3cbc64007c3f14f868aa5/thrift-0.24.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:acbd02baacfa0d2017f85b189ed69cd6baa522785d1ad86476eb7ce8cd16d063", size = 1492591, upload-time = "2026-07-11T16:53:11.519Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a1/882c647a219ff036fb73bf51cec9e1f432e34a687cb92f747ff51ab7d7c4/thrift-0.24.0-cp310-cp310-win_amd64.whl", hash = "sha256:887a10d718d85275da70fe4e9d4740268ae2854f205fb5869909d24cc5576b79", size = 369174, upload-time = "2026-07-11T16:53:13.287Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/3b/7ba9f07a7ac7b98dd7f29f2d9e6f6e98e332942dc8dbd82b71abbac1233d/thrift-0.24.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:873c93d8496cf71589efd3128ddc5af0be350e6c1a0e615475d840eaa54f6124", size = 228606, upload-time = "2026-07-11T16:53:14.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8c/4d0d03b40063504e75c9a74456dbca097ee78af92ddfae6c0216da9d2717/thrift-0.24.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:048d768e5822c436e8920b987d89a6a26e4d438ddf2de4b9d3f81444cd03cd04", size = 227999, upload-time = "2026-07-11T16:53:16.178Z" },
+    { url = "https://files.pythonhosted.org/packages/12/43/74758d030d8d1f103f32026b92e0c9c8b14a6d190197a5e8055b9697294d/thrift-0.24.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2592bb0bf232d0808583626a7a8d71e265851e974c182967d67dde1f16902aee", size = 535383, upload-time = "2026-07-11T16:53:17.375Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d5/2f1e521dd0e8525c460e6e2ed3938f56b0d8208d794e08e0309f6e2ae299/thrift-0.24.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca1b1ba00151565dc4e6673c924debd557aaf25b2790f1570b3430cb35503671", size = 540968, upload-time = "2026-07-11T16:53:18.61Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/02/44abc539a6356d8ffc47fd36724b376d4d4d904924a720b4416911cd8009/thrift-0.24.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:afb7977ccb8ecd7b1520a5141de64b58e94712528a26c10ac8f5b4ef220112a5", size = 1480581, upload-time = "2026-07-11T16:53:19.772Z" },
+    { url = "https://files.pythonhosted.org/packages/34/bc/77a6c2f8f4983473a22905d7c420eb6d6ea46ee590bc287f3443533d0525/thrift-0.24.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c8d37a4311a87bda4bd2b8e4137eec638c18e3a57d11a1011bd98a8867523860", size = 1538742, upload-time = "2026-07-11T16:53:21.216Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b1/4c5e8ac71390292a70c4d75d695a562b6d6c081316d37f6121e18e1878d9/thrift-0.24.0-cp311-cp311-win_amd64.whl", hash = "sha256:fbf461351940ddaa85bf8c2ee1754c9cfdd33bb78322e635e1ea5cd3947ae49a", size = 413572, upload-time = "2026-07-11T16:53:22.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/39/f3e6ec283fa6dbd490eab25a33c46edb6b3114ff9dc46b31bd88af3fd4ea/thrift-0.24.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:306e0fe3c96b300471c19cec60bd6816064fd93d04713488ef07120aff84653b", size = 223061, upload-time = "2026-07-11T16:53:23.804Z" },
+    { url = "https://files.pythonhosted.org/packages/45/86/efd51714e5ce62c4d3c7f998eb1b1f5526cd1ee9fb4080545e7fc25fe5cf/thrift-0.24.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ac42199ea2a6fc6275b0aeec32ae09e7f9edb43890ff9a1af5e34191fb422cc", size = 222518, upload-time = "2026-07-11T16:53:24.885Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/4ea971750d449180363aa2273f1d80e66ce068643c5993589978d7a3951f/thrift-0.24.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8cdd5f927eb98d0e8f00ab148b0cb66ae2598a396e907bd2b6febcbdcc46d80c", size = 531068, upload-time = "2026-07-11T16:53:26.044Z" },
+    { url = "https://files.pythonhosted.org/packages/97/d8/cbd6352723ab4a6668c40c0d10a680b0f05178df2de9ea919ea8e8d2b834/thrift-0.24.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:134cd1a0d80f928377808348d1f9f647284ada093573beaa47040bed5507e219", size = 539609, upload-time = "2026-07-11T16:53:27.238Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b1/af2e258f9c135dc359acda9390e557ddc501a9185b65892fc253f94ca160/thrift-0.24.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:518199062feabfc0982767a0f7bceccb4fd1b485654f75e02913837444c3c130", size = 1474702, upload-time = "2026-07-11T16:53:28.669Z" },
+    { url = "https://files.pythonhosted.org/packages/38/6f/93424dc6ceb2a561d055df4fee825ff7116e342e126c6aab357e0a94185e/thrift-0.24.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d8c5de86af2a44641d423624c71c554a691d9f80c8b87709f15c7f98ccc6aeac", size = 1535581, upload-time = "2026-07-11T16:53:29.967Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/35/88debea28426b31ac417a83cda5c029f67cf72665fd2327562adb5c151b1/thrift-0.24.0-cp312-cp312-win_amd64.whl", hash = "sha256:2f82bb16c4f2009dbc4fc9374604f05e998fb33be6a7787e095cea9842ecfa1d", size = 407669, upload-time = "2026-07-11T16:53:31.282Z" },
+    { url = "https://files.pythonhosted.org/packages/93/5a/3b0d7b47ae73c28891997433447f87ba26de0fc11ca9fd4ea8c6b497bf23/thrift-0.24.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ebb8b389142d67554d0de814dd6c1d62b962751f68721537efca429c57b09327", size = 224851, upload-time = "2026-07-11T16:53:32.528Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/4e17cce911ebbf76c59472b488dbe25c32d51cef2500b6e255a9fb59ff02/thrift-0.24.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:18e7693f1bcef45937ad31a02564add55dec754710d42afc8ee3fc26ecf13028", size = 224313, upload-time = "2026-07-11T16:53:33.797Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/9a/eb8cb5a75fdff60b21b78c712a455adac01e1768792c3232184fa7202961/thrift-0.24.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937b398c311799fd5eddaeaffbd275510c68ead597eb1897e5e8113542fb2b50", size = 532517, upload-time = "2026-07-11T16:53:35.458Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b7/d0ecdf3573eb4026343d04efa64cf465a8453e699bd41a2d68156c3caf83/thrift-0.24.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b89a83d4e9ae6029e14f6f7c73305044bf02739d729c6aa8025ef3b6faef0ec0", size = 541124, upload-time = "2026-07-11T16:53:36.767Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ce/37daa851995ad441e38f83b2a8e67cdf68df10148779fb5bbafd4fb24f6b/thrift-0.24.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6381093f2c54e0f108554004a8cac3f1ef7ba99d6c5a9909c0eb64f450142685", size = 1476528, upload-time = "2026-07-11T16:53:38.056Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/67/80f3aeced7a38d17a281d1b9904ab9e93ab493f5c75e144b3180c278041c/thrift-0.24.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:28e034658d724aaa66007babb258ef12f0294036812fc449d7ce6fd15b07100f", size = 1537515, upload-time = "2026-07-11T16:53:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/37/1f/169f93d531a0d9546b6f18dacf37752c27cccfa719bf231162d1fcf8d0e0/thrift-0.24.0-cp313-cp313-win_amd64.whl", hash = "sha256:f4a44391ae1e32817553639b2991b0753d84487259fe87f8111c956c6bdebf43", size = 409450, upload-time = "2026-07-11T16:53:40.711Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Extends the integration suite to Databricks alongside BigQuery and Snowflake, and closes the gap that let #542 ship: the Databricks branch of `install_skills` had never actually run on Databricks.

Closes #543.

## Query backend

`transactions_table` gains a `databricks` backend, authenticating as an OAuth machine-to-machine service principal and reading a pre-loaded Unity Catalog table, matching how BigQuery and Snowflake already work. The connection is session-scoped and explicitly closed; leaving it to the garbage collector made the Thrift transport log into pytest's already-closed capture stream.

## install_skills on Databricks

`install_skills` resolves `/Workspace/Users/<current_user()>` and requires it to be a real directory. That mount exists only on Databricks compute, so no CI runner can exercise it under any auth method — which is why the only prior coverage was a temp directory and a mocked Spark session.

`tests/integration/test_workspace_skills.py` holds the assertions made against the real mount. The `skills-install-tests` job stages a wheel built from the working tree in a UC volume and runs the module from a notebook on serverless compute. A notebook rather than a Python script task, because that is what a user runs: it has the pre-created Spark session `install_skills` looks for, and `%pip` byte-compiles the package, which is what puts the `__pycache__` directories inside the bundled skill that `/Workspace` rejects with `OSError 95`.

`TestDatabricksInstall` keeps only the states a real workspace will not produce on demand (no Spark session, a missing workspace home, a blank or path-like `current_user()`, a leftover symlink). The happy path, idempotence and refresh-on-change now run for real instead of against a fake.

## Dependency groups

Backend drivers move from `dev` to a non-default `integration` group, so the unit, docs and multi-python jobs stop installing pyspark's 336MB of Spark jars. The Databricks unit tests stub `pyspark.sql` rather than importing it; the comment claiming the string-path patch already avoided that import was wrong, since `monkeypatch.setattr` resolves it through `importlib`.

## Verification

Everything here ran against the live workspace, not just the linters:

- 30 Databricks integration tests pass against the SQL warehouse
- the skills pipeline ran end to end on serverless: **6 passed**, cleaning up its staged files
- 1407 unit tests pass with pyspark uninstalled
- all 12 pre-commit hooks pass

The first pipeline run failed with `OSError 22` from pytest's rootdir probe on the volume mount, which is the class of bug this job exists to catch and which no amount of schema validation would have found.

## Required secrets

Already set: `DATABRICKS_CI_HOST`, `DATABRICKS_CI_CLIENT_ID`, `DATABRICKS_CI_HTTP_PATH`, `DATABRICKS_CI_CATALOG`, `DATABRICKS_CI_SCHEMA`. The OAuth client secret is fetched from GCP Secret Manager with the existing CI service account.

Depends on the Databricks terraform in `pyretailscience_infra` being applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
