### PR TITLE
ci(databricks): stop the skills job reserving an unused uv cache

### DIFF
--- a/.github/workflows/databricks-integration.yml
+++ b/.github/workflows/databricks-integration.yml
@@ -98,10 +98,13 @@ jobs:
         with:
           python-version: "3.11"
 
-      # No enable-cache: this job only builds a wheel, never syncs the environment, so it would
-      # reserve the same cache key as the job above and log a failed reservation for nothing.
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          # "false", not omitted: the default is "auto", which caches whenever a uv.lock is
+          # present. This job only builds a wheel, so it would reserve the same key as the
+          # job above for a cache it never reads.
+          enable-cache: "false"
 
       # The job installs this wheel, so the run tests the working tree, not the last PyPI release.
       - name: Build Wheel

--- a/.github/workflows/databricks-integration.yml
+++ b/.github/workflows/databricks-integration.yml
@@ -101,9 +101,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          # "false", not omitted: the default is "auto", which caches whenever a uv.lock is
-          # present. This job only builds a wheel, so it would reserve the same key as the
-          # job above for a cache it never reads.
+          # "false", not omitted: the default "auto" caches whenever a uv.lock is present.
           enable-cache: "false"
 
       # The job installs this wheel, so the run tests the working tree, not the last PyPI release.

--- a/.github/workflows/databricks-integration.yml
+++ b/.github/workflows/databricks-integration.yml
@@ -98,10 +98,10 @@ jobs:
         with:
           python-version: "3.11"
 
+      # No enable-cache: this job only builds a wheel, never syncs the environment, so it would
+      # reserve the same cache key as the job above and log a failed reservation for nothing.
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: true
 
       # The job installs this wheel, so the run tests the working tree, not the last PyPI release.
       - name: Build Wheel


### PR DESCRIPTION
Follow-up to #544.

## Symptom

The `skills-install-tests` job logs:

```
Failed to save: Unable to reserve cache with key
setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.11.15-pruned-<hash>,
another job may be creating this cache.
```

Both jobs in the workflow start at the same time on the same runner image with the same Python and the same `uv.lock`, so `setup-uv` derives an identical cache key for each. One reserves it, the other logs this. It is a failed reservation, not a failed job: run [30765200837](https://github.com/Data-Simply/openretailscience/actions/runs/30765200837) passed both jobs.

## Fix

Drop `enable-cache` from the skills job rather than giving it a distinct cache suffix. That job never runs `uv sync` — its only uv call is `uv build --wheel` — so it was reserving a dependency cache for dependencies it never installs. A suffix would have stored a second cache nothing ever reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
